### PR TITLE
fix: use Placo kinematics engine for correct 3D viewer rendering

### DIFF
--- a/src-tauri/src/python/mod.rs
+++ b/src-tauri/src/python/mod.rs
@@ -66,7 +66,7 @@ pub fn build_daemon_args(sim_mode: bool) -> Result<Vec<String>, String> {
         "-m".to_string(),
         "reachy_mini.daemon.app.main".to_string(),
         "--kinematics-engine".to_string(),
-        "AnalyticalKinematics".to_string(),
+        "Placo".to_string(),
         "--desktop-app-daemon".to_string(),
     ];
     


### PR DESCRIPTION
## Summary
- Switches the kinematics engine from `AnalyticalKinematics` to `Placo`

## Problem
The 3D viewer requires `passive_joints` (21 values for Stewart platform kinematics) to correctly render the robot head position. These values are only provided by the Placo kinematics engine.

With `AnalyticalKinematics`, the 3D viewer shows the robot head in an incorrect position during startup (wobbly, off to the side) while the physical robot is correctly oriented.

## Solution
Use `Placo` as the default kinematics engine, which provides the complete joint state including passive joints needed for accurate 3D visualization.

## Test plan
- [ ] Launch app and verify 3D viewer shows correct head position during startup
- [ ] Verify physical robot matches 3D viewer orientation

🤖 Generated with [Claude Code](https://claude.com/claude-code)