### PR TITLE
fix: handle Cmd+Q (⌘Q) to properly kill daemon on macOS

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -172,6 +172,22 @@ pub fn run() {
                 _ => {}
             }
         })
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|_app_handle, event| {
+            match event {
+                tauri::RunEvent::ExitRequested { .. } => {
+                    // ⌘Q (Cmd+Q) on macOS triggers this event
+                    // Kill daemon via port 8000 + process name (reliable cleanup)
+                    println!("🔴 ExitRequested (Cmd+Q) - killing daemon");
+                    cleanup_system_daemons();
+                }
+                tauri::RunEvent::Exit => {
+                    // Final cleanup when app is about to exit
+                    println!("🔴 Exit event - final cleanup");
+                    cleanup_system_daemons();
+                }
+                _ => {}
+            }
+        });
 }


### PR DESCRIPTION
## Problem

Previously, pressing **Cmd+Q (⌘Q)** on macOS would trigger `RunEvent::ExitRequested` which was **not handled**, potentially leaving the daemon process running as a zombie.

## Solution

Added handlers for:
- `RunEvent::ExitRequested`: triggered by Cmd+Q
- `RunEvent::Exit`: final cleanup before app exits

Both handlers call `cleanup_system_daemons()` which kills processes via:
1. Port 8000 (SIGTERM then SIGKILL)
2. Process name (`pkill -9 -f reachy_mini.daemon.app.main`)

## Coverage after this fix

| Event | Handler | Cmd+Q | Click ❌ | Force Quit |
|-------|---------|-------|---------|------------|
| `RunEvent::ExitRequested` | ✅ **New** | ✅ | ❌ | ❌ |
| `RunEvent::Exit` | ✅ **New** | ✅ | ✅ | ❌ |
| `WindowEvent::CloseRequested` | ✅ | ❌ | ✅ | ❌ |
| `WindowEvent::Destroyed` | ✅ | ✅ | ✅ | ❌ |
| Signal SIGTERM/SIGINT | ✅ | ✅ | ✅ | ❌ |

## Testing

- [x] `cargo check` passes
- [ ] Manual test: Cmd+Q kills daemon properly