### PR TITLE
fix: UI cleanup - audio curves, camera text, permissions logs

### DIFF
--- a/src/views/active-robot/audio/AudioControls.jsx
+++ b/src/views/active-robot/audio/AudioControls.jsx
@@ -133,6 +133,7 @@ function AudioControls({
         </Box>
 
         {/* Visualizer - responsive width */}
+        {/* Temporarily disabled - no example curve for now
         <Box sx={{ width: '100%', height: '28px', flexShrink: 0, overflow: 'hidden', boxSizing: 'border-box' }}>
           <AudioLevelBars 
             isActive={isActive} 
@@ -140,6 +141,7 @@ function AudioControls({
             barCount={8} 
           />
         </Box>
+        */}
       </Box>
     </Box>
   );

--- a/src/views/active-robot/camera/CameraFeed.jsx
+++ b/src/views/active-robot/camera/CameraFeed.jsx
@@ -130,7 +130,7 @@ export default function CameraFeed({ width = 240, height = 180, isLarge = false 
               letterSpacing: '0.5px',
             }}
           >
-            {hasError ? 'Camera unavailable' : 'Connecting...'}
+            {hasError ? 'Camera coming soon' : 'Connecting...'}
           </Typography>
         </Box>
       )}


### PR DESCRIPTION
## Changes

- **AudioControls**: Temporarily disable example audio level bars (commented out)
- **CameraFeed**: Change 'Camera unavailable' to 'Camera coming soon'
- **PermissionsRequiredView**: Clean verbose debug logs, keep only errors and permission grant messages

## Why

- Audio curves were showing example/placeholder data, better to show nothing for now
- Camera feed is coming soon, text should reflect that
- Permissions view was logging too much verbose debug info, cleaned up for cleaner console output