### PR TITLE
fix: app store stability improvements

### DIFF
--- a/src/utils/stateComparison.js
+++ b/src/utils/stateComparison.js
@@ -128,6 +128,11 @@ export function deepEqual(a, b) {
 export function extractChangedUpdates(prevState, newState, relevantKeys) {
   const changedUpdates = {};
   
+  // Guard against undefined state (can happen during initialization)
+  if (!prevState || !newState) {
+    return changedUpdates;
+  }
+  
   relevantKeys.forEach(key => {
     const prevValue = prevState[key];
     const newValue = newState[key];

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,6 +8,11 @@ export default defineConfig({
   server: {
     port: 1420,
     strictPort: true,
+    watch: {
+      // Ignore app venvs to prevent page reloads during app installation
+      // (Gradio packages contain tsconfig.json files that trigger Vite reloads)
+      ignored: ['**/src-tauri/target/**', '**/*_venv/**'],
+    },
   },
   envPrefix: ['VITE_', 'TAURI_'],
   resolve: {


### PR DESCRIPTION
- Add guard for undefined state in extractChangedUpdates (fixes crash on init)
- Deduplicate apps from daemon response (fixes duplicate apps in list)
- Filter out 'installed' source_kind apps (fetched separately)
- Ignore venv folders in Vite watch (fixes page reload during app install)