### PR TITLE
ci: disable fail-fast

### DIFF
--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: write
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         include:
           - os: macos-latest


### PR DESCRIPTION
Allow all platform builds to complete even if one fails