### PR TITLE
feat: add uv to PATH for Python subprocess to enable fast app installs

### DIFF
--- a/uv-wrapper/src/bin/uv-trampoline.rs
+++ b/uv-wrapper/src/bin/uv-trampoline.rs
@@ -560,6 +560,17 @@ fn main() -> ExitCode {
         cmd
     };
     
+    // Add the working directory (where uv is located) to PATH
+    // This allows Python subprocess to find uv when installing apps
+    let current_path = env::var("PATH").unwrap_or_default();
+    let new_path = if cfg!(target_os = "windows") {
+        format!("{};{}", working_dir.display(), current_path)
+    } else {
+        format!("{}:{}", working_dir.display(), current_path)
+    };
+    cmd.env("PATH", &new_path);
+    println!("📍 Added {} to PATH for subprocess", working_dir.display());
+    
     // Check if this is a pip install command (for auto-signing after installation)
     #[cfg(target_os = "macos")]
     let is_pip_install = !args.is_empty() && args[0] == "pip" && args.len() >= 2 && args[1] == "install";


### PR DESCRIPTION
## Description

Adds the `working_dir` (where `uv` is bundled) to the PATH environment variable before spawning the Python daemon process.

## Problem

The `reachy_mini` daemon (v1.2.2+) now supports using `uv` for faster package installations. However, `shutil.which('uv')` couldn't find the bundled `uv` binary because it wasn't in the PATH.

This caused the warning:
```
uv is not installed. Falling back to pip. Install uv for faster installs: pip install uv
```

## Solution

In `uv-trampoline.rs`, we now prepend the `working_dir` (which contains the bundled `uv` binary) to the PATH before launching Python:

```rust
let current_path = env::var("PATH").unwrap_or_default();
let new_path = if cfg!(target_os = "windows") {
    format!("{};{}", working_dir.display(), current_path)
} else {
    format!("{}:{}", working_dir.display(), current_path)
};
cmd.env("PATH", &new_path);
```

## Testing

- Tested locally on macOS
- Apps now install using `uv` instead of `pip`
- No more warning message

## Notes

- Works on both macOS (`:` separator) and Windows (`;` separator)
- No signature/entitlement changes needed - `uv` is already signed at build time