### PR TITLE
fix: prevent USB detection from disconnecting WiFi mode

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -150,20 +150,31 @@ function App() {
 
   // Determine current view for automatic resize
   const currentView = useMemo(() => {
+    // 🔍 DEBUG: Log state when computing currentView
+    console.log('[App] 🎯 Computing currentView', {
+      isActive,
+      hardwareError: !!hardwareError,
+      isStopping,
+    });
+    
     // Compact view: ClosingView (stopping)
     if (isStopping) {
+      console.log('[App] → currentView = compact (isStopping)');
       return 'compact';
     }
     
-    // ⚡ Expanded view: daemon active (but NEVER during StartingView)
-    // BLOCK resize as long as isStarting = true (scan in progress)
-    if (!isStarting && isActive && !hardwareError) {
+    // ⚡ Expanded view: daemon active
+    // isActive becomes true when transitionTo.ready() is called
+    // (after scan complete + daemon health check passes)
+    if (isActive && !hardwareError) {
+      console.log('[App] → currentView = expanded (isActive && !hardwareError)');
       return 'expanded';
     }
     
     // Compact view: all others (FindingRobot, Starting, ReadyToStart)
+    console.log('[App] → currentView = compact (default)');
     return 'compact';
-  }, [isActive, hardwareError, isStopping, isStarting]);
+  }, [isActive, hardwareError, isStopping]);
 
   // Hook to automatically resize the window
   useWindowResize(currentView);

--- a/src/hooks/system/useWindowResize.js
+++ b/src/hooks/system/useWindowResize.js
@@ -16,11 +16,13 @@ import { moveWindow, Position } from '@tauri-apps/plugin-positioner';
 async function resizeWindowInstantly(targetWidth, targetHeight) {
   // Mock pour le navigateur
   if (!window.__TAURI__) {
+    console.log('[resizeWindowInstantly] ⚠️ Not in Tauri, skipping');
     return;
   }
 
   try {
     const appWindow = getAppWindow();
+    console.log('[resizeWindowInstantly] 🎯 Got appWindow:', appWindow?.label);
     
     // Obtenir la taille actuelle ET le scale factor pour comparer correctement
     const currentSize = await appWindow.innerSize();
@@ -30,19 +32,31 @@ async function resizeWindowInstantly(targetWidth, targetHeight) {
     const currentLogicalWidth = Math.round(currentSize.width / scaleFactor);
     const currentLogicalHeight = Math.round(currentSize.height / scaleFactor);
 
+    console.log('[resizeWindowInstantly] 📐 Current size:', {
+      physical: { width: currentSize.width, height: currentSize.height },
+      logical: { width: currentLogicalWidth, height: currentLogicalHeight },
+      scaleFactor,
+      target: { width: targetWidth, height: targetHeight },
+    });
+
     // If already at correct size (with 2px tolerance for rounding), do nothing
     const widthMatch = Math.abs(currentLogicalWidth - targetWidth) <= 2;
     const heightMatch = Math.abs(currentLogicalHeight - targetHeight) <= 2;
     
     if (widthMatch && heightMatch) {
+      console.log('[resizeWindowInstantly] ✅ Already at target size, skipping');
       return;
     }
 
     // Apply resize - setSize avec LogicalSize gère automatiquement le scale factor
+    console.log('[resizeWindowInstantly] 🔄 Calling setSize...');
     await appWindow.setSize(new LogicalSize(targetWidth, targetHeight));
+    console.log('[resizeWindowInstantly] ✅ setSize completed');
     
     // Center window on screen
+    console.log('[resizeWindowInstantly] 🔄 Calling moveWindow(Center)...');
     await moveWindow(Position.Center);
+    console.log('[resizeWindowInstantly] ✅ moveWindow completed');
   } catch (error) {
     console.error('❌ Window resize error:', error);
   }
@@ -88,6 +102,12 @@ export function useWindowResize(view) {
     if (previousView.current === view) {
       return;
     }
+
+    // 🔍 DEBUG: Log view change
+    console.log(`[WindowResize] 🎯 View changed: ${previousView.current} → ${view}`, {
+      targetWidth: targetSize.width,
+      targetHeight: targetSize.height,
+    });
 
     previousView.current = view;
 

--- a/src/views/starting/HardwareScanView.jsx
+++ b/src/views/starting/HardwareScanView.jsx
@@ -66,13 +66,13 @@ function HardwareScanView({
   // ✅ Helper to get progressive message based on elapsed time
   const getProgressiveMessage = useCallback(() => {
     if (elapsedSeconds >= MESSAGE_THRESHOLDS.VERY_LONG) {
-      return { text: 'If this persists, check the', bold: 'robot connection', suffix: '' };
+      return { text: "That's unusual.", bold: 'Please check the connection', suffix: '' };
     }
     if (elapsedSeconds >= MESSAGE_THRESHOLDS.LONG_WAIT) {
-      return { text: 'Almost there,', bold: 'please wait', suffix: '...' };
+      return { text: 'Patience is a', bold: 'virtue', suffix: ', they say' };
     }
     if (elapsedSeconds >= MESSAGE_THRESHOLDS.TAKING_TIME) {
-      return { text: 'Installing', bold: 'dependencies', suffix: '...' };
+      return { text: 'Loading robot', bold: 'superpowers', suffix: '...' };
     }
     if (elapsedSeconds >= MESSAGE_THRESHOLDS.FIRST_LAUNCH) {
       return { text: 'First launch may take a bit', bold: 'longer', suffix: '' };
@@ -413,13 +413,16 @@ function HardwareScanView({
   }, [checkDaemonHealth, onScanCompleteCallback, clearAllIntervals, setHardwareError]);
   
   const handleScanComplete = useCallback(() => {
+    console.log('[HardwareScanView] 🔍 handleScanComplete called');
+    
     // ✅ Don't mark scan as complete if there's an error - stay in error state
     const currentState = useAppStore.getState();
     if (currentState.hardwareError || (startupError && typeof startupError === 'object' && startupError.type)) {
-      console.warn('⚠️ Scan visual completed but error detected, not completing scan');
+      console.warn('[HardwareScanView] ⚠️ Scan visual completed but error detected, not completing scan');
       return; // Don't complete scan, stay in error state
     }
     
+    console.log('[HardwareScanView] ✅ Scan visual complete, starting daemon health check');
     setScanProgress(prev => ({ ...prev, current: prev.total }));
     setCurrentPart(null);
     setScanComplete(true);
@@ -485,6 +488,12 @@ function HardwareScanView({
       setCurrentPart(null);
     }
   }, [scanComplete, startupError, scanError]);
+
+  // 🔍 DEBUG: Log when HardwareScanView mounts
+  useEffect(() => {
+    console.log('[HardwareScanView] 🎯 MOUNTED', { isStarting, robotStatus });
+    return () => console.log('[HardwareScanView] 🎯 UNMOUNTED');
+  }, []);
 
   // Cleanup intervals on unmount
   useEffect(() => {
@@ -806,15 +815,15 @@ function HardwareScanView({
               >
                 {waitingForDaemon && daemonStep === 'connecting' ? (
                   <>
-                    <Box component="span" sx={{ fontWeight: 700 }}>Connecting</Box> to daemon
+                    <Box component="span" sx={{ fontWeight: 700 }}>Establishing</Box> connection...
                   </>
                 ) : waitingForDaemon && daemonStep === 'initializing' ? (
                   <>
-                    <Box component="span" sx={{ fontWeight: 700 }}>Initializing</Box> robot control
+                    <Box component="span" sx={{ fontWeight: 700 }}>Preparing</Box> motor control...
                   </>
                 ) : waitingForMovements ? (
                   <>
-                    <Box component="span" sx={{ fontWeight: 700 }}>Detecting</Box> robot movements
+                    <Box component="span" sx={{ fontWeight: 700 }}>Waiting</Box> for robot response...
                   </>
                 ) : currentPart ? (
                   <>

--- a/src/views/starting/StartingView.jsx
+++ b/src/views/starting/StartingView.jsx
@@ -2,25 +2,28 @@ import React, { useCallback } from 'react';
 import { Box } from '@mui/material';
 import HardwareScanView from './HardwareScanView';
 import useAppStore from '../../store/useAppStore';
-import { DAEMON_CONFIG } from '../../config/daemon';
 
 /**
  * View displayed during daemon startup
  * Wrapper around HardwareScanView that handles the transition logic
  */
 function StartingView({ startupError, startDaemon }) {
-  const { darkMode, transitionTo, setHardwareError, hardwareError } = useAppStore();
+  const { darkMode, transitionTo, setHardwareError } = useAppStore();
+  
+  // 🔍 DEBUG: Log when StartingView mounts
+  React.useEffect(() => {
+    console.log('[StartingView] 🎯 MOUNTED');
+    return () => console.log('[StartingView] 🎯 UNMOUNTED');
+  }, []);
   
   const handleScanComplete = useCallback(() => {
     // ✅ HardwareScanView only calls this callback after successful healthcheck
-    // ⚡ WAIT for pause to see "Starting Software..." message, then go to ActiveRobotView
-    setTimeout(() => {
-      // ✅ Clear any hardware errors when scan completes successfully
-      setHardwareError(null);
-      // ✅ Direct transition to ActiveRobotView (state machine handles isActive/isStarting)
-      // ActiveRobotView handles its own loading state for apps
-      transitionTo.ready();
-    }, DAEMON_CONFIG.ANIMATIONS.SCAN_COMPLETE_PAUSE);
+    // ✅ Clear any hardware errors when scan completes successfully
+    setHardwareError(null);
+    // ✅ Direct transition to ActiveRobotView (state machine handles isActive/isStarting)
+    // ActiveRobotView handles its own loading state for apps
+    // ⚡ IMMEDIATE transition - window resize will happen now, not after delay
+    transitionTo.ready();
   }, [transitionTo, setHardwareError]);
 
   return (


### PR DESCRIPTION
## Problem
When connecting via WiFi, the USB polling would detect 'no USB device' and call `setIsUsbConnected(false)`, which unconditionally called `transitionTo.disconnected()`. This caused the WiFi connection to be reset, unmounting `StartingView` and `HardwareScanView` before the scan could complete.

## Solution
Modified `setIsUsbConnected` to only call `transitionTo.disconnected()` when `connectionMode === 'usb'`. WiFi and Simulation modes now ignore USB detection changes.

## Also included
Debug logging for state transitions to help diagnose future issues.