### PR TITLE
fix: enable dangerousAllowDowngrades for updater rollback support

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -52,7 +52,7 @@
         "https://pollen-robotics.github.io/reachy-mini-desktop-app/latest.json"
       ],
       "dangerousInsecureTransportProtocol": false,
-      "dangerousAllowDowngrades": false,
+      "dangerousAllowDowngrades": true,
       "dialog": false,
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDNBNDFBQUFGQkFCOTY2NQpSV1JsbHF2N3FocWtBM2pkdlhBVUpXNFkwZkc1dWdHK09NcklYNGthR1dHbVR1aDQ0NlIxR3oyUgo="
     }


### PR DESCRIPTION
## Description

Enable `dangerousAllowDowngrades: true` in the Tauri updater configuration.

## Why?

This allows the app to propose downgrades when the `latest.json` contains a version lower than the installed version. This is useful for:

- Rolling back problematic releases
- Recovering from deleted/failed releases (like the recent 0.8.x situation)

## Risk Assessment

The "dangerous" prefix means "use with caution", not "never use". In our case:
- We control the release cycle
- Data format hasn't changed between versions
- Users with newer versions will now receive the downgrade notification

## Changes

- `src-tauri/tauri.conf.json`: Set `dangerousAllowDowngrades` to `true`