### PR TITLE
fix: set MACOSX_DEPLOYMENT_TARGET=10.15 for compatibility with macOS 13.1

### DIFF
--- a/uv-wrapper/src/bin/uv-bundle.rs
+++ b/uv-wrapper/src/bin/uv-bundle.rs
@@ -117,8 +117,10 @@ fn main() {
                 ""
             };
             run_command(&format!(
-                "{}UV_PYTHON_INSTALL_DIR=. UV_WORKING_DIR=. ./uv pip install {}",
-                git_lfs_skip, deps_str
+                "{}{}UV_PYTHON_INSTALL_DIR=. UV_WORKING_DIR=. ./uv pip install {}",
+                git_lfs_skip,
+                if cfg!(target_os = "macos") { "MACOSX_DEPLOYMENT_TARGET=10.15 " } else { "" },
+                deps_str
             ))
             .expect("Failed to install dependencies");
         }


### PR DESCRIPTION
Fixes compatibility issue with macOS 13.1 (Ventura) where numpy and other packages compiled for macOS 14.0+ fail to load.

## Problem
Users on macOS 13.1 (Ventura) encounter the following error:
```
ImportError: dlopen(...numpy/_core/_multiarray_umath.cpython-312-darwin.so, 0x0002): Symbol not found: _cblas_caxpy$NEWLAPACK$ILP64
Referenced from: <...> (built for macOS 14.0 which is newer than running OS)
```

## Solution
Set `MACOSX_DEPLOYMENT_TARGET=10.15` during Python package installation to ensure compatibility with older macOS versions (10.15+).

## Changes
- Modified `uv-wrapper/src/bin/uv-bundle.rs` to add `MACOSX_DEPLOYMENT_TARGET=10.15` when installing Python packages on macOS

## Testing
- [x] Built sidecar with the fix
- [x] Verified numpy imports successfully
- [x] Verified reachy_mini imports successfully

Fixes issue reported by user on macOS 13.1 (Ventura).