### PR TITLE
fix: add Windows .msi.zip upload for updater in release workflow

### DIFF
--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -1147,6 +1147,8 @@ jobs:
             src-tauri/target/aarch64-apple-darwin/release/bundle/macos/*.app.tar.gz
             src-tauri/target/aarch64-apple-darwin/release/bundle/macos/*.app.tar.gz.sig
             releases/**/*.tar.gz
+            releases/**/*.zip
+            releases/**/*.zip.sig
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -1167,6 +1169,8 @@ jobs:
             ${{ matrix.os == 'macos-latest' && format('src-tauri/target/{0}/release/bundle/macos/*.app.tar.gz', matrix.target) || '' }}
             ${{ matrix.os == 'macos-latest' && format('src-tauri/target/{0}/release/bundle/macos/*.app.tar.gz.sig', matrix.target) || '' }}
             releases/**/*.tar.gz
+            releases/**/*.zip
+            releases/**/*.zip.sig
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## 🐛 Problem

The Windows auto-updater was not working because the required `.msi.zip` file was missing from GitHub releases.

### Root cause
The CI workflow was only uploading `.tar.gz` files from the `releases/` directory, but Windows updater needs `.msi.zip` format (as specified in `latest.json`).

## ✅ Solution

Add upload patterns for Windows updater files in the release workflow:
- `releases/**/*.zip` (for Windows `.msi.zip` updater files)
- `releases/**/*.zip.sig` (for the corresponding signature files)

## 🧪 Testing

This will be validated on the next release:
1. The `build-update.sh` script already creates the `.msi.zip` file
2. With this fix, the file will be uploaded to GitHub releases
3. The `latest.json` will correctly point to the uploaded file
4. Windows users will be able to auto-update

## 📋 Checklist

- [x] Tested locally (verified workflow syntax)
- [x] No breaking changes
- [x] Documentation not needed (CI-only change)
- [x] Ready to merge

## 🔗 Related

Fixes auto-update functionality on Windows platform.