### PR TITLE
feat(update): Add daemon update for USB/Simulation modes

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -559,7 +559,7 @@ dependencies = [
  "cocoa-foundation",
  "core-foundation 0.9.4",
  "core-graphics 0.23.2",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
  "objc",
 ]
@@ -673,7 +673,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
  "core-graphics-types 0.1.3",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -686,7 +686,7 @@ dependencies = [
  "bitflags 2.10.0",
  "core-foundation 0.10.0",
  "core-graphics-types 0.2.0",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -1004,7 +1004,7 @@ dependencies = [
  "rustc_version",
  "toml 0.9.8",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -1158,12 +1158,21 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -1176,6 +1185,12 @@ dependencies = [
  "quote",
  "syn 2.0.109",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1593,6 +1608,25 @@ dependencies = [
 
 [[package]]
 name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap 2.12.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
@@ -1602,7 +1636,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.3.1",
  "indexmap 2.12.0",
  "slab",
  "tokio",
@@ -1660,6 +1694,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
@@ -1671,12 +1716,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.3.1",
 ]
 
 [[package]]
@@ -1687,8 +1743,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1697,6 +1753,36 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
 
 [[package]]
 name = "hyper"
@@ -1708,9 +1794,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.12",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -1726,8 +1812,8 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http",
- "hyper",
+ "http 1.3.1",
+ "hyper 1.7.0",
  "hyper-util",
  "rustls",
  "rustls-pki-types",
@@ -1735,6 +1821,19 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.32",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -1748,15 +1847,15 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "hyper 1.7.0",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
- "system-configuration",
+ "socket2 0.6.1",
+ "system-configuration 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -2345,6 +2444,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2754,6 +2870,50 @@ dependencies = [
  "is-wsl",
  "libc",
  "pathdiff",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.109",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3201,7 +3361,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -3238,7 +3398,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.1",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3376,11 +3536,13 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "reachy-mini-control"
-version = "0.8.3"
+version = "0.8.9"
 dependencies = [
  "block",
  "cocoa",
  "objc",
+ "reqwest 0.11.27",
+ "semver",
  "serde",
  "serde_json",
  "serialport",
@@ -3395,6 +3557,7 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-shell",
  "tauri-plugin-updater",
+ "tokio",
 ]
 
 [[package]]
@@ -3468,6 +3631,46 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "system-configuration 0.5.1",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.12.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
@@ -3479,11 +3682,11 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.12",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.7.0",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -3497,7 +3700,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -3569,6 +3772,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3608,6 +3820,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3666,6 +3887,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3975,6 +4219,16 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
@@ -3992,7 +4246,7 @@ dependencies = [
  "bytemuck",
  "cfg_aliases",
  "core-graphics 0.24.0",
- "foreign-types",
+ "foreign-types 0.5.0",
  "js-sys",
  "log",
  "objc2 0.5.2",
@@ -4115,6 +4369,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -4135,13 +4395,34 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.10.0",
  "core-foundation 0.9.4",
- "system-configuration-sys",
+ "system-configuration-sys 0.6.0",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -4251,7 +4532,7 @@ dependencies = [
  "glob",
  "gtk",
  "heck 0.5.0",
- "http",
+ "http 1.3.1",
  "jni",
  "libc",
  "log",
@@ -4265,7 +4546,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.12.24",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4412,9 +4693,9 @@ dependencies = [
  "bytes",
  "cookie_store",
  "data-url",
- "http",
+ "http 1.3.1",
  "regex",
- "reqwest",
+ "reqwest 0.12.24",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -4520,13 +4801,13 @@ dependencies = [
  "dirs",
  "flate2",
  "futures-util",
- "http",
+ "http 1.3.1",
  "infer",
  "log",
  "minisign-verify",
  "osakit",
  "percent-encoding",
- "reqwest",
+ "reqwest 0.12.24",
  "semver",
  "serde",
  "serde_json",
@@ -4551,7 +4832,7 @@ dependencies = [
  "cookie",
  "dpi",
  "gtk",
- "http",
+ "http 1.3.1",
  "jni",
  "objc2 0.6.3",
  "objc2-ui-kit",
@@ -4574,7 +4855,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "929f5df216f5c02a9e894554401bcdab6eec3e39ec6a4a7731c7067fc8688a93"
 dependencies = [
  "gtk",
- "http",
+ "http 1.3.1",
  "jni",
  "log",
  "objc2 0.6.3",
@@ -4607,7 +4888,7 @@ dependencies = [
  "dunce",
  "glob",
  "html5ever",
- "http",
+ "http 1.3.1",
  "infer",
  "json-patch",
  "kuchikiki",
@@ -4772,7 +5053,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.1",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4786,6 +5067,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.109",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -4916,7 +5207,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -4931,8 +5222,8 @@ dependencies = [
  "bitflags 2.10.0",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -5155,6 +5446,12 @@ dependencies = [
  "serde",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"
@@ -5615,6 +5912,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5662,6 +5968,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5723,6 +6044,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5741,6 +6068,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5756,6 +6089,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5789,6 +6128,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5804,6 +6149,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5825,6 +6176,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5840,6 +6197,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5869,6 +6232,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5909,7 +6282,7 @@ dependencies = [
  "gdkx11",
  "gtk",
  "html5ever",
- "http",
+ "http 1.3.1",
  "javascriptcore-rs",
  "jni",
  "kuchikiki",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,6 +30,9 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serialport = "4.2"
 signal-hook = "0.3"
+reqwest = { version = "0.11", features = ["json"] }
+semver = "1.0"
+tokio = { version = "1", features = ["time"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = "0.25"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,11 +4,11 @@ mod daemon;
 mod permissions;
 mod python;
 mod signing;
+mod update;
 mod usb;
 mod window;
 
 use tauri::{State, Manager};
-use tauri_plugin_shell::ShellExt;
 use daemon::{DaemonState, add_log, kill_daemon, cleanup_system_daemons, spawn_and_monitor_sidecar};
 
 #[cfg(not(windows))]
@@ -153,7 +153,9 @@ pub fn run() {
             window::close_window,
             signing::sign_python_binaries,
             permissions::open_camera_settings,
-            permissions::open_microphone_settings
+            permissions::open_microphone_settings,
+            update::check_daemon_update,
+            update::update_daemon
         ])
         .on_window_event(|window, event| {
             match event {

--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -1,0 +1,409 @@
+/// Update module for managing daemon updates
+/// 
+/// This module provides functionality to check for and install daemon updates
+/// independently of the Python daemon's update routes. It directly queries PyPI
+/// and manages the local venv using pip.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use tauri::{AppHandle, Manager, State};
+
+use crate::daemon::DaemonState;
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct DaemonUpdateInfo {
+    pub current_version: String,
+    pub available_version: String,
+    pub is_available: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct PyPiResponse {
+    info: PackageInfo,
+    releases: HashMap<String, Vec<serde_json::Value>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PackageInfo {
+    version: String,
+}
+
+// ============================================================================
+// HELPER FUNCTIONS
+// ============================================================================
+
+/// Get the path to the local venv SOURCE directory
+/// This is the directory that contains the .venv that uv-trampoline will copy
+/// - In dev: src-tauri/binaries/.venv
+/// - In production: App.app/Contents/Resources/binaries/.venv
+fn get_local_venv_path(app_handle: &AppHandle) -> Result<PathBuf, String> {
+    #[cfg(target_os = "windows")]
+    {
+        // On Windows, the source venv is in Program Files (MSI install)
+        // or in the dev environment
+        let program_files = std::env::var("ProgramFiles")
+            .unwrap_or_else(|_| "C:\\Program Files".to_string());
+        let program_files_dir = PathBuf::from(program_files)
+            .join("Reachy Mini Control")
+            .join("binaries");
+        
+        if program_files_dir.join(".venv").exists() {
+            println!("[update] ✅ Using Program Files venv: {:?}", program_files_dir);
+            return Ok(program_files_dir);
+        }
+        
+        // Try resource_dir for dev
+        let resource_dir = app_handle
+            .path()
+            .resource_dir()
+            .map_err(|e| format!("Failed to get resource dir: {}", e))?;
+        let binaries_dir = resource_dir.join("binaries");
+        
+        if binaries_dir.join(".venv").exists() {
+            println!("[update] ✅ Using dev venv: {:?}", binaries_dir);
+            return Ok(binaries_dir);
+        }
+        
+        Err(format!("Venv not found. Checked {:?} and {:?}", program_files_dir, binaries_dir))
+    }
+    
+    #[cfg(not(target_os = "windows"))]
+    {
+        // On macOS/Linux, first try to get the executable's directory
+        // This will help us determine if we're in dev or prod
+        let exe_path = std::env::current_exe()
+            .map_err(|e| format!("Failed to get exe path: {}", e))?;
+        let exe_dir = exe_path
+            .parent()
+            .ok_or_else(|| "Failed to get exe parent directory".to_string())?;
+        
+        println!("[update] Executable directory: {:?}", exe_dir);
+        
+        // In development, the executable is in target/debug/
+        // The source venv is in src-tauri/binaries/.venv
+        // We need to go up to the tauri-app root, then into src-tauri/binaries/
+        if exe_dir.ends_with("target/debug") || exe_dir.ends_with("target\\debug") {
+            // Dev mode - go to src-tauri/binaries/
+            let src_tauri_dir = exe_dir
+                .parent() // target/
+                .and_then(|p| p.parent()) // tauri-app/src-tauri/ OR tauri-app/ depending on structure
+                .ok_or_else(|| "Failed to navigate to src-tauri directory".to_string())?;
+            
+            // Check if we're already in src-tauri or need to go into it
+            let binaries_dir = if src_tauri_dir.ends_with("src-tauri") {
+                src_tauri_dir.join("binaries")
+            } else {
+                src_tauri_dir.join("src-tauri").join("binaries")
+            };
+            
+            if binaries_dir.join(".venv").exists() {
+                println!("[update] ✅ Using dev venv: {:?}", binaries_dir);
+                return Ok(binaries_dir);
+            } else {
+                return Err(format!(
+                    "Dev venv not found at {:?}",
+                    binaries_dir.join(".venv")
+                ));
+            }
+        }
+        
+        // In production (macOS app bundle), the executable is in:
+        // App.app/Contents/MacOS/
+        // The resources are in App.app/Contents/Resources/
+        // The venv is in App.app/Contents/Resources/binaries/.venv
+        #[cfg(target_os = "macos")]
+        {
+            if let Some(macos_dir) = exe_dir.parent() { // Contents/
+                let resources_dir = macos_dir.join("Resources").join("binaries");
+                if resources_dir.join(".venv").exists() {
+                    println!("[update] ✅ Using production venv: {:?}", resources_dir);
+                    return Ok(resources_dir);
+                }
+            }
+        }
+        
+        // Fallback: Use resource_dir from Tauri API
+        let resource_dir = app_handle
+            .path()
+            .resource_dir()
+            .map_err(|e| format!("Failed to get resource dir: {}", e))?;
+        let binaries_dir = resource_dir.join("binaries");
+        
+        if binaries_dir.join(".venv").exists() {
+            println!("[update] ✅ Using resource_dir venv: {:?}", binaries_dir);
+            Ok(binaries_dir)
+        } else {
+            Err(format!(
+                "Venv not found. Checked exe_dir, macOS Resources, and resource_dir: {:?}",
+                binaries_dir.join(".venv")
+            ))
+        }
+    }
+}
+
+/// Get the currently installed version of reachy-mini from the local venv
+fn get_local_daemon_version(venv_path: &Path) -> Result<String, String> {
+    // Try to read version from dist-info METADATA file
+    // Path: .venv/lib/python3.12/site-packages/reachy_mini-X.Y.Z.dist-info/METADATA
+    
+    #[cfg(target_os = "windows")]
+    let site_packages = venv_path.join(".venv").join("Lib").join("site-packages");
+    
+    #[cfg(not(target_os = "windows"))]
+    let site_packages = venv_path.join(".venv").join("lib").join("python3.12").join("site-packages");
+    
+    if !site_packages.exists() {
+        return Err(format!("Site-packages not found at {:?}", site_packages));
+    }
+    
+    // Find reachy_mini-*.dist-info directory
+    let entries = std::fs::read_dir(&site_packages)
+        .map_err(|e| format!("Failed to read site-packages: {}", e))?;
+    
+    for entry in entries {
+        let entry = entry.map_err(|e| format!("Failed to read entry: {}", e))?;
+        let name = entry.file_name().to_string_lossy().to_string();
+        
+        if name.starts_with("reachy_mini-") && name.ends_with(".dist-info") {
+            let metadata_path = entry.path().join("METADATA");
+            if metadata_path.exists() {
+                let content = std::fs::read_to_string(&metadata_path)
+                    .map_err(|e| format!("Failed to read METADATA: {}", e))?;
+                
+                // Parse METADATA file for "Version: X.Y.Z"
+                for line in content.lines() {
+                    if line.starts_with("Version: ") {
+                        return Ok(line.replace("Version: ", "").trim().to_string());
+                    }
+                }
+            }
+        }
+    }
+    
+    Err("reachy-mini version not found in venv".to_string())
+}
+
+/// Get the latest version available on PyPI
+async fn get_pypi_version(package_name: &str, pre_release: bool) -> Result<String, String> {
+    let url = format!("https://pypi.org/pypi/{}/json", package_name);
+    
+    println!("[update] Fetching PyPI info from: {}", url);
+    
+    let response = reqwest::get(&url)
+        .await
+        .map_err(|e| format!("Failed to fetch PyPI: {}", e))?;
+    
+    if !response.status().is_success() {
+        return Err(format!("PyPI returned status: {}", response.status()));
+    }
+    
+    let data: PyPiResponse = response
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse PyPI JSON: {}", e))?;
+    
+    if pre_release {
+        // Get all versions and sort them
+        let mut versions: Vec<String> = data.releases.keys().cloned().collect();
+        versions.sort_by(|a, b| compare_semver(a, b));
+        
+        if let Some(latest) = versions.last() {
+            println!("[update] Latest version (including pre-release): {}", latest);
+            Ok(latest.clone())
+        } else {
+            Err("No versions found on PyPI".to_string())
+        }
+    } else {
+        // Return the stable version from info
+        println!("[update] Latest stable version: {}", data.info.version);
+        Ok(data.info.version)
+    }
+}
+
+/// Parse a version string, handling PyPI pre-release formats (e.g., "1.2.5rc1" -> "1.2.5-rc.1")
+fn parse_version(version_str: &str) -> Result<semver::Version, String> {
+    // First, try standard semver parsing
+    if let Ok(ver) = semver::Version::parse(version_str) {
+        return Ok(ver);
+    }
+    
+    // If that fails, try to handle PyPI pre-release format: "1.2.5rc1"
+    let parts: Vec<&str> = version_str.split('.').collect();
+    if parts.len() < 3 {
+        return Err(format!("Invalid version string: {}", version_str));
+    }
+    
+    let major = parts[0];
+    let minor = parts[1];
+    let patch_part = parts[2];
+    
+    // Check for "rc" in patch part
+    if patch_part.contains("rc") {
+        let rc_parts: Vec<&str> = patch_part.split("rc").collect();
+        if rc_parts.len() == 2 {
+            let patch = rc_parts[0];
+            let rc_num = rc_parts[1];
+            let clean_version = format!("{}.{}.{}-rc.{}", major, minor, patch, rc_num);
+            return semver::Version::parse(&clean_version)
+                .map_err(|e| format!("Failed to parse cleaned version '{}': {}", clean_version, e));
+        }
+    }
+    
+    // Check for "a" (alpha) or "b" (beta) in patch part
+    if patch_part.contains('a') {
+        let parts: Vec<&str> = patch_part.split('a').collect();
+        if parts.len() == 2 {
+            let patch = parts[0];
+            let alpha_num = parts[1];
+            let clean_version = format!("{}.{}.{}-alpha.{}", major, minor, patch, alpha_num);
+            return semver::Version::parse(&clean_version)
+                .map_err(|e| format!("Failed to parse cleaned version '{}': {}", clean_version, e));
+        }
+    }
+    
+    if patch_part.contains('b') {
+        let parts: Vec<&str> = patch_part.split('b').collect();
+        if parts.len() == 2 {
+            let patch = parts[0];
+            let beta_num = parts[1];
+            let clean_version = format!("{}.{}.{}-beta.{}", major, minor, patch, beta_num);
+            return semver::Version::parse(&clean_version)
+                .map_err(|e| format!("Failed to parse cleaned version '{}': {}", clean_version, e));
+        }
+    }
+    
+    Err(format!("Could not parse version: {}", version_str))
+}
+
+/// Compare two semver version strings
+/// Returns Ordering (Less, Equal, Greater)
+fn compare_semver(a: &str, b: &str) -> std::cmp::Ordering {
+    // Try to parse both versions with our custom parser
+    match (parse_version(a), parse_version(b)) {
+        (Ok(va), Ok(vb)) => va.cmp(&vb),
+        _ => {
+            // Fallback to string comparison if parsing fails
+            a.cmp(b)
+        }
+    }
+}
+
+/// Check if a new version is available
+fn is_update_available(current: &str, available: &str) -> Result<bool, String> {
+    let current_ver = parse_version(current)?;
+    let available_ver = parse_version(available)?;
+    
+    Ok(available_ver > current_ver)
+}
+
+// ============================================================================
+// TAURI COMMANDS
+// ============================================================================
+
+/// Check if an update is available for the daemon
+#[tauri::command]
+pub async fn check_daemon_update(
+    app_handle: AppHandle,
+    pre_release: bool,
+) -> Result<DaemonUpdateInfo, String> {
+    println!("[update] Checking for daemon updates (pre_release: {})", pre_release);
+    
+    // 1. Get local version
+    let venv_path = get_local_venv_path(&app_handle)?;
+    let current_version = get_local_daemon_version(&venv_path)?;
+    println!("[update] Current version: {}", current_version);
+    
+    // 2. Get PyPI version
+    let available_version = get_pypi_version("reachy-mini", pre_release).await?;
+    println!("[update] Available version: {}", available_version);
+    
+    // 3. Compare versions
+    let is_available = is_update_available(&current_version, &available_version)?;
+    println!("[update] Update available: {}", is_available);
+    
+    Ok(DaemonUpdateInfo {
+        current_version,
+        available_version,
+        is_available,
+    })
+}
+
+/// Update the daemon to the latest version
+#[tauri::command]
+pub async fn update_daemon(
+    app_handle: AppHandle,
+    state: State<'_, DaemonState>,
+    pre_release: bool,
+) -> Result<String, String> {
+    println!("[update] Starting daemon update (pre_release: {})", pre_release);
+    
+    // 1. Stop the daemon gracefully
+    println!("[update] Stopping daemon...");
+    crate::stop_daemon(state.clone())?;
+    
+    // Wait a bit for the daemon to stop completely
+    tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
+    
+    // 2. Get venv path and pip executable
+    let venv_path = get_local_venv_path(&app_handle)?;
+    
+    #[cfg(target_os = "windows")]
+    let pip_path = venv_path.join(".venv").join("Scripts").join("pip.exe");
+    
+    #[cfg(not(target_os = "windows"))]
+    let pip_path = venv_path.join(".venv").join("bin").join("pip");
+    
+    if !pip_path.exists() {
+        return Err(format!("pip not found at {:?}", pip_path));
+    }
+    
+    println!("[update] Using pip at: {:?}", pip_path);
+    
+    // 3. Build pip command
+    let mut args = vec!["install", "--upgrade", "reachy-mini[mujoco]"];
+    if pre_release {
+        args.push("--pre");
+    }
+    
+    println!("[update] Running: {:?} {:?}", pip_path, args);
+    
+    // 4. Execute pip install
+    let output = std::process::Command::new(&pip_path)
+        .args(&args)
+        .output()
+        .map_err(|e| format!("Failed to run pip: {}", e))?;
+    
+    // Log output
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    
+    if !stdout.is_empty() {
+        println!("[update] pip stdout:\n{}", stdout);
+    }
+    if !stderr.is_empty() {
+        println!("[update] pip stderr:\n{}", stderr);
+    }
+    
+    if !output.status.success() {
+        return Err(format!(
+            "pip update failed with exit code {:?}:\n{}",
+            output.status.code(),
+            stderr
+        ));
+    }
+    
+    println!("[update] Daemon updated successfully!");
+    println!("[update] ⚠️  The updated venv will be used on next connection");
+    println!("[update] ⚠️  uv-trampoline will copy the new venv when daemon starts again");
+    
+    // 5. DON'T restart daemon here
+    // Let the user reconnect - uv-trampoline will copy the updated venv at next launch
+    
+    Ok("Daemon updated successfully. Reconnect to use the new version.".to_string())
+}
+

--- a/src/components/viewer3d/Viewer3D.jsx
+++ b/src/components/viewer3d/Viewer3D.jsx
@@ -4,8 +4,6 @@ import { IconButton, Switch, Tooltip, Box, Typography } from '@mui/material';
 import VisibilityOutlinedIcon from '@mui/icons-material/VisibilityOutlined';
 import GridOnIcon from '@mui/icons-material/GridOn';
 import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
-import ThreeSixtyOutlinedIcon from '@mui/icons-material/ThreeSixtyOutlined';
-import MyLocationOutlinedIcon from '@mui/icons-material/MyLocationOutlined';
 import CircleIcon from '@mui/icons-material/Circle';
 // Leva removed - was never displayed
 import * as THREE from 'three';
@@ -23,7 +21,7 @@ import { FPSMeter } from '../FPSMeter';
 // ✅ Camera presets
 const CAMERA_PRESETS = {
   normal: {
-    position: [0, 0.25, 0.52], // Zoomed out: Z = 0.32 + 0.20
+    position: [-0.25, 0.35, 0.55], // 3/4 view from left, slightly further
     fov: 50,
     target: [0, 0.2, 0],
     minDistance: 0.2,
@@ -52,8 +50,6 @@ export default function RobotViewer3D({
   onMeshesReady = null, // Callback when robot meshes are ready
   cameraPreset = 'normal', // Camera preset ('normal' | 'scan') or custom object
   useCinematicCamera = false, // Use animated camera instead of OrbitControls
-  useHeadFollowCamera = false, // Camera that follows robot head
-  showCameraToggle = false, // Show toggle to switch between Follow and Free
   errorFocusMesh = null, // Mesh to focus on in case of error
   backgroundColor = '#e0e0e0', // Canvas background color
   wireframe = false, // ✅ Wireframe mode
@@ -173,19 +169,6 @@ export default function RobotViewer3D({
     ? (darkMode ? '#1a1a1a' : '#e0e0e0')
     : backgroundColor;
   
-  // 🎥 Camera modes: 'free' | 'locked'
-  // - free: Free camera with OrbitControls
-  // - locked: Follows head position AND orientation (FPV)
-  const [cameraMode, setCameraMode] = useState('free');
-  
-  // Toggle between the 2 modes
-  const toggleCameraMode = () => {
-    setCameraMode(prev => prev === 'free' ? 'locked' : 'free');
-  };
-  
-  // Compute props for Scene
-  const useHeadFollow = cameraMode === 'locked';
-  const lockToOrientation = cameraMode === 'locked';
   
   // ✨ Determine robot status for tag (with state machine)
   const getStatusTag = () => {
@@ -200,6 +183,9 @@ export default function RobotViewer3D({
         
         case 'starting':
           return { label: 'Starting', color: '#3b82f6', animated: true };
+        
+        case 'sleeping':
+          return { label: 'Sleeping', color: '#FF9500' };
         
         case 'ready':
           // If motors on → Ready, if off → Standby
@@ -322,8 +308,6 @@ export default function RobotViewer3D({
                 onMeshesReady={onMeshesReady}
                 cameraConfig={cameraConfig}
                 useCinematicCamera={useCinematicCamera}
-              useHeadFollowCamera={useHeadFollowCamera && useHeadFollow}
-              lockCameraToHead={lockToOrientation}
               errorFocusMesh={errorFocusMesh}
               hideEffects={hideEffects}
                    darkMode={darkMode}
@@ -362,12 +346,13 @@ export default function RobotViewer3D({
                 width: 32,
                 height: 32,
                 transition: 'all 0.2s ease',
-                opacity: 0.7,
-                color: '#666',
+                color: 'primary.main',
+                border: '1px solid',
+                borderColor: 'primary.main',
+                bgcolor: 'transparent',
                 '&:hover': {
-                  opacity: 1,
-                  color: '#FF9500',
-                  bgcolor: 'rgba(255, 149, 0, 0.08)',
+                  borderColor: 'primary.dark',
+                  bgcolor: 'rgba(99, 102, 241, 0.08)',
                 },
               }}
             >
@@ -375,50 +360,6 @@ export default function RobotViewer3D({
             </IconButton>
           </Tooltip>
 
-          {/* Camera Mode Toggle (si showCameraToggle) - COMMENTED */}
-          {/* {showCameraToggle && (
-            <>
-              <Tooltip
-                title={
-                  cameraMode === 'free' 
-                    ? 'Free Camera - Click to lock to head' 
-                    : 'Locked - Click for free camera'
-                }
-                placement="top"
-                arrow
-              >
-                <IconButton
-                  onClick={toggleCameraMode}
-                  size="small"
-                  sx={{
-                    width: 32,
-                    height: 32,
-                    transition: 'all 0.2s ease',
-                    opacity: 0.7,
-                    '&:hover': {
-                      opacity: 1,
-                      bgcolor: 'rgba(0, 0, 0, 0.04)',
-                    },
-                  }}
-                >
-                  {cameraMode === 'free' ? (
-                    <ThreeSixtyOutlinedIcon sx={{ fontSize: 16, color: '#666' }} />
-                  ) : (
-                    <MyLocationOutlinedIcon sx={{ fontSize: 16, color: '#e63946' }} />
-                  )}
-                </IconButton>
-              </Tooltip>
-
-              <Box
-                sx={{
-                  width: '1px',
-                  height: '14px',
-                  bgcolor: 'rgba(0, 0, 0, 0.1)',
-                  mx: 0.5,
-                }}
-              />
-            </>
-          )} */}
 
           {/* View Mode Toggle - COMMENTED */}
           {/* <Tooltip


### PR DESCRIPTION
Implement a Rust-based daemon update system for Reachy Mini Lite (USB/Simulation modes):

**Backend (Rust):**
- Add new update module with PyPI integration
- Implement check_daemon_update command to query latest version
- Implement update_daemon command to run pip install in local venv
- Handle pre-release versions (rc, alpha, beta) with custom semver parsing

**Frontend (React):**
- Extend SettingsOverlay to support updates in USB/Simulation modes
- Add toast notifications for update success/failure
- Persist beta updates preference in localStorage
- Add WiFi mode disclaimer (plug robot into power outlet during update)
- Settings button styled as primary outlined