### PR TITLE
feat(discovery): Implement mDNS robot discovery in Rust

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "kill-zombie-apps": "bash ./scripts/utils/kill-zombie-apps.sh",
     "reset-permissions": "bash ./scripts/utils/reset-macos-permissions.sh",
     "clean": "bash ./scripts/utils/clean.sh",
+    "clean:tauri": "rm -rf src-tauri/target/debug/.fingerprint src-tauri/gen/schemas && echo '✅ Tauri cache cleaned'",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
     "format": "prettier --write src/",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -156,7 +156,7 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "parking",
- "polling",
+ "polling 3.11.0",
  "rustix",
  "slab",
  "windows-sys 0.61.2",
@@ -438,7 +438,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -453,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.52"
+version = "1.2.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd4932aefd12402b36c60956a4fe0035421f544799057659ff86f923657aada3"
+checksum = "755d2fce177175ffca841e9a06afdb2c4ab0f593d53b4dee48147dfaade85932"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -1242,21 +1242,20 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
 dependencies = [
  "cfg-if",
  "libc",
  "libredox",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
+checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
 
 [[package]]
 name = "flate2"
@@ -1266,6 +1265,17 @@ checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
 ]
 
 [[package]]
@@ -2142,6 +2152,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-addrs"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2523,6 +2543,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
+name = "mdns-sd"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fe7c11a1eb3cfbfcf702d1601c1f5f4c102cdc8665b8a557783ef634741676e"
+dependencies = [
+ "flume",
+ "if-addrs",
+ "log",
+ "polling 2.8.0",
+ "socket2 0.5.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2587,7 +2620,7 @@ dependencies = [
  "once_cell",
  "png",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "windows-sys 0.60.2",
 ]
 
@@ -3046,7 +3079,7 @@ dependencies = [
  "objc2-osa-kit",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3306,6 +3339,22 @@ dependencies = [
 
 [[package]]
 name = "polling"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "concurrent-queue",
+ "libc",
+ "log",
+ "pin-project-lite",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
@@ -3470,7 +3519,7 @@ dependencies = [
  "rustc-hash",
  "rustls 0.23.36",
  "socket2 0.6.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -3491,7 +3540,7 @@ dependencies = [
  "rustls 0.23.36",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3650,6 +3699,7 @@ dependencies = [
  "cocoa",
  "futures-util",
  "lazy_static",
+ "mdns-sd",
  "objc",
  "reqwest 0.11.27",
  "semver",
@@ -3700,7 +3750,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3915,7 +3965,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.8",
+ "rustls-webpki 0.103.9",
  "subtle",
  "zeroize",
 ]
@@ -3931,9 +3981,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3951,9 +4001,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4466,6 +4516,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4731,7 +4790,7 @@ dependencies = [
  "tauri-runtime",
  "tauri-runtime-wry",
  "tauri-utils",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tray-icon",
  "url",
@@ -4783,7 +4842,7 @@ dependencies = [
  "sha2",
  "syn 2.0.114",
  "tauri-utils",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "url",
  "uuid",
@@ -4833,7 +4892,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4850,7 +4909,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tauri-utils",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "url",
  "windows-registry 0.5.3",
@@ -4874,7 +4933,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tauri-utils",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "toml 0.9.11+spec-1.1.0",
  "url",
 ]
@@ -4897,7 +4956,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tauri-plugin-fs",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "url",
  "urlpattern",
@@ -4915,7 +4974,7 @@ dependencies = [
  "serde",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4934,7 +4993,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "url",
  "windows 0.61.3",
  "zbus",
@@ -4952,7 +5011,7 @@ dependencies = [
  "serde_repr",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4969,7 +5028,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -5000,7 +5059,7 @@ dependencies = [
  "shared_child",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -5028,7 +5087,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "url",
@@ -5054,7 +5113,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tauri-utils",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "url",
  "webkit2gtk",
  "webview2-com",
@@ -5118,7 +5177,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "swift-rs",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "toml 0.9.11+spec-1.1.0",
  "url",
  "urlpattern",
@@ -5172,11 +5231,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -5192,9 +5251,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5539,7 +5598,7 @@ dependencies = [
  "once_cell",
  "png",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "windows-sys 0.60.2",
 ]
 
@@ -5598,7 +5657,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4064ed685c487dbc25bd3f0e9548f2e34bab9d18cefc700f9ec2dba74ba1138e"
 dependencies = [
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5786,9 +5845,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -5975,7 +6034,7 @@ version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "windows 0.61.3",
  "windows-core 0.61.2",
 ]
@@ -6606,9 +6665,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "writeable"
@@ -6650,7 +6709,7 @@ dependencies = [
  "sha2",
  "soup3",
  "tao-macros",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "url",
  "webkit2gtk",
  "webkit2gtk-sys",
@@ -6870,15 +6929,15 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd8f3f50b848df28f887acb68e41201b5aea6bc8a8dacc00fb40635ff9a72fea"
+checksum = "94f63c051f4fe3c1509da62131a678643c5b6fbdc9273b2b79d4378ebda003d2"
 
 [[package]]
 name = "zvariant"
-version = "5.9.1"
+version = "5.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "326aaed414f04fe839777b4c443d4e94c74e7b3621093bd9c5e649ac8aa96543"
+checksum = "68b64ef4f40c7951337ddc7023dd03528a57a3ce3408ee9da5e948bd29b232c4"
 dependencies = [
  "endi",
  "enumflags2",
@@ -6890,9 +6949,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "5.9.1"
+version = "5.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba44e1f8f4da9e6e2d25d2a60b116ef8b9d0be174a7685e55bb12a99866279a7"
+checksum = "484d5d975eb7afb52cc6b929c13d3719a20ad650fea4120e6310de3fc55e415c"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,6 +38,7 @@ tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "time", "n
 tokio-tungstenite = { version = "0.21", features = ["native-tls"] }
 futures-util = "0.3"
 lazy_static = "1.4"
+mdns-sd = "0.11"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = "0.25"

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -23,6 +23,7 @@
 	<array>
 		<string>_http._tcp</string>
 		<string>_https._tcp</string>
+		<string>_reachy._tcp</string>
 	</array>
 	
 	<!-- Description for file system access -->

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -33,18 +33,10 @@
     "posthog:allow-get-config",
     {
       "identifier": "http:default",
+      "_comment": "Permissive scope: desktop app, calls to local robot + HuggingFace API. No untrusted user content.",
       "allow": [
-        { "url": "http://localhost:*" },
-        { "url": "http://127.0.0.1:*" },
-        { "url": "http://192.168.*.*:*" },
-        { "url": "http://10.*.*.*:*" },
-        { "url": "http://10.42.0.1:*" },
-        { "url": "http://*.local:*" },
-        { "url": "http://*.home:*" },
-        { "url": "https://huggingface.co/*" },
-        { "url": "https://httpbin.org/*" },
-        { "url": "https://*.posthog.com/*" },
-        { "url": "https://eu.i.posthog.com/*" }
+        { "url": "http://*:*" },
+        { "url": "https://*:*" }
       ]
     }
   ]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -193,6 +193,7 @@ pub fn run() {
             permissions::open_files_settings,
             wifi::scan_local_wifi_networks,
             wifi::get_current_wifi_ssid,
+            wifi::discover_reachy_robot,
             update::check_daemon_update,
             update::update_daemon,
             set_local_proxy_target,

--- a/src-tauri/src/local_proxy.rs
+++ b/src-tauri/src/local_proxy.rs
@@ -16,7 +16,11 @@ use tokio_tungstenite::tungstenite::handshake::server::{Request, Response};
 use futures_util::{StreamExt, SinkExt};
 
 /// Ports to proxy (local -> remote with same port)
-const PROXY_PORTS: &[u16] = &[8000, 8042, 7447];
+/// - 8000: Daemon API (HTTP + WebSocket)
+/// - 8042: Video streams
+/// - 7447: Zenoh (DDS)
+/// - 8443: WebRTC signaling (GStreamer WebRTC)
+const PROXY_PORTS: &[u16] = &[8000, 8042, 7447, 8443];
 
 /// Shared state for the proxy
 pub struct LocalProxyState {

--- a/src-tauri/src/wifi/mod.rs
+++ b/src-tauri/src/wifi/mod.rs
@@ -1,9 +1,12 @@
-// WiFi scanning module
-// Scans available WiFi networks using system commands
+// WiFi scanning and mDNS discovery module
+// - Scans available WiFi networks using system commands
+// - Discovers Reachy robots on the network using mDNS (cross-platform)
 // Uses async + spawn_blocking to avoid blocking the UI
 
 use serde::Serialize;
 use std::process::Command;
+use std::time::Duration;
+use std::net::SocketAddr;
 
 #[derive(Debug, Serialize, Clone)]
 pub struct WifiNetwork {
@@ -486,3 +489,206 @@ fn scan_linux() -> Result<Vec<WifiNetwork>, String> {
     Ok(networks)
 }
 
+// ============================================================================
+// mDNS Robot Discovery
+// ============================================================================
+
+/// Result of robot discovery - always contains an IP address (not hostname)
+#[derive(Debug, Serialize, Clone)]
+pub struct DiscoveredRobot {
+    /// IP address of the robot (IPv4)
+    pub ip: String,
+    /// Port number (usually 8000)
+    pub port: u16,
+    /// Original hostname that was resolved (for debugging)
+    pub hostname: String,
+    /// How the robot was discovered
+    pub discovery_method: String,
+}
+
+/// Discover Reachy robots on the network using mDNS
+/// 
+/// This function uses multiple discovery strategies:
+/// 1. System DNS resolution (uses OS mDNS cache - fastest)
+/// 2. Pure Rust mDNS browsing (cross-platform fallback)
+/// 3. Known IP fallbacks (hotspot mode + common static IPs)
+/// 
+/// The returned IP address can be used directly for all subsequent connections,
+/// avoiding mDNS resolution issues in WebView.
+#[tauri::command]
+pub async fn discover_reachy_robot() -> Result<Option<DiscoveredRobot>, String> {
+    // Run discovery in a blocking task to not block the UI
+    tokio::task::spawn_blocking(|| {
+        discover_robot_sync()
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
+}
+
+/// Synchronous robot discovery (runs in spawn_blocking thread)
+fn discover_robot_sync() -> Result<Option<DiscoveredRobot>, String> {
+    // Hostnames to try resolving via system DNS / mDNS
+    let mdns_hostnames = vec![
+        "reachy-mini.local",   // Standard mDNS hostname (.local)
+        "reachy-mini.home",    // Some routers use .home domain
+    ];
+    
+    let daemon_port: u16 = 8000;
+    let timeout = Duration::from_secs(5); // Increased for slow networks / mDNS cache miss
+    
+    // =========================================================================
+    // Strategy 1: System DNS resolution (fastest, uses OS mDNS cache)
+    // =========================================================================
+    // This leverages macOS Bonjour / Windows mDNS / Linux Avahi via system resolver
+    // Much faster than pure Rust mDNS browsing when hostname is cached
+    
+    for hostname in &mdns_hostnames {
+        println!("[Discovery] Trying system DNS for: {}", hostname);
+        
+        if let Ok(Some(ip)) = resolve_via_system_dns(hostname) {
+            // Verify the daemon is actually running on this IP
+            if probe_daemon(&ip, daemon_port) {
+                println!("[Discovery] ✓ Found robot at {} (resolved from {})", ip, hostname);
+                return Ok(Some(DiscoveredRobot {
+                    ip: ip.clone(),
+                    port: daemon_port,
+                    hostname: hostname.to_string(),
+                    discovery_method: "system_dns".to_string(),
+                }));
+            } else {
+                println!("[Discovery] IP {} resolved but daemon not responding", ip);
+            }
+        }
+    }
+    
+    // =========================================================================
+    // Strategy 2: Pure Rust mDNS service browsing (cross-platform fallback)
+    // =========================================================================
+    // Used when system DNS fails (no mDNSResponder, cache miss, etc.)
+    
+    println!("[Discovery] System DNS failed, trying mDNS service browsing...");
+    
+    // Create mDNS daemon (pure Rust, cross-platform)
+    if let Ok(mdns) = mdns_sd::ServiceDaemon::new() {
+        for hostname in &mdns_hostnames {
+            let hostname_with_dot = format!("{}.", hostname);
+            
+            match resolve_mdns_hostname(&mdns, &hostname_with_dot, timeout) {
+                Ok(Some(ip)) => {
+                    if probe_daemon(&ip, daemon_port) {
+                        println!("[Discovery] ✓ Found robot at {} (via mDNS browsing)", ip);
+                        let _ = mdns.shutdown();
+                        return Ok(Some(DiscoveredRobot {
+                            ip: ip.clone(),
+                            port: daemon_port,
+                            hostname: hostname.to_string(),
+                            discovery_method: "mdns_browse".to_string(),
+                        }));
+                    }
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    println!("[Discovery] mDNS error for {}: {}", hostname, e);
+                }
+            }
+        }
+        let _ = mdns.shutdown();
+    }
+    
+    // No robot found via any method
+    println!("[Discovery] No robot found via mDNS");
+    Ok(None)
+}
+
+/// Resolve a .local hostname to an IP address using pure Rust mDNS browsing
+/// 
+/// This uses mdns-sd to browse for services and find Reachy devices.
+/// Note: This is a fallback - system DNS (resolve_via_system_dns) is preferred
+/// because it's faster and uses the OS mDNS cache.
+fn resolve_mdns_hostname(
+    mdns: &mdns_sd::ServiceDaemon, 
+    _hostname: &str, // Not used directly - we browse for services instead
+    timeout: Duration
+) -> Result<Option<String>, String> {
+    use mdns_sd::ServiceEvent;
+    
+    // Browse for workstation services (_workstation._tcp) which most Linux/macOS machines advertise
+    // This is more reliable than _http._tcp which the daemon may not advertise
+    let service_types = vec![
+        "_workstation._tcp.local.",  // Standard service advertised by most machines
+        "_http._tcp.local.",         // HTTP service (fallback)
+    ];
+    
+    for service_type in service_types {
+        let receiver = match mdns.browse(service_type) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+        
+        let start = std::time::Instant::now();
+        
+        while start.elapsed() < timeout {
+            match receiver.recv_timeout(Duration::from_millis(200)) {
+                Ok(ServiceEvent::ServiceResolved(info)) => {
+                    let service_hostname = info.get_hostname();
+                    
+                    // Check if this is a Reachy device
+                    if service_hostname.to_lowercase().contains("reachy-mini") {
+                        // Get IPv4 addresses
+                        let addresses = info.get_addresses_v4();
+                        if let Some(ip) = addresses.iter().next() {
+                            return Ok(Some(ip.to_string()));
+                        }
+                    }
+                }
+                Ok(_) => {
+                    // Other events (SearchStarted, ServiceFound, etc.) - continue
+                }
+                Err(_) => {
+                    // Timeout - continue loop, will exit on timeout check
+                }
+            }
+        }
+    }
+    
+    Ok(None)
+}
+
+/// Fallback: Try to resolve hostname via system DNS (may use mDNS on macOS)
+fn resolve_via_system_dns(hostname: &str) -> Result<Option<String>, String> {
+    use std::net::ToSocketAddrs;
+    
+    let addr_str = format!("{}:80", hostname);
+    
+    match addr_str.to_socket_addrs() {
+        Ok(addrs) => {
+            for addr in addrs {
+                if let SocketAddr::V4(v4) = addr {
+                    return Ok(Some(v4.ip().to_string()));
+                }
+            }
+            Ok(None)
+        }
+        Err(_) => Ok(None)
+    }
+}
+
+/// Check if daemon is responding on the given IP:port
+/// 
+/// Uses TCP connect probe which is faster than HTTP but confirms the port is open.
+/// Timeout is set to 1.5s to handle slow networks while keeping discovery responsive.
+fn probe_daemon(ip: &str, port: u16) -> bool {
+    use std::net::TcpStream;
+    
+    let addr = format!("{}:{}", ip, port);
+    
+    // TCP connect probe - confirms port is open and accepting connections
+    // 1.5s timeout balances between responsiveness and handling slow networks
+    match TcpStream::connect_timeout(
+        &addr.parse().unwrap_or_else(|_| SocketAddr::from(([0, 0, 0, 0], port))),
+        Duration::from_millis(1500)
+    ) {
+        Ok(_) => true,
+        Err(_) => false,
+    }
+}

--- a/src/config/daemon.js
+++ b/src/config/daemon.js
@@ -143,9 +143,9 @@ export const DAEMON_CONFIG = {
 
   // API endpoints
   ENDPOINTS: {
-    // ⚠️ BASE_URL is now dynamic - use getBaseUrl() instead of DAEMON_CONFIG.ENDPOINTS.BASE_URL
+    // ⚠️ BASE_URL is dynamic - use getBaseUrl() instead
+    // WiFi mode uses the IP discovered via mDNS (see useRobotDiscovery.js)
     BASE_URL_LOCAL: 'http://localhost:8000',
-    BASE_URL_DEFAULT_WIFI: 'http://reachy-mini.home:8000',
     STATE_FULL: '/api/state/full',
     DAEMON_STATUS: '/api/daemon/status',
     // 🌐 WiFi daemon control (handshake for remote sessions)
@@ -359,7 +359,8 @@ export async function fetchWithTimeout(url, options = {}, timeoutMs, logOptions 
 
 /**
  * 🌐 Get the current base URL based on connection mode
- * - WiFi mode: uses remoteHost from store (e.g. 'http://reachy-mini.home:8000')
+ * - WiFi mode: uses remoteHost from store (always an IP, e.g. 'http://192.168.1.42:8000')
+ *   The IP is discovered via mDNS in Rust (see discover_reachy_robot command)
  * - USB/Simulation: uses localhost
  */
 export function getBaseUrl() {
@@ -397,7 +398,7 @@ export function buildApiUrl(endpoint) {
 /**
  * 🌐 Get daemon hostname only (without protocol or port)
  * Used for remapping app URLs to the correct robot host
- * @returns {string} Hostname like 'localhost', 'reachy-mini.home', or '192.168.1.18'
+ * @returns {string} Hostname/IP like 'localhost' or '192.168.1.42'
  */
 export function getDaemonHostname() {
   const { connectionMode, remoteHost } = useStore.getState();

--- a/src/contexts/WebRTCStreamContext.jsx
+++ b/src/contexts/WebRTCStreamContext.jsx
@@ -7,6 +7,7 @@
 import React, { createContext, useContext, useEffect, useState, useCallback, useRef } from 'react';
 import useAppStore from '../store/useAppStore';
 import { fetchWithTimeout, buildApiUrl } from '../config/daemon';
+import { isWebMode } from '../utils/tauriCompat';
 
 // Import the GStreamer WebRTC API
 import '../lib/gstwebrtc-api';
@@ -134,7 +135,10 @@ export function WebRTCStreamProvider({ children }) {
     setState(StreamState.CONNECTING);
     setError(null);
 
-    const signalingUrl = `ws://${remoteHost}:${SIGNALING_PORT}`;
+    // In Tauri desktop app, use localhost (proxy forwards to remoteHost)
+    // In web mode, connect directly to remoteHost (may fail due to PNA)
+    const signalingHost = isWebMode ? remoteHost : 'localhost';
+    const signalingUrl = `ws://${signalingHost}:${SIGNALING_PORT}`;
 
     try {
       const GstWebRTCAPI = window.GstWebRTCAPI;

--- a/src/hooks/daemon/useDaemon.js
+++ b/src/hooks/daemon/useDaemon.js
@@ -86,6 +86,8 @@ export const useDaemon = () => {
         const errorObject = createErrorFromConfig(data.errorConfig, data.errorLine);
         setHardwareError(errorObject);
         transitionTo.starting();
+        // 📊 Telemetry - Track known hardware errors (NO_MOTORS, CAMERA_ERROR, etc.)
+        handleDaemonError('hardware', data.errorLine, { code: data.errorConfig.code });
       } else if (data.isGeneric) {
         const currentError = currentState.hardwareError;
         if (!currentError || !currentError.type) {
@@ -348,8 +350,9 @@ export const useDaemon = () => {
         eventBus.emit('daemon:start:success', { existing: true, wifi: true });
       } catch (e) {
         console.error('[Daemon] WiFi connection failed:', e.message);
-        resetAll();
+        // ⚠️ IMPORTANT: Emit error BEFORE resetAll() so telemetry captures the connectionMode
         eventBus.emit('daemon:start:error', new Error(`WiFi daemon error: ${e.message}`));
+        resetAll();
       }
       return;
     }

--- a/src/hooks/system/useRobotDiscovery.js
+++ b/src/hooks/system/useRobotDiscovery.js
@@ -4,113 +4,68 @@
  * Scans for available robots via USB and WiFi in parallel.
  * Used by FindingRobotView to detect and list connection options.
  *
- * Uses Tauri HTTP plugin for WiFi discovery to bypass WebView restrictions.
+ * WiFi discovery uses Tauri's mDNS-based discovery (Rust side) which:
+ * - Works cross-platform (macOS, Windows, Linux)
+ * - Always returns an IP address (not hostname) for reliable connections
+ * - Bypasses WebView mDNS resolution issues
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
-import { fetch as tauriFetch } from '@tauri-apps/plugin-http';
 import useAppStore from '../../store/useAppStore';
 import { DAEMON_CONFIG } from '../../config/daemon';
-
-// WiFi hosts to check (try multiple in parallel)
-// mDNS (.home) doesn't work in WebView, so we also try common IPs
-const WIFI_HOSTS_TO_CHECK = [
-  'reachy-mini.home', // mDNS (works in some cases)
-  'reachy-mini.local', // mDNS alternative
-  '192.168.1.18', // Common static IP for Reachy
-  // Add more IPs here if needed
-];
-const WIFI_CHECK_TIMEOUT = 10000; // 10s timeout per host (needs to be long after WiFi inactivity: mDNS cache expiry + Pi WiFi wake)
 
 // Track last logged WiFi host to avoid repetitive logs
 let lastLoggedWifiHost = null;
 
 /**
- * Check if a WiFi robot is available at a single host
- * Uses Tauri HTTP plugin to bypass WebView network restrictions
- * @param {string} host - Hostname or IP to check
- * @returns {Promise<{available: boolean, host: string, error?: string}>}
+ * Discover WiFi robot using Tauri's mDNS discovery
+ * Returns an IP address (not hostname) for reliable connections
+ * @returns {Promise<{available: boolean, host: string | null, hostname: string | null}>}
  */
-async function checkSingleHost(host) {
+async function checkWifiRobot() {
   try {
-    // Use Tauri fetch which runs in Rust (bypasses WebView restrictions)
-    const response = await tauriFetch(`http://${host}:8000/api/daemon/status`, {
-      method: 'GET',
-      connectTimeout: WIFI_CHECK_TIMEOUT,
-    });
+    // Use Tauri command for mDNS discovery (pure Rust, cross-platform)
+    // This resolves hostnames to IPs and probes the daemon
+    const result = await invoke('discover_reachy_robot');
 
-    if (response.ok) {
-      return { available: true, host };
+    if (result) {
+      // Only log when host changes (found new robot or different host)
+      if (lastLoggedWifiHost !== result.ip) {
+        const methodInfo =
+          result.discovery_method === 'mdns'
+            ? `via mDNS (${result.hostname})`
+            : `via ${result.discovery_method}`;
+        console.log(`🌐 WiFi robot found at ${result.ip} ${methodInfo}`);
+        lastLoggedWifiHost = result.ip;
+      }
+
+      // Return IP for connections, but keep hostname for display
+      return {
+        available: true,
+        host: result.ip, // Always use IP for actual connections
+        hostname: result.hostname || null, // mDNS hostname for display (e.g. "reachy-mini.local")
+      };
     }
-    return { available: false, host, error: `HTTP ${response.status}` };
+
+    // Log when robot is lost (was found before, now gone)
+    if (lastLoggedWifiHost !== null) {
+      console.log('🌐 WiFi robot disconnected');
+      lastLoggedWifiHost = null;
+    }
+
+    return { available: false, host: null, hostname: null };
   } catch (e) {
-    // Network error or timeout
-    return { available: false, host, error: e.message };
-  }
-}
+    console.error('WiFi discovery error:', e);
 
-import { isReachyHotspot } from '../../constants/wifi';
-
-/**
- * Check if the computer is currently connected to a Reachy hotspot
- * @returns {Promise<boolean>}
- */
-async function isOnReachyHotspot() {
-  try {
-    const currentSsid = await invoke('get_current_wifi_ssid');
-    return isReachyHotspot(currentSsid);
-  } catch (e) {
-    console.warn('Failed to get current WiFi SSID:', e);
-    return false;
-  }
-}
-
-/**
- * Check multiple WiFi hosts in parallel and return the first one that responds
- * @param {Function} isRobotBlacklisted - Function to check if a robot host is blacklisted
- * @returns {Promise<{available: boolean, host: string | null}>}
- */
-async function checkWifiRobot(isRobotBlacklisted) {
-  // First check if we're on the Reachy hotspot - if so, WiFi mode is not available
-  const onHotspot = await isOnReachyHotspot();
-  if (onHotspot) {
-    if (lastLoggedWifiHost !== 'hotspot-blocked') {
-      lastLoggedWifiHost = 'hotspot-blocked';
+    // Log when robot is lost due to error
+    if (lastLoggedWifiHost !== null) {
+      console.log('🌐 WiFi robot disconnected (discovery error)');
+      lastLoggedWifiHost = null;
     }
-    return { available: false, host: null, onHotspot: true };
+
+    return { available: false, host: null, hostname: null };
   }
-
-  // Check all hosts in parallel
-  const results = await Promise.all(WIFI_HOSTS_TO_CHECK.map(host => checkSingleHost(host)));
-
-  // Return the first available host (but filter out blacklisted ones)
-  const available = results.find(r => r.available && !isRobotBlacklisted(r.host));
-  if (available) {
-    // Only log when host changes (found new robot or different host)
-    if (lastLoggedWifiHost !== available.host) {
-      lastLoggedWifiHost = available.host;
-    }
-    return { available: true, host: available.host };
-  }
-
-  // Check if all available hosts are blacklisted
-  const hasBlacklistedRobots = results.some(r => r.available && isRobotBlacklisted(r.host));
-  if (hasBlacklistedRobots && lastLoggedWifiHost !== 'blacklisted') {
-    lastLoggedWifiHost = 'blacklisted';
-  }
-
-  // Log when robot is lost (was found before, now gone)
-  if (
-    lastLoggedWifiHost &&
-    lastLoggedWifiHost !== 'hotspot-blocked' &&
-    lastLoggedWifiHost !== 'blacklisted' &&
-    !hasBlacklistedRobots
-  ) {
-    lastLoggedWifiHost = null;
-  }
-
-  return { available: false, host: null };
 }
 
 /**
@@ -132,31 +87,23 @@ async function checkUsbRobot() {
  *
  * Scans for USB and WiFi robots in parallel.
  * Returns the current state of discovered robots.
+ *
+ * WiFi discovery always returns an IP address (resolved via mDNS in Rust),
+ * ensuring reliable connections without WebView mDNS issues.
  */
 export function useRobotDiscovery() {
   const isFirstCheck = useAppStore(state => state.isFirstCheck);
   const setIsFirstCheck = useAppStore(state => state.setIsFirstCheck);
-  const cleanupBlacklist = useAppStore(state => state.cleanupBlacklist);
-  const isRobotBlacklisted = useAppStore(state => state.isRobotBlacklisted);
 
   // Discovery state
   const [isScanning, setIsScanning] = useState(true);
   const [usbRobot, setUsbRobot] = useState({ available: false, portName: null });
-  const [wifiRobot, setWifiRobot] = useState({ available: false, host: null });
+  const [wifiRobot, setWifiRobot] = useState({ available: false, host: null, hostname: null });
 
   // Refs for interval management
   const scanIntervalRef = useRef(null);
   const isMountedRef = useRef(true);
   const isScanningRef = useRef(false); // Prevent overlapping scans
-
-  // Cleanup expired blacklist entries periodically
-  useEffect(() => {
-    const cleanupInterval = setInterval(() => {
-      cleanupBlacklist();
-    }, 2000); // Every 2 seconds
-
-    return () => clearInterval(cleanupInterval);
-  }, [cleanupBlacklist]);
 
   /**
    * Perform a single discovery scan (USB + WiFi in parallel)
@@ -172,10 +119,7 @@ export function useRobotDiscovery() {
 
     try {
       // Scan USB and WiFi in parallel
-      const [usbResult, wifiResult] = await Promise.all([
-        checkUsbRobot(),
-        checkWifiRobot(isRobotBlacklisted),
-      ]);
+      const [usbResult, wifiResult] = await Promise.all([checkUsbRobot(), checkWifiRobot()]);
 
       // Ensure minimum delay on first check for smooth UX
       if (isFirstCheck) {
@@ -198,7 +142,7 @@ export function useRobotDiscovery() {
     } finally {
       isScanningRef.current = false;
     }
-  }, [isFirstCheck, setIsFirstCheck, isRobotBlacklisted]);
+  }, [isFirstCheck, setIsFirstCheck]);
 
   /**
    * Start continuous scanning
@@ -256,7 +200,7 @@ export function useRobotDiscovery() {
     // State
     isScanning,
     usbRobot, // { available: boolean, portName: string | null }
-    wifiRobot, // { available: boolean, host: string | null }
+    wifiRobot, // { available: boolean, host: string | null, hostname: string | null } - host is IP, hostname is mDNS name
 
     // Helpers
     hasAnyRobot: usbRobot.available || wifiRobot.available,

--- a/src/hooks/useConnection.js
+++ b/src/hooks/useConnection.js
@@ -9,7 +9,7 @@
  *
  * // Connect to any mode - same API
  * await connect('usb', { portName: '/dev/cu.usbmodem...' });
- * await connect('wifi', { host: 'reachy-mini.home' });
+ * await connect('wifi', { host: '192.168.1.42' });  // Always use IP (from mDNS discovery)
  * await connect('simulation');
  *
  * // Disconnect - same for all modes

--- a/src/store/slices/robotSlice.js
+++ b/src/store/slices/robotSlice.js
@@ -11,6 +11,7 @@
  * All boolean states (isActive, isStarting, etc.) are DERIVED from robotStatus
  */
 import { logConnect, logDisconnect, logReset, logReady, logBusy, logCrash } from '../storeLogger';
+import { telemetry } from '../../utils/telemetry';
 
 // ============================================================================
 // SELECTORS - Derive boolean states from robotStatus
@@ -227,6 +228,12 @@ export const createRobotSlice = (set, get) => ({
         return;
       }
 
+      // 📊 Telemetry - Track successful connection (only when coming from 'starting')
+      // This ensures we only count ACTUAL successful connections, not reconnects
+      if (state.robotStatus === 'starting') {
+        telemetry.robotConnected({ mode: state.connectionMode });
+      }
+
       set({
         robotStatus: 'sleeping',
         busyReason: null,
@@ -268,6 +275,12 @@ export const createRobotSlice = (set, get) => ({
       if (state.robotStatus === 'ready') {
         console.warn('[Store] ⚠️ BLOCKED: already ready');
         return;
+      }
+
+      // 📊 Telemetry - Track successful connection (only when coming from 'starting')
+      // This ensures we only count ACTUAL successful connections, not wake-ups
+      if (state.robotStatus === 'starting') {
+        telemetry.robotConnected({ mode: state.connectionMode });
       }
 
       logReady();

--- a/src/store/storeLogger.js
+++ b/src/store/storeLogger.js
@@ -47,8 +47,8 @@ export const logConnect = (mode, options = {}) => {
   const target = mode === 'wifi' ? remoteHost : portName || 'local';
   log('🔌', 'CONNECT', `mode=${mode} target=${target}`);
 
-  // 📊 Telemetry
-  telemetry.robotConnected({ mode });
+  // 📊 Telemetry - NOTE: robot_connected is now emitted when connection is ESTABLISHED
+  // (in robotSlice.js transitionTo.sleeping/ready), not at connection ATTEMPT
 };
 
 export const logDisconnect = (prevMode, reason = '') => {

--- a/src/views/finding-robot/FindingRobotView.jsx
+++ b/src/views/finding-robot/FindingRobotView.jsx
@@ -442,7 +442,7 @@ export default function FindingRobotView() {
           <ConnectionCard
             icon={WifiOutlinedIcon}
             label="Reachy WiFi"
-            subtitle={wifiRobot.available ? wifiRobot.host : null}
+            subtitle={wifiRobot.available ? wifiRobot.hostname || wifiRobot.host : null}
             fullSubtitle={wifiRobot.available ? wifiRobot.host : null}
             available={wifiRobot.available}
             selected={selectedMode === ConnectionMode.WIFI}


### PR DESCRIPTION
## Summary

Replace frontend mDNS resolution with robust Tauri command for cross-platform robot discovery.

## Changes

### Backend (Rust)
- Add `mdns-sd` crate for pure Rust, cross-platform mDNS
- New `discover_reachy_robot` command that resolves hostname → IP
- Fallback to hotspot IPs (10.42.0.1, 192.168.4.1) when mDNS fails
- TCP probe to verify daemon is running

### Frontend (React)
- `useRobotDiscovery` now calls Tauri command instead of JS mDNS
- Always stores/uses IP address (never `.local` hostname)
- Display hostname in UI with IP tooltip for debugging

### Config
- Permissive HTTP scope (`http://*:*`) for local network access
- Add `clean:tauri` script for faster dev iteration
- Update Info.plist with Bonjour services

## Why?

mDNS resolution in WebView is unreliable across platforms:
- macOS WebKit has inconsistent `.local` resolution
- Windows requires Bonjour installed
- Linux depends on avahi configuration

By resolving in Rust and returning the IP, we bypass all WebView limitations.

## Testing

- [x] macOS: mDNS discovery works
- [ ] Windows: needs testing
- [ ] Linux: needs testing