### PR TITLE
feat: replace MuJoCo simulation with mockup-sim mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "deploy:daemon-v2": "npm run build:web && rm -rf ../reachy_mini/src/reachy_mini/daemon/app/dashboard-v2/* && cp -r dist-web/* ../reachy_mini/src/reachy_mini/daemon/app/dashboard-v2/",
     "tauri": "tauri",
     "tauri:dev": "tauri dev --no-watch",
-    "tauri:dev:sim": "VITE_SIM_MODE=true tauri dev --no-watch",
     "tauri:build": "tauri build",
     "build:sidecar-macos": "bash ./scripts/build/build-sidecar-unix.sh",
     "build:sidecar-linux": "bash ./scripts/build/build-sidecar-unix.sh",

--- a/src-tauri/src/daemon/mod.rs
+++ b/src-tauri/src/daemon/mod.rs
@@ -195,7 +195,7 @@ macro_rules! spawn_sidecar_monitor {
 /// # Arguments
 /// * `app_handle` - Tauri app handle
 /// * `state` - Daemon state
-/// * `sim_mode` - If true, launch daemon in simulation mode (MuJoCo) with --sim flag
+/// * `sim_mode` - If true, launch daemon in simulation mode (mockup-sim) with --mockup-sim flag
 pub fn spawn_and_monitor_sidecar(
     app_handle: tauri::AppHandle,
     state: &State<DaemonState>,
@@ -219,7 +219,7 @@ pub fn spawn_and_monitor_sidecar(
     // which runs in the correct working directory context
     
     if sim_mode {
-        println!("[tauri] 🎭 Launching daemon in simulation mode (MuJoCo headless)");
+        println!("[tauri] 🎭 Launching daemon in simulation mode (mockup-sim)");
     }
     
     // Convert Vec<String> to Vec<&str> for args()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -35,10 +35,9 @@ fn install_mujoco(_app_handle: tauri::AppHandle) -> Result<String, String> {
 fn start_daemon(app_handle: tauri::AppHandle, state: State<DaemonState>, sim_mode: Option<bool>) -> Result<String, String> {
     let sim_mode = sim_mode.unwrap_or(false);
     
-    // 🎭 Simulation mode: MuJoCo is pre-bundled at build-time
-    // No installation needed - all binaries are already signed (fixes Issue #16)
+    // 🎭 Simulation mode: mockup-sim backend (no MuJoCo needed)
     if sim_mode {
-        add_log(&state, "🎭 Starting simulation mode (MuJoCo pre-bundled)...".to_string());
+        add_log(&state, "🎭 Starting simulation mode (mockup-sim)...".to_string());
     }
     
     // 1. ⚡ Aggressive cleanup of all existing daemons (including zombies)
@@ -55,7 +54,7 @@ fn start_daemon(app_handle: tauri::AppHandle, state: State<DaemonState>, sim_mod
     
     // 3. Log success
     let success_msg = if sim_mode {
-        "✓ Daemon started in simulation mode (MuJoCo) via embedded sidecar"
+        "✓ Daemon started in simulation mode (mockup-sim) via embedded sidecar"
     } else {
         "✓ Daemon started via embedded sidecar"
     };

--- a/src-tauri/src/python/mod.rs
+++ b/src-tauri/src/python/mod.rs
@@ -1,75 +1,13 @@
-// Helper to fix mjpython shebang on macOS
-// mjpython's shebang points to binaries/.venv but we're in target/debug/.venv
-#[cfg(target_os = "macos")]
-pub fn fix_mjpython_shebang() -> Result<(), String> {
-    use std::fs;
-    use std::env;
-    
-    // Find the current working directory (where uv-trampoline runs)
-    let current_dir = env::current_dir().map_err(|e| format!("Failed to get current dir: {}", e))?;
-    let mjpython_path = current_dir.join(".venv/bin/mjpython");
-    
-    if !mjpython_path.exists() {
-        return Ok(()); // mjpython doesn't exist, skip
-    }
-    
-    // Read mjpython content
-    let content = fs::read_to_string(&mjpython_path)
-        .map_err(|e| format!("Failed to read mjpython: {}", e))?;
-    
-    // Get the correct Python path (absolute path)
-    let python_path = current_dir.join(".venv/bin/python3");
-    let python_path_str = python_path.to_str()
-        .ok_or("Invalid Python path")?;
-    
-    // Check if shebang needs fixing (points to binaries/.venv)
-    if content.contains("binaries/.venv/bin/python3") {
-        // Fix the shebang on line 2
-        let lines: Vec<&str> = content.lines().collect();
-        if lines.len() >= 2 {
-            let mut new_lines: Vec<String> = lines.iter().map(|s| s.to_string()).collect();
-            new_lines[1] = format!("'''exec' '{}' \"$0\" \"$@\"", python_path_str);
-            let new_content = new_lines.join("\n");
-            
-            fs::write(&mjpython_path, new_content)
-                .map_err(|e| format!("Failed to write mjpython: {}", e))?;
-            
-            println!("[tauri] ✅ Fixed mjpython shebang to point to {}", python_path_str);
-        }
-    }
-    
-    Ok(())
-}
-
-#[cfg(not(target_os = "macos"))]
-pub fn fix_mjpython_shebang() -> Result<(), String> {
-    Ok(()) // No-op on non-macOS
-}
-
 // Helper to build daemon arguments
-// On macOS with simulation mode, we need to use mjpython (required by MuJoCo)
 // IMPORTANT: Use .venv/bin/python3 directly instead of "uv run python" to ensure
 // we use the venv Python with all installed packages, not the cpython bundle
 pub fn build_daemon_args(sim_mode: bool) -> Result<Vec<String>, String> {
     // Use Python from .venv directly (not via uv run)
     // This ensures we use the venv with all installed packages
-    let python_cmd = if sim_mode && cfg!(target_os = "macos") {
-        // Fix mjpython shebang before using it
-        fix_mjpython_shebang()?;
-        ".venv/bin/mjpython"
-    } else if sim_mode {
-        // Linux/Windows: use python3 for simulation
-        #[cfg(target_os = "windows")]
-        { ".venv\\Scripts\\python.exe" }
-        #[cfg(not(target_os = "windows"))]
-        { ".venv/bin/python3" }
-    } else {
-        // Non-simulation mode: use python3
-        #[cfg(target_os = "windows")]
-        { ".venv\\Scripts\\python.exe" }
-        #[cfg(not(target_os = "windows"))]
-        { ".venv/bin/python3" }
-    };
+    #[cfg(target_os = "windows")]
+    let python_cmd = ".venv\\Scripts\\python.exe";
+    #[cfg(not(target_os = "windows"))]
+    let python_cmd = ".venv/bin/python3";
     
     let mut args = vec![
         python_cmd.to_string(),
@@ -80,7 +18,8 @@ pub fn build_daemon_args(sim_mode: bool) -> Result<Vec<String>, String> {
     ];
     
     if sim_mode {
-        args.push("--sim".to_string());
+        // Use --mockup-sim for mockup simulation (no MuJoCo required)
+        args.push("--mockup-sim".to_string());
     }
     
     Ok(args)

--- a/src/components/LogConsole/useLogProcessing.js
+++ b/src/components/LogConsole/useLogProcessing.js
@@ -29,7 +29,7 @@ export const useLogProcessing = (logs, frontendLogs, appLogs, includeStoreLogs, 
       '🧹 Cleaning up existing daemons...',
       '🧹 Cleaning up existing daemons (simulation mode)...',
       '✓ Daemon started via embedded sidecar',
-      '✓ Daemon started in simulation mode (MuJoCo) via embedded sidecar',
+      '✓ Daemon started in simulation mode (mockup-sim) via embedded sidecar',
       '✓ Daemon stopped',
     ];
     

--- a/src/config/daemon.js
+++ b/src/config/daemon.js
@@ -48,7 +48,7 @@ export const DAEMON_CONFIG = {
   // Startup timeouts (in milliseconds)
   STARTUP: {
     TIMEOUT_NORMAL: 30000,     // 30s for normal mode (robot connected)
-    TIMEOUT_SIMULATION: 180000, // 3 minutes for simulation mode (MuJoCo install can take time)
+    TIMEOUT_SIMULATION: 60000, // 1 minute for simulation mode (mockup-sim is fast)
     ACTIVITY_RESET_DELAY: 15000, // Reset timeout when we see activity (logs from sidecar)
   },
   

--- a/src/config/startupStages.js
+++ b/src/config/startupStages.js
@@ -27,35 +27,17 @@ export const STARTUP_STAGES = {
   // ============================================
   // SIMULATION MODE STAGES (50-70%)
   // ============================================
-  INSTALLING_MUJOCO: {
-    id: 'installing_mujoco',
-    label: 'Installing MuJoCo',
-    description: 'Setting up physics simulation',
-    progressMin: 50,
-    progressMax: 60,
-    isSimOnly: true,
-    // Patterns to detect this stage from sidecar logs
-    logPatterns: [
-      'Installing MuJoCo',
-      'mujoco',
-      'pip install',
-      'Downloading',
-      'Collecting',
-    ],
-  },
-  
   STARTING_SIMULATION: {
     id: 'starting_simulation',
     label: 'Starting Simulation',
-    description: 'Launching MuJoCo physics engine',
-    progressMin: 60,
+    description: 'Launching mockup-sim backend',
+    progressMin: 50,
     progressMax: 70,
     isSimOnly: true,
     logPatterns: [
-      'mjpython',
       'simulation mode',
-      'MuJoCo',
-      '--sim',
+      'mockup-sim',
+      '--mockup-sim',
     ],
   },
   
@@ -143,7 +125,6 @@ export function getStagesForMode(isSimMode) {
   
   if (isSimMode) {
     stages.push(
-      STARTUP_STAGES.INSTALLING_MUJOCO,
       STARTUP_STAGES.STARTING_SIMULATION,
     );
   }
@@ -228,17 +209,10 @@ export function getStageDisplayText(stage, options = {}) {
         boldText: options.currentPart || 'scan',
       };
       
-    case 'installing_mujoco':
-      return {
-        title: stage.label,
-        subtitle: 'Setting up physics simulation...',
-        boldText: 'MuJoCo',
-      };
-      
     case 'starting_simulation':
       return {
         title: stage.label,
-        subtitle: 'Launching physics engine...',
+        subtitle: 'Starting simulation mode...',
         boldText: 'simulation',
       };
       

--- a/src/hooks/daemon/useDaemon.js
+++ b/src/hooks/daemon/useDaemon.js
@@ -40,7 +40,7 @@ export const useDaemon = () => {
       // Daemon started successfully - no action needed here
       // useRobotState will detect when it becomes active
       if (data?.simMode) {
-        logger.info('Daemon started in simulation mode (MuJoCo)');
+        logger.info('Daemon started in simulation mode (mockup-sim)');
       }
     });
     
@@ -383,7 +383,7 @@ export const useDaemon = () => {
       await new Promise(resolve => setTimeout(resolve, DAEMON_CONFIG.ANIMATIONS.BUTTON_SPINNER_DELAY));
       // Note: isStarting already set by startConnection() in FindingRobotView
       
-      // ✅ Set explicit startup timeout - longer for simulation mode (MuJoCo install takes time)
+      // ✅ Set explicit startup timeout - longer for simulation mode
       const startupTimeout = simMode 
         ? DAEMON_CONFIG.STARTUP.TIMEOUT_SIMULATION 
         : DAEMON_CONFIG.STARTUP.TIMEOUT_NORMAL;

--- a/src/hooks/daemon/useStartupStages.js
+++ b/src/hooks/daemon/useStartupStages.js
@@ -72,7 +72,7 @@ export function useStartupStages({
     // If scan is complete and we're still in scanning stage, move to next
     if (scanComplete && currentStage.id === 'scanning') {
       const nextStage = isSimMode 
-        ? STARTUP_STAGES.INSTALLING_MUJOCO 
+        ? STARTUP_STAGES.STARTING_SIMULATION 
         : STARTUP_STAGES.CONNECTING;
       setCurrentStage(nextStage);
       setStageAttempts(0);
@@ -174,7 +174,6 @@ export function useStartupStages({
     
     // Helpers
     isScanning: currentStage.id === 'scanning',
-    isInstallingMujoco: currentStage.id === 'installing_mujoco',
     isStartingSimulation: currentStage.id === 'starting_simulation',
     isConnecting: currentStage.id === 'connecting',
     isInitializing: currentStage.id === 'initializing',

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -35,13 +35,6 @@ import App from './components/App';
 import DevPlayground from './components/DevPlayground';
 import WebApp from './components/WebApp';
 import robotModelCache from './utils/robotModelCache';
-import { disableSimulationMode } from './utils/simulationMode';
-
-// 🧹 Clean up simulation mode from localStorage on normal startup
-// Only keep simMode if VITE_SIM_MODE is explicitly set (env variable takes priority)
-if (import.meta.env?.VITE_SIM_MODE !== 'true') {
-  disableSimulationMode();
-}
 import useAppStore from './store/useAppStore';
 
 // 🚀 Preload robot 3D model (FORCE complete reload)

--- a/src/utils/simulationMode.js
+++ b/src/utils/simulationMode.js
@@ -1,65 +1,28 @@
 /**
  * 🎭 Simulation Mode Utility
  * 
- * Allows launching the application in simulation mode for development/testing without USB robot connected.
- * 
- * Usage:
- *   - In dev: SIM_MODE=true yarn tauri:dev
- *   - Via script: yarn tauri:dev:sim
- *   - Via localStorage: localStorage.setItem('simMode', 'true') then reload
+ * Simulation mode is controlled by the user in the app interface.
+ * Uses localStorage to persist the user's choice.
  */
-
-// Cache to avoid logging multiple times
-let _simModeLogged = false;
 
 /**
  * Detects if simulation mode is enabled
  * @returns {boolean} true if simulation mode is active
  */
 export function isSimulationMode() {
-  // 1. Check import.meta.env (Vite) - highest priority
-  // Vite exposes environment variables prefixed with VITE_
-  if (import.meta.env?.VITE_SIM_MODE === 'true' || import.meta.env?.VITE_SIM_MODE === true) {
-    if (!_simModeLogged) {
-      console.log('🎭 Simulation mode enabled (via VITE_SIM_MODE)');
-      _simModeLogged = true;
-    }
-    return true;
-  }
-  
-  // 2. Check localStorage (for quick development without restarting)
-  // Useful to quickly enable/disable from console
   if (typeof window !== 'undefined') {
-    const stored = localStorage.getItem('simMode');
-    if (stored === 'true') {
-      if (!_simModeLogged) {
-        console.log('🎭 Simulation mode enabled (via localStorage)');
-        _simModeLogged = true;
-      }
-      return true;
-    }
+    return localStorage.getItem('simMode') === 'true';
   }
-  
-  // 3. Check process.env (fallback for Node.js)
-  if (typeof process !== 'undefined' && process.env?.SIM_MODE === 'true') {
-    if (!_simModeLogged) {
-      console.log('🎭 Simulation mode enabled (via SIM_MODE env)');
-      _simModeLogged = true;
-    }
-    return true;
-  }
-  
   return false;
 }
 
 /**
- * Enables simulation mode (for development)
+ * Enables simulation mode
  */
 export function enableSimulationMode() {
   if (typeof window !== 'undefined') {
     localStorage.setItem('simMode', 'true');
-    _simModeLogged = false; // Reset to re-log on next check
-    console.log('🎭 Simulation mode enabled (via enableSimulationMode())');
+    console.log('🎭 Simulation mode enabled');
   }
 }
 
@@ -69,7 +32,6 @@ export function enableSimulationMode() {
 export function disableSimulationMode() {
   if (typeof window !== 'undefined') {
     localStorage.removeItem('simMode');
-    _simModeLogged = false; // Reset to re-log on next check
     console.log('🎭 Simulation mode disabled');
   }
 }
@@ -78,4 +40,3 @@ export function disableSimulationMode() {
  * Simulated USB port for simulation mode
  */
 export const SIMULATED_USB_PORT = '/dev/tty.usbserial-SIMULATED';
-

--- a/uv-wrapper/src/bin/uv-trampoline.rs
+++ b/uv-wrapper/src/bin/uv-trampoline.rs
@@ -438,157 +438,8 @@ fn main() -> ExitCode {
     // Check if the first argument is a Python executable path (e.g., .venv/bin/python3)
     // If so, execute it directly instead of passing through uv
     println!("🔍 Checking args: {:?}", args);
-    let mut cmd = if !args.is_empty() && (args[0].contains("python") || args[0].contains("mjpython")) {
+    let mut cmd = if !args.is_empty() && args[0].contains("python") {
         println!("✅ Detected Python executable: {}", args[0]);
-        
-        // Fix mjpython on macOS if needed
-        #[cfg(target_os = "macos")]
-        if args[0].contains("mjpython") {
-            println!("🔍 Detected mjpython, checking Python interpreter...");
-            
-            // Find the cpython bundled in the app (this always exists and works)
-            let cpython_python = find_cpython_folder(&working_dir)
-                .ok()
-                .map(|folder| working_dir.join(&folder).join("bin/python3"));
-            
-            let venv_python = working_dir.join(".venv/bin/python3");
-            
-            // Check if .venv/bin/python3 works
-            // It may be a broken binary, symlink, or script with wrong paths
-            println!("🔍 Testing .venv/bin/python3...");
-            let venv_python_works = if venv_python.exists() {
-                let test_result = Command::new(&venv_python)
-                    .arg("--version")
-                    .output();
-                match &test_result {
-                    Ok(output) if output.status.success() => {
-                        println!("   ✅ .venv/bin/python3 works");
-                        true
-                    }
-                    Ok(output) => {
-                        println!("   ❌ .venv/bin/python3 failed with status: {:?}", output.status);
-                        false
-                    }
-                    Err(e) => {
-                        println!("   ❌ .venv/bin/python3 cannot be executed: {}", e);
-                        false
-                    }
-                }
-            } else {
-                println!("   ❌ .venv/bin/python3 does not exist");
-                false
-            };
-            
-            // If .venv/bin/python3 doesn't work, replace it with a symlink to cpython
-            // This preserves the venv configuration (pyvenv.cfg) while using the working cpython
-            if !venv_python_works {
-                if let Some(ref cpython) = cpython_python {
-                    if cpython.exists() {
-                        println!("🔧 Fixing .venv/bin/python3 by creating symlink to cpython...");
-                        
-                        // Remove the broken file if it exists
-                        if venv_python.exists() || venv_python.is_symlink() {
-                            if let Err(e) = fs::remove_file(&venv_python) {
-                                eprintln!("   ⚠️  Failed to remove broken python3: {}", e);
-                            }
-                        }
-                        
-                        // Create symlink to cpython
-                        #[cfg(unix)]
-                        {
-                            use std::os::unix::fs::symlink;
-                            if let Err(e) = symlink(cpython, &venv_python) {
-                                eprintln!("   ⚠️  Failed to create python3 symlink: {}", e);
-                            } else {
-                                println!("   ✅ Created .venv/bin/python3 -> {:?}", cpython);
-                            }
-                        }
-                    }
-                }
-            }
-            
-            // Always use .venv/bin/python3 in the shebang because:
-            // - It's now either working or fixed to point to cpython
-            // - The pyvenv.cfg in .venv/ tells Python to use the venv's site-packages
-            let python_path = venv_python.clone();
-            let python_path_str = python_path.to_string_lossy();
-            
-            // Now fix mjpython script
-            let mjpython_path = working_dir.join(&args[0]);
-            println!("🔍 mjpython path: {:?}", mjpython_path);
-            if mjpython_path.exists() {
-                println!("✅ mjpython exists, reading content...");
-                if let Ok(content) = fs::read_to_string(&mjpython_path) {
-                    let lines: Vec<&str> = content.lines().collect();
-                    let first_line = lines.first().unwrap_or(&"");
-                    let second_line = lines.get(1).unwrap_or(&"");
-                    println!("🔍 First line: {}", first_line);
-                    println!("🔍 Second line: {}", second_line);
-                    
-                    // Check if shebang needs fixing:
-                    // - Contains path to binaries/.venv or binaries/cpython (CI build paths)
-                    // - Or contains /Users/runner/ (CI runner path)
-                    let needs_fix = content.contains("binaries/.venv") 
-                        || content.contains("binaries/cpython")
-                        || content.contains("/Users/runner/");
-                    
-                    if needs_fix {
-                        println!("🔧 Fixing mjpython script to use {}...", python_path_str);
-                        
-                        let mut new_lines: Vec<String> = lines.iter().map(|s| s.to_string()).collect();
-                        
-                        // Detect script format:
-                        // - Polyglot: first line is #!/bin/sh, second line contains exec
-                        // - Direct Python: first line is #!/path/to/python
-                        let is_polyglot = first_line.contains("/bin/sh") && second_line.contains("exec");
-                        
-                        if is_polyglot && new_lines.len() >= 2 {
-                            // Polyglot format: fix the exec line (line 2)
-                            // Format: '''exec' '/path/to/python' "$0" "$@"
-                            println!("🔧 Detected polyglot format, fixing exec line...");
-                            new_lines[1] = format!("'''exec' '{}' \"$0\" \"$@\"", python_path_str);
-                        } else if !new_lines.is_empty() {
-                            // Direct Python shebang: fix the first line
-                            println!("🔧 Detected direct Python shebang, fixing first line...");
-                            new_lines[0] = format!("#!{}", python_path_str);
-                        }
-                        
-                        let new_content = new_lines.join("\n");
-                        
-                        if let Err(e) = fs::write(&mjpython_path, new_content) {
-                            eprintln!("⚠️  Failed to fix mjpython: {}", e);
-                        } else {
-                            println!("✅ Fixed mjpython to use {}", python_path_str);
-                        }
-                    } else {
-                        println!("ℹ️  mjpython doesn't need fixing");
-                    }
-                } else {
-                    println!("⚠️  Failed to read mjpython");
-                }
-            } else {
-                println!("⚠️  mjpython doesn't exist at path");
-            }
-            
-            // 2. Create symlink for libpython3.12.dylib at .venv/ level
-            // mjpython looks for it at .venv/libpython3.12.dylib but it's in .venv/lib/
-            let venv_dir = working_dir.join(".venv");
-            let libpython_symlink = venv_dir.join("libpython3.12.dylib");
-            let libpython_target = venv_dir.join("lib/libpython3.12.dylib");
-            
-            if libpython_target.exists() && !libpython_symlink.exists() {
-                println!("🔧 Creating libpython3.12.dylib symlink for mjpython...");
-                #[cfg(unix)]
-                {
-                    use std::os::unix::fs::symlink;
-                    if let Err(e) = symlink("lib/libpython3.12.dylib", &libpython_symlink) {
-                        eprintln!("⚠️  Failed to create libpython symlink: {}", e);
-                    } else {
-                        println!("✅ Created libpython3.12.dylib symlink");
-                    }
-                }
-            }
-        }
         
         // Convert Unix-style path to Windows-style if needed
         #[cfg(target_os = "windows")]
@@ -612,10 +463,6 @@ fn main() -> ExitCode {
         #[cfg(not(target_os = "windows"))]
         let python_arg = args[0].clone();
         
-        // Check if this is mjpython - we need special handling on macOS
-        // because shebangs don't work with paths containing spaces
-        let is_mjpython = python_arg.contains("mjpython");
-        
         // First argument is a Python executable - execute it directly
         let python_path = if python_arg.starts_with("/") || python_arg.starts_with(".") || 
                           (cfg!(target_os = "windows") && (python_arg.starts_with(".") || python_arg.chars().nth(1) == Some(':'))) {
@@ -633,47 +480,12 @@ fn main() -> ExitCode {
             PathBuf::from(&python_arg)
         };
         
-        // On macOS, binaries are signed at build time via sign-all-binaries.sh
-        // Entitlements handle library validation, no runtime verification needed
-        
-        // On macOS with mjpython, we can't execute it directly because:
-        // 1. Its shebang contains a path with spaces (e.g., "/Applications/Reachy Mini Control.app/...")
-        // 2. Unix shebangs don't support paths with spaces
-        // Solution: Execute python3 directly with mjpython as a script argument
-        #[cfg(target_os = "macos")]
-        let cmd = if is_mjpython {
-            let venv_python = working_dir.join(".venv/bin/python3");
-            println!("🐍 Executing mjpython via python3 (shebang workaround for paths with spaces)");
-            println!("   Python: {:?}", venv_python);
-            println!("   Script: {:?}", python_path);
-            println!("   Args: {:?}", &args[1..]);
-            
-            let mut c = Command::new(&venv_python);
-            c.env("UV_WORKING_DIR", &working_dir)
-             .env("UV_PYTHON_INSTALL_DIR", &working_dir)
-             .arg(&python_path)  // mjpython script as first arg
-             .args(&args[1..]);  // remaining arguments
-            c
-        } else {
-            println!("🐍 Direct Python execution: {:?} with args: {:?}", python_path, &args[1..]);
-            let mut c = Command::new(&python_path);
-            c.env("UV_WORKING_DIR", &working_dir)
-             .env("UV_PYTHON_INSTALL_DIR", &working_dir)
-             .args(&args[1..]); // Pass remaining arguments
-            c
-        };
-        
-        #[cfg(not(target_os = "macos"))]
-        let mut cmd = {
-            println!("🐍 Direct Python execution: {:?} with args: {:?}", python_path, &args[1..]);
-            let mut c = Command::new(&python_path);
-            c.env("UV_WORKING_DIR", &working_dir)
-             .env("UV_PYTHON_INSTALL_DIR", &working_dir)
-             .args(&args[1..]); // Pass remaining arguments
-            c
-        };
-        
-        cmd
+        println!("🐍 Direct Python execution: {:?} with args: {:?}", python_path, &args[1..]);
+        let mut c = Command::new(&python_path);
+        c.env("UV_WORKING_DIR", &working_dir)
+         .env("UV_PYTHON_INSTALL_DIR", &working_dir)
+         .args(&args[1..]); // Pass remaining arguments
+        c
     } else {
         println!("ℹ️  Using normal uv command execution");
         // Normal uv command execution


### PR DESCRIPTION
## Summary

Replaces the heavy MuJoCo-based simulation with a lightweight `--mockup-sim` mode that requires no external dependencies.

## Related PR

- **Daemon**: [pollen-robotics/reachy_mini#652](https://github.com/pollen-robotics/reachy_mini/pull/652)

## Changes

### Removed
- All `mjpython` detection, fixing, and symlinking logic from `uv-trampoline.rs`
- macOS binary re-signing for Python (not needed for mockup-sim)
- `INSTALLING_MUJOCO` startup stage
- `tauri:dev:sim` script from package.json
- `VITE_SIM_MODE` environment variable handling

### Updated
- Daemon args: `--sim` → `--mockup-sim`
- Startup stages simplified (no MuJoCo installation step)
- Log patterns updated to match "mockup-sim" messages
- Simulation timeout reduced from 3 minutes to 1 minute
- Comments and messages updated throughout

## Benefits

- **Faster startup**: No MuJoCo installation step
- **Smaller footprint**: No MuJoCo dependency (~hundreds of MB saved)
- **Simpler codebase**: ~320 lines of code removed
- **Same functionality**: Full kinematics, 3D viewer, API/SDK work identically

## Testing

1. Build sidecar with daemon branch:
   ```bash
   REACHY_MINI_SOURCE=feature/sim-lite-backend yarn build:sidecar-macos
   ```
2. Run app in simulation mode
3. Verify 3D viewer, API endpoints, and apps work correctly