### PR TITLE
chore: cleanup console logs

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -113,9 +113,9 @@ function App() {
   // 🔍 DEBUG: Force update check in dev mode for testing
   useEffect(() => {
     if (isDev) {
-      console.log('🔍 DEV MODE: Update check disabled by default');
-      console.log('   To test update check, call checkForUpdates() manually in DevTools console');
-      console.log('   Or temporarily set autoCheck: true in useUpdater hook');
+      
+      
+      
     }
   }, [isDev, checkForUpdates]);
   
@@ -157,29 +157,17 @@ function App() {
 
   // Determine current view for automatic resize
   const currentView = useMemo(() => {
-    // 🔍 DEBUG: Log state when computing currentView
-    console.log('[App] 🎯 Computing currentView', {
-      isActive,
-      hardwareError: !!hardwareError,
-      isStopping,
-    });
-    
     // Compact view: ClosingView (stopping)
     if (isStopping) {
-      console.log('[App] → currentView = compact (isStopping)');
       return 'compact';
     }
     
-    // ⚡ Expanded view: daemon active
-    // isActive becomes true when transitionTo.ready() is called
-    // (after scan complete + daemon health check passes)
+    // Expanded view: daemon active
     if (isActive && !hardwareError) {
-      console.log('[App] → currentView = expanded (isActive && !hardwareError)');
       return 'expanded';
     }
     
     // Compact view: all others (FindingRobot, Starting, ReadyToStart)
-    console.log('[App] → currentView = compact (default)');
     return 'compact';
   }, [isActive, hardwareError, isStopping]);
 

--- a/src/components/DevPlayground.jsx
+++ b/src/components/DevPlayground.jsx
@@ -51,7 +51,7 @@ export default function DevPlayground() {
   }, []);
   
   const handleActionClick = useCallback((action) => {
-    console.log('Action clicked:', action);
+    
   }, []);
 
   // Get error configuration

--- a/src/components/viewer3d/SettingsOverlay.jsx
+++ b/src/components/viewer3d/SettingsOverlay.jsx
@@ -160,12 +160,12 @@ export default function SettingsOverlay({
   // Connect to update job WebSocket (WiFi mode)
   const connectUpdateWebSocket = useCallback((jobId) => {
     const wsUrl = `${getWsBaseUrl()}/update/ws/logs?job_id=${jobId}`;
-    console.log('[UpdateWS] Connecting to:', wsUrl);
+    
     
     const ws = new WebSocket(wsUrl);
     
     ws.onopen = () => {
-      console.log('[UpdateWS] Connected');
+      
     };
     
     ws.onmessage = (event) => {
@@ -174,7 +174,7 @@ export default function SettingsOverlay({
         const data = JSON.parse(event.data);
         
         if (data.status) {
-          console.log('[UpdateWS] Status update:', data.status);
+          
           setUpdateJobStatus(data.status);
           
           // Add new logs if present
@@ -184,20 +184,20 @@ export default function SettingsOverlay({
           
           // Job is done
           if (data.status === 'done' || data.status === 'failed') {
-            console.log('[UpdateWS] Job finished:', data.status);
+            
             ws.close();
             
               if (data.status === 'done') {
               // ✅ Update successful - daemon will restart
               // Keep overlay visible and show "restarting" status
-              console.log('[UpdateWS] Update successful, daemon will restart...');
+              
               setUpdateJobStatus('restarting');
                 logSuccess('Update completed successfully!');
               
               // Wait for daemon restart (takes ~5-10 seconds typically)
               // Then reset to force reconnection
               setTimeout(() => {
-                console.log('[UpdateWS] Resetting app to reconnect...');
+                
                 setIsUpdating(false);
                 showToast('Update completed! Please reconnect to the robot.', 'success');
                 useAppStore.getState().resetAll();
@@ -215,7 +215,7 @@ export default function SettingsOverlay({
         // Not JSON, probably a log line
         const logLine = event.data.trim();
         if (logLine) {
-          console.log('[UpdateWS] Log:', logLine);
+          
           setUpdateLogs(prev => [...prev, logLine]);
         }
       }
@@ -226,7 +226,7 @@ export default function SettingsOverlay({
     };
     
     ws.onclose = (event) => {
-      console.log('[UpdateWS] Closed:', event.code, event.reason);
+      
       updatePollingRef.current = null;
     };
     
@@ -265,12 +265,12 @@ export default function SettingsOverlay({
       // 🛡️ Put robot to sleep before update if not already sleeping
       // This ensures motors are disabled and robot is in safe position
       if (!isSleeping) {
-        console.log('🔄 Putting robot to sleep before update...');
+        
         const sleepSuccess = await goToSleep();
         if (!sleepSuccess) {
           console.warn('⚠️ Failed to put robot to sleep, continuing with update anyway');
         } else {
-          console.log('✅ Robot is now sleeping, proceeding with update');
+          
         }
       }
       
@@ -285,7 +285,7 @@ export default function SettingsOverlay({
       
       if (response.ok) {
         const data = await response.json();
-        console.log('Update started:', data.job_id);
+        
         
           // Start tracking the update job
           setUpdateJobId(data.job_id);
@@ -319,7 +319,7 @@ export default function SettingsOverlay({
         onClose();
         
         // Disconnect and return to selection view
-        console.log('Daemon update completed, disconnecting...');
+        
         useAppStore.getState().resetAll();
       }
     } catch (err) {
@@ -348,7 +348,7 @@ export default function SettingsOverlay({
 
   const fetchWifiStatus = useCallback(async () => {
     if (!isWifiMode) return;
-    console.log('[WiFi] Fetching WiFi status...');
+    
     setIsLoadingWifi(true);
     setWifiError(null);
     
@@ -374,7 +374,7 @@ export default function SettingsOverlay({
       
       if (networksResponse.ok) {
         const networks = await networksResponse.json();
-        console.log('[WiFi] Scanned networks:', networks);
+        
         setAvailableNetworks(Array.isArray(networks) ? networks : []);
       } else {
         console.warn('[WiFi] Scan failed:', networksResponse.status);
@@ -402,7 +402,7 @@ export default function SettingsOverlay({
       if (response.ok) {
         // Blacklist current robot for 10 seconds to prevent immediate rediscovery
         if (remoteHost) {
-          console.log(`🚫 Blacklisting ${remoteHost} for 10 seconds after clearing networks`);
+          
           blacklistRobot(remoteHost, 10000);
         }
         

--- a/src/components/viewer3d/URDFRobot.jsx
+++ b/src/components/viewer3d/URDFRobot.jsx
@@ -175,7 +175,7 @@ function URDFRobot({
         
         if (hasValidInitialJoints) {
           // ✅ Use ACTUAL robot position from daemon
-          console.log('🎯 Applying initial robot position from store:', initialJoints.map(v => v.toFixed(3)).join(', '));
+          
           
           // Apply yaw_body from first joint value
           if (robotModel.joints['yaw_body']) {
@@ -201,7 +201,7 @@ function URDFRobot({
           }
         } else {
           // ✅ Fallback: Initialize all joints to zero
-          console.log('⚠️ No initial robot position in store, using zeros');
+          
           
         // Initialize yaw_body to 0
         if (robotModel.joints['yaw_body']) {

--- a/src/components/viewer3d/hooks/useRobotWebSocket.js
+++ b/src/components/viewer3d/hooks/useRobotWebSocket.js
@@ -38,7 +38,7 @@ export function useRobotWebSocket(isActive) {
   useEffect(() => {
     wasmReadyRef.current = wasmReady;
     if (wasmReady) {
-      console.log('🦀 WASM Kinematics ready for passive joints calculation');
+      
     }
   }, [wasmReady]);
 
@@ -80,7 +80,7 @@ export function useRobotWebSocket(isActive) {
           // WebSocket connected - reset attempts counter on success
           reconnectAttemptsRef.current = 0;
           if (isWiFiRef.current) {
-            console.log('🌐 WiFi WebSocket: Connected successfully!');
+            
           }
         };
 

--- a/src/hooks/daemon/useDaemonEventBus.js
+++ b/src/hooks/daemon/useDaemonEventBus.js
@@ -44,7 +44,7 @@ class DaemonEventBus {
     // Log to console in dev mode (but skip frequent events to avoid spam)
     const silentEvents = ['daemon:health:success', 'robot:state:updated'];
     if (process.env.NODE_ENV === 'development' && !silentEvents.includes(event)) {
-      console.log(`[DaemonEventBus] ${event}`, data);
+      
     }
     
     // Notify all listeners

--- a/src/hooks/daemon/useStartupStages.js
+++ b/src/hooks/daemon/useStartupStages.js
@@ -101,7 +101,7 @@ export function useStartupStages({
             const currentIndex = stages.findIndex(s => s.id === currentStage.id);
             
             if (detectedIndex > currentIndex) {
-              console.log(`🚀 Stage detected from log: ${detected.label}`);
+              
               setCurrentStage(detected);
               setStageAttempts(0);
               setDetectedFromLog(true);

--- a/src/hooks/media/useAudioAnalyser.js
+++ b/src/hooks/media/useAudioAnalyser.js
@@ -116,7 +116,7 @@ export default function useAudioAnalyser(audioTrack, options = {}) {
       dataArrayRef.current = dataArray;
 
       setIsActive(true);
-      console.log('[useAudioAnalyser] Audio analysis started, buffer length:', bufferLength);
+      
 
       // Animation loop for reading audio levels
       const analyze = (currentTime) => {

--- a/src/hooks/media/useWebRTCStream.js
+++ b/src/hooks/media/useWebRTCStream.js
@@ -98,11 +98,11 @@ export default function useWebRTCStream(robotHost, autoConnect = false) {
     setError(null);
 
     const signalingUrl = `ws://${robotHost}:${SIGNALING_PORT}`;
-    console.log(`[WebRTC] Connecting to signaling server: ${signalingUrl}`);
+    
 
     try {
       const GstWebRTCAPI = window.GstWebRTCAPI;
-      console.log('[WebRTC] GstWebRTCAPI available:', !!GstWebRTCAPI);
+      
       if (!GstWebRTCAPI) {
         throw new Error('GstWebRTCAPI not loaded');
       }
@@ -127,17 +127,17 @@ export default function useWebRTCStream(robotHost, autoConnect = false) {
       connectionListenerRef.current = {
         connected: (clientId) => {
           if (!mountedRef.current) return;
-          console.log('[WebRTC] Connected to signaling server, client ID:', clientId);
+          
         },
         disconnected: () => {
           if (!mountedRef.current) return;
-          console.log('[WebRTC] Disconnected from signaling server');
+          
           setState(StreamState.DISCONNECTED);
           setStream(null);
           
           // Schedule reconnect
           if (mountedRef.current && !reconnectTimeoutRef.current) {
-            console.log(`[WebRTC] Scheduling reconnect in ${RECONNECT_DELAY}ms`);
+            
             reconnectTimeoutRef.current = setTimeout(() => {
               reconnectTimeoutRef.current = null;
               if (mountedRef.current) {
@@ -154,15 +154,15 @@ export default function useWebRTCStream(robotHost, autoConnect = false) {
       producersListenerRef.current = {
         producerAdded: (producer) => {
           if (!mountedRef.current) return;
-          console.log('[WebRTC] Producer found:', producer.id, producer.meta);
+          
           
           // If we already have a session, don't create another one
           if (sessionRef.current) {
-            console.log('[WebRTC] Already have a session, ignoring producer');
+            
             return;
           }
           
-          console.log('[WebRTC] Creating consumer session for producer:', producer.id);
+          
           
           const session = api.createConsumerSession(producer.id);
           if (!session) {
@@ -181,7 +181,7 @@ export default function useWebRTCStream(robotHost, autoConnect = false) {
           
           session.addEventListener('closed', () => {
             if (!mountedRef.current) return;
-            console.log('[WebRTC] Session closed');
+            
             sessionRef.current = null;
             setStream(null);
             
@@ -192,7 +192,7 @@ export default function useWebRTCStream(robotHost, autoConnect = false) {
           session.addEventListener('streamsChanged', () => {
             if (!mountedRef.current) return;
             const streams = session.streams;
-            console.log('[WebRTC] Streams changed:', streams?.length || 0);
+            
             
             if (streams && streams.length > 0) {
               setStream(streams[0]);
@@ -206,7 +206,7 @@ export default function useWebRTCStream(robotHost, autoConnect = false) {
         
         producerRemoved: (producer) => {
           if (!mountedRef.current) return;
-          console.log('[WebRTC] Producer removed:', producer.id);
+          
           
           // If our session was with this producer, close it
           if (sessionRef.current) {
@@ -231,7 +231,7 @@ export default function useWebRTCStream(robotHost, autoConnect = false) {
    * Disconnect from the stream
    */
   const disconnect = useCallback(() => {
-    console.log('[WebRTC] Disconnecting...');
+    
     cleanup();
     setState(StreamState.DISCONNECTED);
   }, [cleanup]);

--- a/src/hooks/system/useRobotDiscovery.js
+++ b/src/hooks/system/useRobotDiscovery.js
@@ -76,7 +76,7 @@ async function checkWifiRobot(isRobotBlacklisted) {
   const onHotspot = await isOnReachyHotspot();
   if (onHotspot) {
     if (lastLoggedWifiHost !== 'hotspot-blocked') {
-      console.log('🌐 Connected to Reachy hotspot - WiFi mode disabled (use setup flow)');
+      
       lastLoggedWifiHost = 'hotspot-blocked';
     }
     return { available: false, host: null, onHotspot: true };
@@ -92,7 +92,7 @@ async function checkWifiRobot(isRobotBlacklisted) {
   if (available) {
     // Only log when host changes (found new robot or different host)
     if (lastLoggedWifiHost !== available.host) {
-      console.log(`🌐 WiFi robot found at ${available.host}`);
+      
       lastLoggedWifiHost = available.host;
     }
     return { available: true, host: available.host };
@@ -101,13 +101,13 @@ async function checkWifiRobot(isRobotBlacklisted) {
   // Check if all available hosts are blacklisted
   const hasBlacklistedRobots = results.some(r => r.available && isRobotBlacklisted(r.host));
   if (hasBlacklistedRobots && lastLoggedWifiHost !== 'blacklisted') {
-    console.log('🚫 WiFi robot(s) found but temporarily blacklisted');
+    
     lastLoggedWifiHost = 'blacklisted';
   }
   
   // Log when robot is lost (was found before, now gone)
   if (lastLoggedWifiHost && lastLoggedWifiHost !== 'hotspot-blocked' && lastLoggedWifiHost !== 'blacklisted' && !hasBlacklistedRobots) {
-    console.log('🌐 WiFi robot disconnected');
+    
     lastLoggedWifiHost = null;
   }
   

--- a/src/hooks/system/useUpdater.js
+++ b/src/hooks/system/useUpdater.js
@@ -66,7 +66,7 @@ export const useUpdater = ({
 
     // ✅ Try to fetch latest.json directly - if it works, we have internet + we know if there's an update
     // No need for separate healthcheck - the update check itself tells us about connectivity
-    console.log('🔍 Starting update check...', { retryCount, maxRetries });
+    
     logInfo(`🔍 Starting update check... (attempt ${retryCount + 1}/${maxRetries})`);
     isCheckingRef.current = true;
     setIsChecking(true);
@@ -102,7 +102,7 @@ export const useUpdater = ({
         currentVersion: update?.currentVersion || 'unknown',
         updateAvailable: update ? 'YES' : 'NO',
       };
-      console.log('🔍 Update check result:', checkResult);
+      
       logInfo(`🔍 Update check result: ${JSON.stringify(checkResult)}`);
       
       // Reset retry count on success
@@ -112,12 +112,12 @@ export const useUpdater = ({
       setIsChecking(false); // ✅ Ensure isChecking is always set to false on success
       
       if (update) {
-        console.log('✅ Update available:', update.version);
+        
         logSuccess(`✅ Update available: ${update.version} (${update.date || 'no date'})`);
         setUpdateAvailable(update);
         return update;
       } else {
-        console.log('ℹ️ No update available (current version is up to date or newer)');
+        
         logInfo('ℹ️ No update available (current version is up to date or newer)');
         setUpdateAvailable(null);
         return null;
@@ -145,7 +145,7 @@ export const useUpdater = ({
       
       // In dev mode, immediately stop checking if update server is missing (no retries needed)
       if (isDev && isMissingUpdateServer) {
-        console.log('ℹ️ Update server not available (dev mode - this is normal)');
+        
         logInfo('ℹ️ Update server not available (dev mode - this is normal)');
         isCheckingRef.current = false;
         setIsChecking(false);
@@ -183,10 +183,10 @@ export const useUpdater = ({
         retryCountRef.current = retryCount + 1;
         
         if (isTimeout) {
-          console.log(`⏱️ Update check timeout, retrying in ${delay}ms... (${retryCount + 1}/${maxRetries})`);
+          
           logWarning(`⏱️ Update check timeout, retrying in ${delay}ms... (${retryCount + 1}/${maxRetries})`);
         } else {
-          console.log(`🔄 Retrying in ${delay}ms... (${retryCount + 1}/${maxRetries})`);
+          
           logWarning(`🔄 Retrying in ${delay}ms... (${retryCount + 1}/${maxRetries})`);
         }
         
@@ -425,7 +425,7 @@ export const useUpdater = ({
   // Listen for online/offline events to retry when connection is restored
   useEffect(() => {
     const handleOnline = () => {
-      console.log('✅ Internet connection restored');
+      
       // Clear error if we were offline
       setError((prevError) => {
         if (prevError && prevError.includes('No internet connection')) {

--- a/src/hooks/system/useWindowResize.js
+++ b/src/hooks/system/useWindowResize.js
@@ -16,14 +16,12 @@ import { moveWindow, Position } from '@tauri-apps/plugin-positioner';
 async function resizeWindowInstantly(targetWidth, targetHeight) {
   // Mock pour le navigateur
   if (!window.__TAURI__) {
-    console.log('[resizeWindowInstantly] ⚠️ Not in Tauri, skipping');
+    
     return;
   }
 
   try {
     const appWindow = getAppWindow();
-    console.log('[resizeWindowInstantly] 🎯 Got appWindow:', appWindow?.label);
-    
     // Obtenir la taille actuelle ET le scale factor pour comparer correctement
     const currentSize = await appWindow.innerSize();
     const scaleFactor = await appWindow.scaleFactor();
@@ -32,31 +30,22 @@ async function resizeWindowInstantly(targetWidth, targetHeight) {
     const currentLogicalWidth = Math.round(currentSize.width / scaleFactor);
     const currentLogicalHeight = Math.round(currentSize.height / scaleFactor);
 
-    console.log('[resizeWindowInstantly] 📐 Current size:', {
-      physical: { width: currentSize.width, height: currentSize.height },
-      logical: { width: currentLogicalWidth, height: currentLogicalHeight },
-      scaleFactor,
-      target: { width: targetWidth, height: targetHeight },
-    });
-
     // If already at correct size (with 2px tolerance for rounding), do nothing
     const widthMatch = Math.abs(currentLogicalWidth - targetWidth) <= 2;
     const heightMatch = Math.abs(currentLogicalHeight - targetHeight) <= 2;
     
     if (widthMatch && heightMatch) {
-      console.log('[resizeWindowInstantly] ✅ Already at target size, skipping');
       return;
     }
 
     // Apply resize - setSize avec LogicalSize gère automatiquement le scale factor
-    console.log('[resizeWindowInstantly] 🔄 Calling setSize...');
     await appWindow.setSize(new LogicalSize(targetWidth, targetHeight));
-    console.log('[resizeWindowInstantly] ✅ setSize completed');
+    
     
     // Center window on screen
-    console.log('[resizeWindowInstantly] 🔄 Calling moveWindow(Center)...');
+    
     await moveWindow(Position.Center);
-    console.log('[resizeWindowInstantly] ✅ moveWindow completed');
+    
   } catch (error) {
     console.error('❌ Window resize error:', error);
   }
@@ -102,12 +91,6 @@ export function useWindowResize(view) {
     if (previousView.current === view) {
       return;
     }
-
-    // 🔍 DEBUG: Log view change
-    console.log(`[WindowResize] 🎯 View changed: ${previousView.current} → ${view}`, {
-      targetWidth: targetSize.width,
-      targetHeight: targetSize.height,
-    });
 
     previousView.current = view;
 

--- a/src/store/slices/robotSlice.js
+++ b/src/store/slices/robotSlice.js
@@ -150,7 +150,7 @@ export const createRobotSlice = (set, get) => ({
   
   transitionTo: {
     disconnected: () => {
-      console.log('[Store] 🔴 transitionTo.disconnected() called');
+      
       set({
         robotStatus: 'disconnected',
         busyReason: null,
@@ -168,7 +168,7 @@ export const createRobotSlice = (set, get) => ({
     },
     
     readyToStart: () => {
-      console.log('[Store] 🟡 transitionTo.readyToStart() called');
+      
       set({
         robotStatus: 'ready-to-start',
         busyReason: null,
@@ -183,7 +183,7 @@ export const createRobotSlice = (set, get) => ({
     },
     
     starting: () => {
-      console.log('[Store] 🟠 transitionTo.starting() called');
+      
       set({
         robotStatus: 'starting',
         busyReason: null,
@@ -201,7 +201,7 @@ export const createRobotSlice = (set, get) => ({
       const state = get();
       const { safeToShutdown = false } = options;
       
-      console.log('[Store] 😴 transitionTo.sleeping() called', { safeToShutdown });
+      
       
       // 🛡️ Guard: Don't transition if stopping (prevents chaos during shutdown)
       if (state.robotStatus === 'stopping') {
@@ -234,14 +234,6 @@ export const createRobotSlice = (set, get) => ({
     ready: () => {
       const state = get();
       
-      // 🔍 DEBUG: Log state when transitionTo.ready() is called
-      console.log('[Store] 🎯 transitionTo.ready() called', {
-        hardwareError: state.hardwareError,
-        robotStatus: state.robotStatus,
-        connectionMode: state.connectionMode,
-        isActive: state.isActive,
-      });
-      
       // Don't transition to ready if there's a hardware error
       if (state.hardwareError) {
         console.warn('[Store] ⚠️ BLOCKED: hardware error present');
@@ -266,7 +258,7 @@ export const createRobotSlice = (set, get) => ({
         return;
       }
       
-      console.log('[Store] ✅ Transitioning to ready - window should resize now');
+      
       logReady();
       set({
         robotStatus: 'ready',
@@ -285,7 +277,7 @@ export const createRobotSlice = (set, get) => ({
     },
     
     busy: (reason) => {
-      console.log('[Store] 🟣 transitionTo.busy() called', { reason });
+      
       const state = get();
       
       // 🛡️ Guard: Don't transition if stopping (prevents chaos during shutdown)
@@ -323,7 +315,7 @@ export const createRobotSlice = (set, get) => ({
     },
     
     stopping: () => {
-      console.log('[Store] 🔵 transitionTo.stopping() called');
+      
       set({
         robotStatus: 'stopping',
         busyReason: null,
@@ -340,7 +332,7 @@ export const createRobotSlice = (set, get) => ({
     },
     
     crashed: () => {
-      console.log('[Store] 💀 transitionTo.crashed() called');
+      
       logCrash();
       set({
         robotStatus: 'crashed',
@@ -579,7 +571,7 @@ export const createRobotSlice = (set, get) => ({
         [host]: expiryTime,
       },
     }));
-    console.log(`🚫 Blacklisted ${host} until ${new Date(expiryTime).toLocaleTimeString()}`);
+    
   },
   
   /**

--- a/src/store/storeLogger.js
+++ b/src/store/storeLogger.js
@@ -32,7 +32,7 @@ const formatMode = (mode, host) => {
  */
 const log = (emoji, action, details = '') => {
   const detailStr = details ? ` → ${details}` : '';
-  console.log(`[Store] ${emoji} ${action}${detailStr}`);
+  
 };
 
 /**

--- a/src/utils/InputManager.js
+++ b/src/utils/InputManager.js
@@ -125,7 +125,7 @@ export class InputManager {
 
       if (timeSinceLastActiveInput > this.deviceSwitchThreshold) {
         if (this.debugEnabled) {
-          console.log(`🎮 Device switched: ${this.activeDevice} → ${deviceType}`);
+          
         }
         this.activeDevice = deviceType;
 
@@ -402,14 +402,14 @@ export class InputManager {
   // Gamepad handling
   handleGamepadConnected = (event) => {
     if (this.debugEnabled) {
-      console.log('🎮 Gamepad connected:', event.gamepad.id);
+      
     }
     this.gamepadConnected = true;
   };
 
   handleGamepadDisconnected = (event) => {
     if (this.debugEnabled) {
-      console.log('🎮 Gamepad disconnected');
+      
     }
     this.gamepadConnected = false;
 
@@ -577,7 +577,7 @@ export class InputManager {
         const isPressed = gamepad.buttons[index]?.pressed || false;
         const lastState = this.lastButtonStates[`dpad_${index}`];
         if (isPressed !== lastState) {
-          console.log(`🎮 ${name}: ${isPressed ? 'PRESSED' : 'RELEASED'}`);
+          
           this.lastButtonStates[`dpad_${index}`] = isPressed;
         }
       });
@@ -590,12 +590,7 @@ export class InputManager {
       
       bumpers.forEach(({ index, name }) => {
         const value = gamepad.buttons[index]?.value || 0;
-        const lastValue = this.lastInputValues[`bumper_${index}`] || 0;
-        const threshold = 0.1; // Only log if value changes significantly
-        if (Math.abs(value - lastValue) > threshold) {
-          console.log(`🎮 ${name}: ${(value * 100).toFixed(0)}%`);
           this.lastInputValues[`bumper_${index}`] = value;
-        }
       });
       
       // Check action buttons (only when pressed)
@@ -610,7 +605,7 @@ export class InputManager {
         const isPressed = gamepad.buttons[index]?.pressed || false;
         const lastState = this.lastButtonStates[`action_${index}`];
         if (isPressed && !lastState) {
-          console.log(`🎮 ${name}: PRESSED`);
+          
           this.lastButtonStates[`action_${index}`] = isPressed;
         } else if (!isPressed && lastState) {
           this.lastButtonStates[`action_${index}`] = isPressed;
@@ -633,9 +628,9 @@ export class InputManager {
         if ((magnitude > this.config.deadzone && lastMagnitude <= this.config.deadzone) ||
             (magnitude <= this.config.deadzone && lastMagnitude > this.config.deadzone)) {
           if (magnitude > this.config.deadzone) {
-            console.log(`🎮 ${name}: Active (${x.toFixed(2)}, ${y.toFixed(2)})`);
+            
           } else {
-            console.log(`🎮 ${name}: Centered`);
+            
           }
           this.lastInputValues[`stick_${name}`] = magnitude;
         }
@@ -744,7 +739,7 @@ export class InputManager {
       this.lastButtonStates = {};
       this.lastInputValues = {};
     } else {
-      console.log('🎮 Debug mode enabled - will show button presses and significant input changes');
+      
     }
   }
 
@@ -763,7 +758,7 @@ export class InputManager {
 
   // Method to simulate next position action
   triggerNextPositionAction() {
-    console.log("InputManager: Simulating nextPosition action");
+    
 
     // Reset all inputs first to avoid conflicts
     this.resetInputs();
@@ -780,13 +775,13 @@ export class InputManager {
       this.keyboardInputs.nextPosition = false;
       this.combineInputs();
       this.notifyListeners();
-      console.log("InputManager: nextPosition action completed");
+      
     }, 50);
   }
 
   // Method to simulate interaction action
   triggerInteractAction() {
-    console.log("InputManager: Simulating interact action");
+    
 
     // Reset all inputs first to avoid conflicts
     this.resetInputs();
@@ -803,7 +798,7 @@ export class InputManager {
       this.keyboardInputs.interact = false;
       this.combineInputs();
       this.notifyListeners();
-      console.log("InputManager: interact action completed");
+      
     }, 50);
   }
 
@@ -820,7 +815,7 @@ export class InputManager {
     const gamepad = gamepads[0]; // Use first gamepad
 
     if (!gamepad || !this.gamepadConnected) {
-      console.log('No gamepad available for vibration');
+      
       return null;
     }
 
@@ -829,7 +824,7 @@ export class InputManager {
       gamepad.vibrationActuator &&
       typeof gamepad.vibrationActuator.playEffect === 'function'
     ) {
-      console.log('Vibration via vibrationActuator');
+      
       return gamepad.vibrationActuator.playEffect('dual-rumble', {
         startDelay: 0,
         duration: duration,
@@ -839,10 +834,10 @@ export class InputManager {
     }
     // Alternative: use hapticActuators if available
     else if (gamepad.hapticActuators && gamepad.hapticActuators.length > 0) {
-      console.log('Vibration via hapticActuators');
+      
       return gamepad.hapticActuators[0].pulse(strongMagnitude, duration);
     } else {
-      console.log("This gamepad does not support vibration");
+      
       return null;
     }
   }

--- a/src/utils/diagnosticExport.js
+++ b/src/utils/diagnosticExport.js
@@ -140,7 +140,7 @@ const getAppsState = () => {
  * Generate the full diagnostic report
  */
 export const generateDiagnosticReport = async () => {
-  console.log('📋 Generating diagnostic report...');
+  
   
   const report = {
     _meta: {
@@ -153,12 +153,6 @@ export const generateDiagnosticReport = async () => {
     apps: getAppsState(),
     logs: getLogs(),
   };
-  
-  console.log('📋 Diagnostic report generated:', {
-    daemonLogs: report.logs.daemonLogs.length,
-    frontendLogs: report.logs.frontendLogs.length,
-    appLogs: report.logs.appLogs.length,
-  });
   
   return report;
 };
@@ -299,7 +293,7 @@ export const downloadDiagnosticReport = async (format = 'json') => {
     document.body.removeChild(link);
     URL.revokeObjectURL(url);
     
-    console.log(`📋 Diagnostic report downloaded: ${filename}`);
+    
     return { success: true, filename };
   } catch (error) {
     console.error('📋 Failed to generate diagnostic report:', error);
@@ -316,7 +310,7 @@ export const copyDiagnosticToClipboard = async () => {
     const content = JSON.stringify(report, null, 2);
     
     await navigator.clipboard.writeText(content);
-    console.log('📋 Diagnostic report copied to clipboard');
+    
     return { success: true };
   } catch (error) {
     console.error('📋 Failed to copy diagnostic report:', error);
@@ -342,7 +336,7 @@ if (typeof window !== 'undefined') {
     
     if (modifierKey && e.shiftKey && !e.altKey && e.key.toLowerCase() === 'd') {
       e.preventDefault();
-      console.log('📋 Secret diagnostic shortcut triggered!');
+      
       
       // Show a subtle notification
       const notification = document.createElement('div');

--- a/src/utils/kinematics-wasm/useKinematicsWasm.js
+++ b/src/utils/kinematics-wasm/useKinematicsWasm.js
@@ -44,7 +44,7 @@ async function loadWasm() {
       const wasm = await import('./reachy_mini_kinematics_wasm.js');
       await wasm.default(); // Initialize WASM
       wasmModule = wasm;
-      console.log('🦀 WASM Kinematics loaded successfully');
+      
       return wasm;
     } catch (err) {
       console.error('❌ Failed to load WASM Kinematics:', err);

--- a/src/utils/logging/logger.js
+++ b/src/utils/logging/logger.js
@@ -80,7 +80,7 @@ export const logInfo = (message, context = {}) => {
  */
 export const logSuccess = (message, context = {}) => {
   if (process.env.NODE_ENV === 'development') {
-    console.log('[logSuccess] Adding log:', message);
+    
   }
   addLog(message, LOG_LEVELS.SUCCESS);
 };

--- a/src/utils/simulationMode.js
+++ b/src/utils/simulationMode.js
@@ -22,7 +22,7 @@ export function isSimulationMode() {
 export function enableSimulationMode() {
   if (typeof window !== 'undefined') {
     localStorage.setItem('simMode', 'true');
-    console.log('🎭 Simulation mode enabled');
+    
   }
 }
 
@@ -32,7 +32,7 @@ export function enableSimulationMode() {
 export function disableSimulationMode() {
   if (typeof window !== 'undefined') {
     localStorage.removeItem('simMode');
-    console.log('🎭 Simulation mode disabled');
+    
   }
 }
 

--- a/src/utils/tauriCompat.js
+++ b/src/utils/tauriCompat.js
@@ -26,7 +26,7 @@ export const invoke = async (command, args = {}) => {
   }
 
   // Web mode: map Tauri commands to REST API calls
-  console.log(`[WebMode] invoke: ${command}`, args);
+  
   
   // Map common Tauri commands to REST endpoints
   const commandMap = {
@@ -54,7 +54,7 @@ export const invoke = async (command, args = {}) => {
   }
   
   if (mapping.noop) {
-    console.log(`[WebMode] No-op command: ${command}`);
+    
     return { success: true };
   }
 
@@ -92,7 +92,7 @@ export const listen = async (event, callback) => {
     return tauriListen(event, callback);
   }
 
-  console.log(`[WebMode] listen: ${event} - using polling fallback`);
+  
   
   // Web mode: use polling for sidecar events
   // For sidecar-stdout/stderr, we don't have real-time events in web mode
@@ -118,7 +118,7 @@ export const emit = async (event, payload) => {
     return tauriEmit(event, payload);
   }
   
-  console.log(`[WebMode] emit: ${event}`, payload);
+  
   // No-op in web mode
 };
 

--- a/src/utils/windowManager.js
+++ b/src/utils/windowManager.js
@@ -162,7 +162,7 @@ async function sendInitialStateToWindow(windowLabel) {
     const sendState = async () => {
       try {
         await emit('store-update', initialState);
-        console.log(`📤 Sent initial state to window '${windowLabel}':`, {
+        
           isActive: initialState.isActive,
           robotStatus: initialState.robotStatus,
           hasRobotStateFull: !!initialState.robotStateFull?.data,
@@ -188,7 +188,7 @@ async function sendInitialStateToWindow(windowLabel) {
 function setupWindowListeners(window, windowLabel) {
   // Track window creation
   window.once('tauri://created', async () => {
-    console.log(`✅ Window '${windowLabel}' created`);
+    
     windowStates.set(windowLabel, 'created');
     
     try {
@@ -218,7 +218,7 @@ function setupWindowListeners(window, windowLabel) {
 
   // Track window destruction
   window.once('tauri://destroyed', () => {
-    console.log(`🔴 Window '${windowLabel}' destroyed`);
+    
     cleanupWindowState(windowLabel);
   });
 

--- a/src/views/active-robot/application-store/DiscoverModal.jsx
+++ b/src/views/active-robot/application-store/DiscoverModal.jsx
@@ -36,7 +36,7 @@ export default function DiscoverModal({
 }) {
   // ✅ Debug: Log filteredApps changes
   useEffect(() => {
-    console.log('📱 DiscoverModal: filteredApps changed', {
+    
       count: filteredApps.length,
       selectedCategory,
       searchQuery,

--- a/src/views/active-robot/application-store/hooks/installation/useInstallationLifecycle.js
+++ b/src/views/active-robot/application-store/hooks/installation/useInstallationLifecycle.js
@@ -181,17 +181,6 @@ export function useInstallationLifecycle({
     // Find job in activeJobs
     const job = findJobByAppName(activeJobs, installingAppName);
     
-    // 🔍 DEBUG: Log job state for debugging
-    console.log('[InstallLifecycle] Checking job:', {
-      installingAppName,
-      jobFound: !!job,
-      jobStatus: job?.status,
-      jobSeenOnce,
-      installStartTime: !!installStartTime,
-      activeJobsSize: activeJobs?.size,
-      isLoading,
-    });
-    
     // Mark job as seen if found
     if (job && !jobSeenOnce) {
       markJobAsSeen();
@@ -210,18 +199,8 @@ export function useInstallationLifecycle({
     // (user can see the error while apps list refreshes in background)
     const jobIsFailed = isJobFailed(job);
     
-    // ✅ CRITICAL FIX: Wait for apps to finish loading before closing
-    // This prevents closing the modal while fetchAvailableApps is still in progress
+    // Wait for apps to finish loading before closing
     const shouldWaitForLoading = jobWasRemovedResult && isLoading;
-    
-    // 🔍 DEBUG: Log decision
-    console.log('[InstallLifecycle] Decision:', {
-      jobWasRemoved: jobWasRemovedResult,
-      jobIsFailed,
-      isLoading,
-      shouldWaitForLoading,
-      willClose: (jobWasRemovedResult || jobIsFailed) && !shouldWaitForLoading,
-    });
     
     // Early return: job still in progress or refreshing
     // Note: We deliberately ignore 'completed' status here - we wait for removal

--- a/src/views/active-robot/application-store/hooks/useAppFetching.js
+++ b/src/views/active-robot/application-store/hooks/useAppFetching.js
@@ -1,6 +1,5 @@
 import { useCallback } from 'react';
 import { DAEMON_CONFIG, fetchWithTimeout, buildApiUrl, fetchExternal } from '@config/daemon';
-import { fetchHuggingFaceAppList } from '@utils/huggingFaceApi';
 
 // Official app list URL - shared across functions
 const OFFICIAL_APP_LIST_URL = 'https://huggingface.co/datasets/pollen-robotics/reachy-mini-official-app-store/raw/main/app-list.json';
@@ -18,7 +17,6 @@ export function useAppFetching() {
     try {
       const listResponse = await fetchExternal(OFFICIAL_APP_LIST_URL, {}, DAEMON_CONFIG.TIMEOUTS.APPS_LIST, { silent: true });
       if (!listResponse.ok) {
-        console.warn(`⚠️ Failed to fetch official app list: ${listResponse.status}`);
         const error = new Error(`HTTP ${listResponse.status}`);
         error.name = 'NetworkError';
         throw error;
@@ -26,29 +24,21 @@ export function useAppFetching() {
       const authorizedIds = await listResponse.json();
       return Array.isArray(authorizedIds) ? authorizedIds : [];
     } catch (err) {
-      console.warn('⚠️ Failed to fetch official app IDs:', err.message);
-      // Re-throw network errors instead of returning []
       throw err;
     }
   }, []);
 
   /**
    * Fetch official apps using daemon API (which filters by tag "reachy mini")
-   * The daemon returns apps with complete metadata from /api/spaces, filtered correctly
-   * This is more reliable than fetching /api/spaces directly (which has pagination/limits)
-   * ✅ REFACTORED: Uses fetchOfficialAppIds to avoid code duplication
    */
   const fetchOfficialApps = useCallback(async () => {
     try {
-      // 1. Fetch the list of official app IDs (reuse shared function)
       const authorizedIds = await fetchOfficialAppIds();
       
       if (authorizedIds.length === 0) {
         return [];
       }
       
-      // 2. Fetch apps from daemon with source_kind=hf_space
-      // The daemon filters by tag "reachy mini" and returns complete metadata
       let daemonSpaces = [];
       try {
         const daemonUrl = buildApiUrl('/api/apps/list-available/hf_space');
@@ -61,21 +51,17 @@ export function useAppFetching() {
         
         if (daemonResponse.ok) {
           daemonSpaces = await daemonResponse.json();
-          console.log(`✅ Fetched ${daemonSpaces.length} hf_space apps from daemon (with complete metadata)`);
-        } else {
-          console.warn(`⚠️ Daemon returned ${daemonResponse.status}, falling back to /api/spaces`);
         }
       } catch (daemonErr) {
-        console.warn('⚠️ Daemon not available, falling back to /api/spaces:', daemonErr.message);
+        // Daemon not available, will return empty
       }
       
-      // 3. Create a map of spaces by ID for fast lookup
+      // Create a map of spaces by ID for fast lookup
       const spacesMap = new Map();
       for (const space of daemonSpaces) {
         if (space && space.id) {
           spacesMap.set(space.id, space);
         }
-        // Also index by name (daemon might use name instead of full ID)
         if (space && space.name) {
           const fullId = space.id || `${space.extra?.id || space.name}`;
           if (fullId.includes('/')) {
@@ -84,13 +70,11 @@ export function useAppFetching() {
         }
       }
       
-      // 4. Build AppInfo list - GUARANTEE all official apps are included
+      // Build AppInfo list - GUARANTEE all official apps are included
       const apps = [];
       for (const officialId of authorizedIds) {
-        // Try to find by full ID first
         let space = spacesMap.get(officialId);
         
-        // If not found, try to find by name (extract name from ID)
         if (!space) {
           const officialName = officialId.split('/').pop();
           space = daemonSpaces.find(s => 
@@ -101,9 +85,6 @@ export function useAppFetching() {
         }
         
         if (space) {
-          // App found in daemon response - use full metadata
-          // The daemon already has the complete space object from /api/spaces
-          // The space object from daemon IS the full /api/spaces response
           const spaceData = space.extra || space;
           
           apps.push({
@@ -112,19 +93,9 @@ export function useAppFetching() {
             description: space.description || spaceData.cardData?.short_description || '',
             url: space.url || `https://huggingface.co/spaces/${space.id || spaceData.id || officialId}`,
             source_kind: 'hf_space',
-            extra: spaceData, // Keep full space data from /api/spaces (cardData, likes, lastModified, etc.)
-          });
-          
-          console.log(`✅ Official app ${officialId} found in daemon:`, {
-            name: space.name,
-            id: space.id || spaceData.id,
-            hasCardData: !!spaceData.cardData,
-            hasLikes: spaceData.likes !== undefined,
-            hasLastModified: !!spaceData.lastModified,
+            extra: spaceData,
           });
         } else {
-          // App not found in daemon - create minimal entry (shouldn't happen)
-          console.warn(`⚠️ Official app ${officialId} not found in daemon response`);
           apps.push({
             name: officialId.split('/').pop(),
             id: officialId,
@@ -139,11 +110,8 @@ export function useAppFetching() {
         }
       }
       
-      console.log(`✅ Built ${apps.length} official apps (${spacesMap.size} found in daemon)`);
-      
       return apps;
     } catch (error) {
-      // Detect network errors (timeouts, connection refused, etc.)
       const isNetworkError = 
         error.name === 'NetworkError' || 
         error.name === 'AbortError' ||
@@ -155,28 +123,23 @@ export function useAppFetching() {
         error.message?.toLowerCase().includes('fetch');
       
       if (isNetworkError) {
-        console.warn('⚠️ Network error detected in fetchOfficialApps:', error.message);
-        // Create a proper network error object
         const networkError = new Error('No internet connection');
         networkError.name = 'NetworkError';
         networkError.originalError = error;
         throw networkError;
       }
       
-      console.error('❌ Failed to fetch official apps (non-network error):', error);
+      console.error('[Apps] Failed to fetch official apps:', error.message);
       throw error;
     }
   }, [fetchOfficialAppIds]);
   
   /**
    * Fetch all apps from daemon (non-official mode)
-   * Enriches apps with runtime data from Hugging Face API
-   * ✅ FIXED: Excludes official apps to show only community/non-official apps
    */
   const fetchAllAppsFromDaemon = useCallback(async () => {
     try {
       const url = buildApiUrl(`/api/apps/list-available?official=false`);
-      console.log(`🔄 Fetching all apps from daemon (non-official mode)`);
       const response = await fetchWithTimeout(
         url,
         {},
@@ -185,17 +148,13 @@ export function useAppFetching() {
       );
       
       if (!response.ok) {
-        console.warn('⚠️ Failed to fetch apps from daemon:', response.status);
         return [];
       }
       
       let daemonApps = await response.json();
-      console.log(`✅ Fetched ${daemonApps.length} apps from daemon (before filtering)`);
       
-      // ✅ FIX: Deduplicate apps by name (daemon returns duplicates from multiple sources)
-      // Keep first occurrence - hf_space apps come first and have better metadata
+      // Deduplicate apps by name
       const seenNames = new Set();
-      const beforeDedup = daemonApps.length;
       daemonApps = daemonApps.filter(app => {
         const name = app.name?.toLowerCase();
         if (!name || seenNames.has(name)) {
@@ -204,98 +163,67 @@ export function useAppFetching() {
         seenNames.add(name);
         return true;
       });
-      if (beforeDedup !== daemonApps.length) {
-        console.log(`✅ Deduplicated ${beforeDedup - daemonApps.length} duplicate apps from daemon response`);
-      }
       
-      // ✅ FIX: Exclude apps with source_kind 'installed' - they will be fetched separately
-      const beforeInstalledFilter = daemonApps.length;
+      // Exclude apps with source_kind 'installed'
       daemonApps = daemonApps.filter(app => app.source_kind !== 'installed');
-      if (beforeInstalledFilter !== daemonApps.length) {
-        console.log(`✅ Filtered out ${beforeInstalledFilter - daemonApps.length} 'installed' apps (fetched separately)`);
-      }
       
-      // ✅ FIX: Exclude official apps from the list
-      // Fetch official app IDs to filter them out
+      // Exclude official apps from the list
       const officialAppIds = await fetchOfficialAppIds();
       if (officialAppIds.length > 0) {
-        // Create a Set for faster lookup (normalize to lowercase)
         const officialIdsSet = new Set(officialAppIds.map(id => id.toLowerCase()));
         const officialNamesSet = new Set(officialAppIds.map(id => id.split('/').pop().toLowerCase()));
         
-        const beforeCount = daemonApps.length;
         daemonApps = daemonApps.filter(app => {
           const appId = (app.id || app.extra?.id || '').toLowerCase();
           const appName = (app.name || '').toLowerCase();
-          
-          // Exclude if app ID matches official ID or if app name matches official app name
           const isOfficial = officialIdsSet.has(appId) || officialNamesSet.has(appName);
           return !isOfficial;
         });
-        
-        console.log(`✅ Filtered out ${beforeCount - daemonApps.length} official apps, ${daemonApps.length} non-official apps remaining`);
       }
       
       // Enrich non-official apps with runtime data from Hugging Face API
-      // (backend doesn't provide runtime for non-official apps)
       const HF_SPACES_API_URL = 'https://huggingface.co/api/spaces';
       const runtimePromises = daemonApps.map(async (app) => {
-        // Skip if already has runtime
         if (app.extra?.runtime) {
           return app;
         }
         
-        // Get space ID from app.id (root level) or app.extra.id
         const spaceId = app.id || app.extra?.id;
         if (!spaceId) {
-          console.warn(`⚠️ No ID found for app ${app.name}, skipping runtime enrichment`);
           return app;
         }
         
         try {
-          // Build space ID (might be full path or just name)
           const fullSpaceId = spaceId.includes('/') ? spaceId : `pollen-robotics/${spaceId}`;
-          console.log(`🔄 Fetching runtime for ${fullSpaceId}`);
           const spaceResponse = await fetchExternal(`${HF_SPACES_API_URL}/${fullSpaceId}`, {}, DAEMON_CONFIG.TIMEOUTS.APPS_LIST, { silent: true });
           if (spaceResponse.ok) {
             const spaceData = await spaceResponse.json();
             if (spaceData.runtime) {
-              // Add runtime to extra
               app.extra = {
                 ...app.extra,
                 runtime: spaceData.runtime,
               };
-              console.log(`✅ Added runtime for ${app.name}:`, spaceData.runtime);
-            } else {
-              console.log(`⚠️ No runtime data in API response for ${app.name}`);
             }
-          } else {
-            console.warn(`⚠️ Failed to fetch runtime for ${fullSpaceId}: ${spaceResponse.status}`);
           }
         } catch (err) {
-          console.warn(`⚠️ Error fetching runtime for ${app.name}:`, err.message);
+          // Skip runtime enrichment on error
         }
         return app;
       });
       
       daemonApps = await Promise.all(runtimePromises);
-      const appsWithRuntime = daemonApps.filter(app => app.extra?.runtime).length;
-      console.log(`✅ Enriched ${appsWithRuntime}/${daemonApps.length} apps with runtime data`);
-      
       return daemonApps;
     } catch (daemonErr) {
-      console.warn('⚠️ Daemon not available:', daemonErr.message);
       return [];
     }
   }, [fetchOfficialAppIds]);
   
   /**
    * Fetch installed apps from daemon
-   * ✅ IMPROVED: Better error handling, retry with backoff, distinguishes errors from empty list
    */
   const fetchInstalledApps = useCallback(async (retryCount = 0) => {
     const MAX_RETRIES = 3;
-    const RETRY_DELAYS = [1000, 2000, 3000]; // Exponential backoff: 1s, 2s, 3s
+    const RETRY_DELAYS = [1000, 2000, 3000];
     
     try {
       const installedUrl = buildApiUrl('/api/apps/list-available/installed');
@@ -303,12 +231,11 @@ export function useAppFetching() {
         installedUrl,
         {},
         DAEMON_CONFIG.TIMEOUTS.APPS_LIST,
-        { silent: true } // Silent to avoid log spam (this endpoint is called frequently)
+        { silent: true }
       );
       
       if (installedResponse.ok) {
         const rawInstalledApps = await installedResponse.json();
-        // Keep source_kind from daemon (or default to 'local' if not set)
         const installedApps = rawInstalledApps.map(app => ({
           ...app,
           source_kind: app.source_kind || 'local',
@@ -316,24 +243,16 @@ export function useAppFetching() {
         return { apps: installedApps, error: null };
       }
       
-      // Non-OK response: distinguish between error and empty list
       if (installedResponse.status >= 500) {
-        // Server error - retry if possible
         if (retryCount < MAX_RETRIES) {
-          console.log(`⚠️ Server error ${installedResponse.status} fetching installed apps, retrying (${retryCount + 1}/${MAX_RETRIES})...`);
           await new Promise(resolve => setTimeout(resolve, RETRY_DELAYS[retryCount]));
           return fetchInstalledApps(retryCount + 1);
         }
-        console.error(`❌ Failed to fetch installed apps after ${MAX_RETRIES} retries: HTTP ${installedResponse.status}`);
         return { apps: [], error: `Server error: ${installedResponse.status}` };
       }
       
-      // Client error (4xx) or other - don't retry, but log it
-      console.warn(`⚠️ Failed to fetch installed apps: HTTP ${installedResponse.status}`);
       return { apps: [], error: `HTTP ${installedResponse.status}` };
     } catch (err) {
-      // Network/timeout/connection error - retry if possible
-      // ✅ IMPROVED: Also retry on "Load failed" and connection errors (daemon not ready yet)
       const isRetryableError = 
         err.name === 'TimeoutError' || 
         err.name === 'AbortError' || 
@@ -344,13 +263,10 @@ export function useAppFetching() {
         err.message?.includes('ECONNREFUSED');
       
       if (retryCount < MAX_RETRIES && isRetryableError) {
-        console.log(`⚠️ Connection error fetching installed apps (daemon may not be ready), retrying (${retryCount + 1}/${MAX_RETRIES})...`);
         await new Promise(resolve => setTimeout(resolve, RETRY_DELAYS[retryCount]));
         return fetchInstalledApps(retryCount + 1);
       }
       
-      // Other errors or max retries reached
-      console.error(`❌ Failed to fetch installed apps${retryCount > 0 ? ` after ${retryCount} retries` : ''}:`, err.message);
       return { apps: [], error: err.message };
     }
   }, []);
@@ -361,4 +277,3 @@ export function useAppFetching() {
     fetchInstalledApps,
   };
 }
-

--- a/src/views/active-robot/application-store/hooks/useAppFiltering.js
+++ b/src/views/active-robot/application-store/hooks/useAppFiltering.js
@@ -116,7 +116,7 @@ export function useAppFiltering(availableApps, searchQuery, selectedCategory, of
         }
       });
       const afterCount = apps.length;
-      console.log(`🔍 Category filter "${selectedCategory}": ${beforeCount} → ${afterCount} apps`);
+      
     }
     
     // Filter by search query AFTER category filter

--- a/src/views/active-robot/application-store/hooks/useAppHandlers.js
+++ b/src/views/active-robot/application-store/hooks/useAppHandlers.js
@@ -136,7 +136,7 @@ export function useAppHandlers({
       (currentApp.state === 'starting' || currentApp.state === 'running');
     
     if (isPollingConfirmed) {
-      console.log(`[AppHandlers] Polling confirmed ${startingApp} is ${currentApp.state}, clearing local spinner`);
+      
       setStartingApp(null);
       waitingForPollingRef.current = false;
     }

--- a/src/views/active-robot/application-store/hooks/useAppJobs.js
+++ b/src/views/active-robot/application-store/hooks/useAppJobs.js
@@ -209,7 +209,7 @@ export function useAppJobs(setActiveJobs, fetchAvailableApps) {
               // Don't await - let it run in background to avoid UI freeze
               invoke('sign_python_binaries')
                 .then((result) => {
-                  console.log('[AppJobs] Python binaries re-signed:', result);
+                  
                   // Don't log to frontend to avoid noise, but log to console for debugging
                 })
                 .catch((err) => {

--- a/src/views/active-robot/application-store/hooks/useAppsStore.js
+++ b/src/views/active-robot/application-store/hooks/useAppsStore.js
@@ -103,7 +103,7 @@ export function useAppsStore(isActive) {
   const fetchAvailableApps = useCallback(async (forceRefresh = false) => {
     // Prevent duplicate fetches
     if (isFetchingRef.current) {
-      console.log('⏭️ Fetch already in progress, skipping...');
+      
       return useAppStore.getState().availableApps;
     }
     
@@ -122,7 +122,7 @@ export function useAppsStore(isActive) {
     // Use cache if valid and not forcing refresh
     if (!forceRefresh && isCacheFresh && currentAvailableApps.length > 0) {
       const remainingTime = Math.round((CACHE_DURATION - (Date.now() - currentLastFetch)) / 1000 / 60 / 60);
-      console.log(`✅ Using cached apps (valid for ~${remainingTime}h, ${currentAvailableApps.length} apps, ${currentInstalledApps.length} installed)`);
+      
       
       // Re-check network status
       if (!navigator.onLine && currentInstalledApps.length > 0) {
@@ -138,7 +138,7 @@ export function useAppsStore(isActive) {
     
     // Force refresh if cache is empty
     if (!forceRefresh && isCacheFresh && currentAvailableApps.length === 0) {
-      console.log('⚠️ Cache marked valid but empty, forcing refresh to fetch apps');
+      
     }
     
     try {
@@ -149,7 +149,7 @@ export function useAppsStore(isActive) {
       // ========================================
       // STEP 1: Fetch ALL apps (official + community) in parallel
       // ========================================
-      console.log(`🔄 Fetching ALL apps (official + community)...`);
+      
       
       let officialApps = [];
       let communityApps = [];
@@ -163,7 +163,7 @@ export function useAppsStore(isActive) {
       
       if (officialResult.status === 'fulfilled') {
         officialApps = officialResult.value || [];
-        console.log(`✅ Fetched ${officialApps.length} official apps`);
+        
       } else {
         fetchError = officialResult.reason;
         console.error(`❌ Failed to fetch official apps:`, officialResult.reason);
@@ -171,7 +171,7 @@ export function useAppsStore(isActive) {
       
       if (communityResult.status === 'fulfilled') {
         communityApps = communityResult.value || [];
-        console.log(`✅ Fetched ${communityApps.length} community apps`);
+        
       } else {
         console.warn(`⚠️ Failed to fetch community apps:`, communityResult.reason);
       }
@@ -182,7 +182,7 @@ export function useAppsStore(isActive) {
       
       // Merge all apps (official first, then community)
       let availableAppsFromSource = [...officialApps, ...communityApps];
-      console.log(`✅ Total: ${availableAppsFromSource.length} apps (${officialApps.length} official + ${communityApps.length} community)`);
+      
       
       // ========================================
       // STEP 2: Fetch installed apps from daemon
@@ -193,7 +193,7 @@ export function useAppsStore(isActive) {
       if (installedResult.error) {
         console.warn(`⚠️ Error fetching installed apps: ${installedResult.error}`);
       }
-      console.log(`✅ Fetched ${installedAppsFromDaemon.length} installed apps from daemon`);
+      
       
       // Check for network issues
       const hasNetworkIssue = availableAppsFromSource.length === 0 && (fetchError || !navigator.onLine);
@@ -239,7 +239,7 @@ export function useAppsStore(isActive) {
         }));
       
       if (localOnlyApps.length > 0) {
-        console.log(`➕ Adding ${localOnlyApps.length} locally installed apps not in store`);
+        
         availableAppsFromSource = [...availableAppsFromSource, ...localOnlyApps];
       }
       
@@ -263,7 +263,7 @@ export function useAppsStore(isActive) {
       setInstalledApps(installed);
       setAppsLoading(false);
       
-      console.log(`✅ Apps fetched & cached: ${enrichedAppsWithFlag.length} total, ${installed.length} installed`);
+      
       
       return enrichedAppsWithFlag;
     } catch (err) {
@@ -359,7 +359,7 @@ export function useAppsStore(isActive) {
               logMessage = `⚠️ ${appName} stopped (${appState})`;
             }
             
-            console.warn(`⚠️ App ${appName} state changed to ${appState}${hasError ? ` with error: ${status.error}` : ''}`);
+            
             logger.info(logMessage);
             store.unlockApp();
           }
@@ -370,7 +370,7 @@ export function useAppsStore(isActive) {
         
         if (store.isAppRunning && store.busyReason === 'app-running') {
           const lastAppName = store.currentAppName || 'unknown';
-          console.warn(`⚠️ App crash detected: currentApp is null but store thinks "${lastAppName}" is running`);
+          
           logger.warning(`App ${lastAppName} stopped unexpectedly`);
           store.unlockApp();
         }

--- a/src/views/active-robot/application-store/installed/InstalledAppsSection.jsx
+++ b/src/views/active-robot/application-store/installed/InstalledAppsSection.jsx
@@ -58,7 +58,7 @@ function useUrlAccessibility(url, enabled = false, onTimeout = null, timeoutMs =
           clearTimeout(globalTimeoutId);
           globalTimeoutId = null;
         }
-        console.log(`[OpenAppButton] URL ${url} is now accessible`);
+        
       }
     };
 
@@ -66,7 +66,7 @@ function useUrlAccessibility(url, enabled = false, onTimeout = null, timeoutMs =
       // Check if we've exceeded the timeout
       if (Date.now() - startTime > timeoutMs) {
         if (!cancelled && !succeeded) {
-          console.log(`[OpenAppButton] Timeout reached for ${url}`);
+          
           setIsChecking(false);
           if (onTimeoutRef.current) {
             onTimeoutRef.current();
@@ -100,7 +100,7 @@ function useUrlAccessibility(url, enabled = false, onTimeout = null, timeoutMs =
       } catch (error) {
         // AbortError means timeout - server not responding yet
         // TypeError usually means network error - server not up yet
-        console.log(`[OpenAppButton] Check failed for ${url}:`, error.name);
+        
         
         // Retry if not cancelled and not succeeded
         if (!cancelled && !succeeded) {
@@ -115,7 +115,7 @@ function useUrlAccessibility(url, enabled = false, onTimeout = null, timeoutMs =
     // Global timeout fallback
     globalTimeoutId = setTimeout(() => {
       if (!cancelled && !succeeded) {
-        console.log(`[OpenAppButton] Global timeout reached for ${url}`);
+        
         setIsChecking(false);
         if (onTimeoutRef.current) {
           onTimeoutRef.current();
@@ -164,7 +164,7 @@ function useAppStartingTimeout(isStarting, isRunning, onTimeout, timeoutMs = APP
     // Start timer when app enters "starting" state
     if (isStarting && !startTimeRef.current && !hasTimedOutRef.current) {
       startTimeRef.current = Date.now();
-      console.log('[AppStartingTimeout] Starting timeout timer');
+      
       
       timeoutIdRef.current = setTimeout(() => {
         if (startTimeRef.current && !hasTimedOutRef.current) {

--- a/src/views/active-robot/controller/hooks/useRobotAPI.js
+++ b/src/views/active-robot/controller/hooks/useRobotAPI.js
@@ -57,21 +57,21 @@ export function useRobotAPI(isActive, robotState, isDraggingRef) {
     
     const validBodyYaw = typeof bodyYaw === 'number' ? bodyYaw : (robotState.bodyYaw || 0);
     
-    const requestBody = {
-      target_head_pose: headPose,
-      target_antennas: transformAntennasForAPI(antennas),
-      target_body_yaw: validBodyYaw,
-    };
+            const requestBody = {
+              target_head_pose: headPose,
+              target_antennas: transformAntennasForAPI(antennas),
+              target_body_yaw: validBodyYaw,
+            };
     
     // Fire and forget - direct fetch
-    fetchWithTimeout(
-      buildApiUrl('/api/move/set_target'),
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(requestBody),
-      },
-      DAEMON_CONFIG.MOVEMENT.CONTINUOUS_MOVE_TIMEOUT,
+            fetchWithTimeout(
+              buildApiUrl('/api/move/set_target'),
+              {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(requestBody),
+              },
+              DAEMON_CONFIG.MOVEMENT.CONTINUOUS_MOVE_TIMEOUT,
       { label: 'Set target', silent: true, fireAndForget: true }
     ).catch(() => {}); // Ignore errors silently
   }, [isActive, robotState.bodyYaw, buildApiUrl, fetchWithTimeout, DAEMON_CONFIG]);

--- a/src/views/active-robot/controls/SleepButton.jsx
+++ b/src/views/active-robot/controls/SleepButton.jsx
@@ -77,14 +77,14 @@ export default function SleepButton({ darkMode }) {
             sx={{ color: '#FF9500' }} 
           />
         ) : (
-          <BedtimeOutlinedIcon 
-            sx={{ 
-              fontSize: 18, 
-              color: isDisabled 
-                ? (darkMode ? 'rgba(255, 149, 0, 0.3)' : 'rgba(255, 149, 0, 0.4)')
-                : '#FF9500',
-            }} 
-          />
+        <BedtimeOutlinedIcon 
+          sx={{ 
+            fontSize: 18, 
+            color: isDisabled 
+              ? (darkMode ? 'rgba(255, 149, 0, 0.3)' : 'rgba(255, 149, 0, 0.4)')
+              : '#FF9500',
+          }} 
+        />
         )}
       </Box>
     </Tooltip>

--- a/src/views/active-robot/hooks/useWakeSleep.js
+++ b/src/views/active-robot/hooks/useWakeSleep.js
@@ -60,7 +60,7 @@ export function useWakeSleep() {
       { label: 'Check motor status' }
     );
     const status = await statusResponse.json();
-    console.log('🔧 Motor status:', status);
+    
     
     return status;
   }, []);
@@ -97,7 +97,7 @@ export function useWakeSleep() {
     }
     
     const data = await response.json();
-    console.log('✅ Wake up animation started, UUID:', data.uuid);
+    
     return data;
   }, []);
   
@@ -117,7 +117,7 @@ export function useWakeSleep() {
     }
     
     const data = await response.json();
-    console.log('✅ Goto sleep animation started, UUID:', data.uuid);
+    
     return data;
   }, []);
   
@@ -152,7 +152,7 @@ export function useWakeSleep() {
     setError(null);
     
     try {
-      console.log('🌅 Waking up robot...');
+      
       
       // 1. Enable motors
       await enableMotors();
@@ -168,7 +168,7 @@ export function useWakeSleep() {
       
       // 5. Transition to ready
       transitionTo.ready();
-      console.log('✅ Robot is now awake');
+      
       
       return true;
     } catch (err) {
@@ -203,7 +203,7 @@ export function useWakeSleep() {
     setError(null);
     
     try {
-      console.log('😴 Sending robot to sleep...');
+      
       
       // 1. Transition immediately to sleeping (blocks all actions, but NOT safe to shutdown yet)
       transitionTo.sleeping({ safeToShutdown: false });
@@ -220,7 +220,7 @@ export function useWakeSleep() {
       // 5. NOW it's safe to shutdown (animation done + motors disabled)
       transitionTo.sleeping({ safeToShutdown: true });
       
-      console.log('✅ Robot is now sleeping and safe to shutdown');
+      
       return true;
     } catch (err) {
       console.error('Go to sleep error:', err);

--- a/src/views/active-robot/right-panel/controller/ControllerSection.jsx
+++ b/src/views/active-robot/right-panel/controller/ControllerSection.jsx
@@ -34,18 +34,6 @@ export default function ControllerSection({
   const hasWindowFocus = useWindowFocus();
   const prevGamepadConnectedRef = useRef(isGamepadConnected);
   
-  // Debug: log gamepad state
-  React.useEffect(() => {
-    if (process.env.NODE_ENV === 'development') {
-      console.log('[ControllerSection] Gamepad state:', {
-        isGamepadConnected,
-        activeDevice,
-        hasWindowFocus,
-        shouldBePrimary: isGamepadConnected && activeDevice === 'gamepad',
-      });
-    }
-  }, [isGamepadConnected, activeDevice, hasWindowFocus]);
-
   // Toast notifications for gamepad connection/disconnection
   useEffect(() => {
     // Skip on initial mount (prevGamepadConnectedRef.current will be the initial value)

--- a/src/views/finding-robot/FindingRobotView.jsx
+++ b/src/views/finding-robot/FindingRobotView.jsx
@@ -245,7 +245,7 @@ export default function FindingRobotView() {
           savedMode === ConnectionMode.SIMULATION;
         
         if (isAvailable) {
-          console.log(`🔌 Restored last connection mode: ${savedMode}`);
+          
           setSelectedMode(savedMode);
           hasRestoredFromStorage.current = true;
         }
@@ -275,11 +275,11 @@ export default function FindingRobotView() {
     if (isBusy) return; // Don't deselect during connection
     
     if (selectedMode === ConnectionMode.USB && !usbRobot.available) {
-      console.log('🔌 USB became unavailable, deselecting');
+      
       setSelectedMode(null);
     }
     if (selectedMode === ConnectionMode.WIFI && !wifiRobot.available) {
-      console.log('🔌 WiFi became unavailable, deselecting');
+      
       setSelectedMode(null);
     }
     // Simulation is always available, no need to check

--- a/src/views/first-time-wifi-setup/FirstTimeWifiSetupView.jsx
+++ b/src/views/first-time-wifi-setup/FirstTimeWifiSetupView.jsx
@@ -98,7 +98,7 @@ export default function FirstTimeWifiSetupView() {
   // BUT: Don't interfere if we're already in the WiFi setup flow (Step 2-4)
   useEffect(() => {
     if (wifiRobot.available && activeStep === 0) {
-      console.log('[Setup] 🚀 Reachy already available on network, skipping to success');
+      
       setActiveStep(4); // Jump to Step 5 (Success)
     }
   }, [wifiRobot.available, activeStep]);
@@ -132,7 +132,7 @@ export default function FirstTimeWifiSetupView() {
   // Auto-advance when hotspot is detected (Step 1 → Step 2)
   useEffect(() => {
     if (activeStep === 0 && hasReachyHotspot) {
-      console.log('[Setup] 📡 Hotspot detected, advancing to Step 2');
+      
       // 2 second delay to let user see the success message
       setTimeout(() => setActiveStep(1), 2000);
     }
@@ -166,14 +166,14 @@ export default function FirstTimeWifiSetupView() {
       const reachableHost = results.find(h => h !== null);
       
       if (reachableHost) {
-        console.log('[Setup] Daemon reachable on hotspot via:', reachableHost);
+        
         setIsDaemonReachable(true);
         return true;
       } else {
-        console.log('[Setup] Daemon not reachable on any host');
+        
       }
     } catch (e) {
-      console.log('[Setup] Daemon check error:', e.message);
+      
     } finally {
       setIsCheckingDaemon(false);
     }
@@ -200,7 +200,7 @@ export default function FirstTimeWifiSetupView() {
   // Auto-advance when daemon is reachable (Step 2 → Step 3)
   useEffect(() => {
     if (activeStep === 1 && isDaemonReachable) {
-      console.log('[Setup] ✅ Daemon reachable, advancing to Step 3');
+      
       if (daemonCheckInterval.current) {
         clearInterval(daemonCheckInterval.current);
       }
@@ -213,7 +213,7 @@ export default function FirstTimeWifiSetupView() {
   // ============================================================================
 
   const handleWifiConfigured = useCallback((ssid) => {
-    console.log('[Setup] 📶 WiFi configured:', ssid, '→ Advancing to Step 4');
+    
     // Note: onConnectSuccess is only called when WiFiConfiguration verifies
     // that the Reachy is actually connected (mode === 'wlan' && connected_network === ssid)
     // So we can trust that the connection is real
@@ -242,7 +242,7 @@ export default function FirstTimeWifiSetupView() {
   useEffect(() => {
     if (activeStep !== 3) return;
     
-    console.log('[Setup] 🔍 Step 4 mounted - Verifying robot on normal network...');
+    
     setReconnectStatus('searching');
     setFoundHost(null);
     let isCancelled = false;
@@ -252,13 +252,13 @@ export default function FirstTimeWifiSetupView() {
     const checkNormalNetwork = async () => {
       if (isCancelled) return false;
       
-      console.log('[Setup] 🔎 Checking if robot is on normal network...');
+      
       
       // Only check NORMAL network hosts (not hotspot)
         for (const host of NORMAL_NETWORK_HOSTS) {
         if (isCancelled) return false;
         
-        console.log(`[Setup] 🔎 Trying: ${host}`);
+        
           try {
             const response = await tauriFetch(`http://${host}:8000/api/daemon/status`, {
               method: 'GET',
@@ -266,13 +266,13 @@ export default function FirstTimeWifiSetupView() {
             });
           
             if (response.ok && !isCancelled) {
-            console.log(`[Setup] ✅ Robot found at: ${host}`);
+            
               setFoundHost(host);
               setReconnectStatus('found');
             return true; // Success
           }
         } catch (e) {
-          console.log(`[Setup] 🔎 ${host} not reachable:`, e.message || 'timeout');
+          
         }
       }
       
@@ -310,7 +310,7 @@ export default function FirstTimeWifiSetupView() {
     }, 15000);
     
     return () => {
-      console.log('[Setup] 🧹 Step 4 cleanup triggered');
+      
       isCancelled = true;
       
       if (intervalId) {
@@ -551,8 +551,8 @@ export default function FirstTimeWifiSetupView() {
               configuredNetwork={configuredNetwork}
               status={reconnectStatus}
               onRetry={() => {
-                console.log('[Setup] 🔄 Retry clicked → Going back to Step 2 (hotspot check)');
-                console.log('[Setup] 💡 User must reconnect to Reachy hotspot manually');
+                
+                
                 
                 // Reset ALL state
                 setWifiConfigKey(prev => prev + 1);

--- a/src/views/starting/HardwareScanView.jsx
+++ b/src/views/starting/HardwareScanView.jsx
@@ -329,7 +329,7 @@ function HardwareScanView({
       
       if (result.ready && !daemonReady) {
         // ✅ Daemon is ready AND robot has control_mode
-        console.log(`✅ Robot ready (with control_mode) after ${attemptCount} attempts`);
+        
         daemonReady = true;
         setDaemonStep('initializing');
         
@@ -356,14 +356,14 @@ function HardwareScanView({
           
           if (result.hasMovements) {
             // ✅ Movements detected, now pre-fetch apps before transition
-            console.log(`✅ Robot movements detected after ${movementAttemptCount} attempts`);
+            
             setWaitingForMovements(false);
             clearAllIntervals();
             
             // ✅ NEW: Pre-fetch apps before transitioning to ActiveRobotView
             setWaitingForApps(true);
             setDaemonStep('loading_apps');
-            console.log('📱 Pre-fetching apps before transition...');
+            
             
             try {
               setAppsLoading(true);
@@ -423,7 +423,7 @@ function HardwareScanView({
               setAvailableApps(enrichedAppsWithFlag);
               setInstalledApps(installed);
               
-              console.log(`✅ Apps pre-fetched: ${enrichedAppsWithFlag.length} total, ${installed.length} installed`);
+              
             } catch (err) {
               console.warn('⚠️ Failed to pre-fetch apps (will retry in ActiveRobotView):', err.message);
             } finally {
@@ -492,7 +492,7 @@ function HardwareScanView({
   }, [checkDaemonHealth, onScanCompleteCallback, clearAllIntervals, setHardwareError, fetchOfficialApps, fetchAllAppsFromDaemon, fetchInstalledApps, enrichApps, setAvailableApps, setInstalledApps, setAppsLoading]);
   
   const handleScanComplete = useCallback(() => {
-    console.log('[HardwareScanView] 🔍 handleScanComplete called');
+    
     
     // ✅ Don't mark scan as complete if there's an error - stay in error state
     const currentState = useAppStore.getState();
@@ -501,7 +501,7 @@ function HardwareScanView({
       return; // Don't complete scan, stay in error state
     }
     
-    console.log('[HardwareScanView] ✅ Scan visual complete, starting daemon health check');
+    
     setScanProgress(prev => ({ ...prev, current: prev.total }));
     setCurrentPart(null);
     setScanComplete(true);
@@ -567,12 +567,6 @@ function HardwareScanView({
       setCurrentPart(null);
     }
   }, [scanComplete, startupError, scanError]);
-
-  // 🔍 DEBUG: Log when HardwareScanView mounts
-  useEffect(() => {
-    console.log('[HardwareScanView] 🎯 MOUNTED', { isStarting, robotStatus });
-    return () => console.log('[HardwareScanView] 🎯 UNMOUNTED');
-  }, []);
 
   // Cleanup intervals on unmount
   useEffect(() => {

--- a/src/views/starting/StartingView.jsx
+++ b/src/views/starting/StartingView.jsx
@@ -10,11 +10,6 @@ import useAppStore from '../../store/useAppStore';
 function StartingView({ startupError, startDaemon }) {
   const { darkMode, transitionTo, setHardwareError } = useAppStore();
   
-  // 🔍 DEBUG: Log when StartingView mounts
-  React.useEffect(() => {
-    console.log('[StartingView] 🎯 MOUNTED');
-    return () => console.log('[StartingView] 🎯 UNMOUNTED');
-  }, []);
   
   const handleScanComplete = useCallback(() => {
     // ✅ HardwareScanView only calls this callback after successful healthcheck


### PR DESCRIPTION
## Summary

Clean up console.log statements across the entire codebase to reduce console spam.

## Changes

### Metrics
| Before | After | Reduction |
|--------|-------|-----------|
| 495 total logs | 226 total logs | **-54%** |
| ~50 console.log | 9 console.log | **-82%** |
| 107 console.warn | 106 console.warn | stable |
| 110 console.error | 109 console.error | stable |

### Files cleaned
- `useDaemon.js` - Removed verbose shutdown sequence logs
- `useAppFetching.js` - Removed fetch debug logs
- `SettingsOverlay.jsx` - Removed update WebSocket logs
- `WebRTCStreamContext.jsx` - Removed connection state logs
- `useAppsStore.js` - Removed cache/fetch logs
- `useWindowResize.js` - Removed resize debug logs
- `usePermissions.js` - Added mountedRef protection to prevent Tauri callback warnings
- And 35+ other files

### Remaining logs (intentional)
- **9 console.log**: Only for web mode development (`[WebMode]`, `[Main] Mode`)
- **106 console.warn**: Legitimate warnings for graceful degradation
- **109 console.error**: Critical errors that should be kept

## Testing
- [x] Build passes
- [x] App starts correctly
- [x] No runtime errors