### PR TITLE
feat: Use WebSocket polling for wake/sleep animation completion

### DIFF
--- a/src/views/active-robot/hooks/useWakeSleep.js
+++ b/src/views/active-robot/hooks/useWakeSleep.js
@@ -1,5 +1,5 @@
-import { useState, useCallback } from 'react';
-import { DAEMON_CONFIG, fetchWithTimeout, buildApiUrl } from '../../../config/daemon';
+import { useState, useCallback, useRef } from 'react';
+import { DAEMON_CONFIG, fetchWithTimeout, buildApiUrl, getWsBaseUrl } from '../../../config/daemon';
 import useAppStore from '../../../store/useAppStore';
 import { ROBOT_STATUS } from '../../../constants/robotStatus';
 
@@ -10,6 +10,7 @@ import { ROBOT_STATUS } from '../../../constants/robotStatus';
  * - Enabling/disabling motors
  * - Playing wake_up/goto_sleep animations
  * - Managing state transitions
+ * - Polling for animation completion via WebSocket
  *
  * @returns {Object} Wake/sleep controls and state
  */
@@ -18,6 +19,9 @@ export function useWakeSleep() {
     useAppStore();
   const [isTransitioning, setIsTransitioning] = useState(false);
   const [error, setError] = useState(null);
+
+  // Ref to track active WebSocket for cleanup
+  const wsRef = useRef(null);
 
   // Sync local transitioning state with global store
   const setTransitioningState = useCallback(
@@ -89,6 +93,7 @@ export function useWakeSleep() {
 
   /**
    * Play wake_up animation via API
+   * @returns {Promise<{uuid: string}>} Move UUID for tracking completion
    */
   const playWakeUpAnimation = useCallback(async () => {
     const response = await fetchWithTimeout(
@@ -103,12 +108,12 @@ export function useWakeSleep() {
     }
 
     const data = await response.json();
-
     return data;
   }, []);
 
   /**
    * Play goto_sleep animation via API
+   * @returns {Promise<{uuid: string}>} Move UUID for tracking completion
    */
   const playGoToSleepAnimation = useCallback(async () => {
     const response = await fetchWithTimeout(
@@ -123,16 +128,122 @@ export function useWakeSleep() {
     }
 
     const data = await response.json();
-
     return data;
   }, []);
 
   /**
-   * Wait for animation to complete
-   * TODO: Could be improved to poll actual animation status instead of fixed timeout
+   * Wait for a move to complete using WebSocket
+   *
+   * Connects to /api/move/ws/updates and waits for:
+   * - move_completed: resolves successfully
+   * - move_failed/move_cancelled: rejects with error
+   * - timeout: rejects after max wait time
+   *
+   * @param {string} moveUuid - UUID of the move to wait for
+   * @param {number} timeoutMs - Maximum time to wait (default: 10s)
+   * @returns {Promise<void>}
    */
-  const waitForAnimation = useCallback(async () => {
-    await new Promise(resolve => setTimeout(resolve, DAEMON_CONFIG.ANIMATIONS.SLEEP_DURATION));
+  const waitForMoveCompletion = useCallback(async (moveUuid, timeoutMs = 10000) => {
+    // If no UUID provided, fall back to fixed timeout (legacy behavior)
+    if (!moveUuid) {
+      console.warn('[WakeSleep] No move UUID provided, using fixed timeout');
+      await new Promise(resolve => setTimeout(resolve, DAEMON_CONFIG.ANIMATIONS.SLEEP_DURATION));
+      return;
+    }
+
+    return new Promise((resolve, reject) => {
+      let ws = null;
+      let timeoutId = null;
+      let resolved = false;
+
+      const cleanup = () => {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+          timeoutId = null;
+        }
+        if (ws) {
+          ws.close();
+          ws = null;
+          wsRef.current = null;
+        }
+      };
+
+      const finish = (error = null) => {
+        if (resolved) return;
+        resolved = true;
+        cleanup();
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      };
+
+      // Set up timeout fallback
+      timeoutId = setTimeout(() => {
+        console.warn(`[WakeSleep] Timeout waiting for move ${moveUuid}, continuing anyway`);
+        finish(); // Resolve on timeout (don't fail the whole operation)
+      }, timeoutMs);
+
+      try {
+        const wsUrl = `${getWsBaseUrl()}/api/move/ws/updates`;
+        ws = new WebSocket(wsUrl);
+        wsRef.current = ws;
+
+        ws.onopen = () => {
+          // WebSocket connected, now waiting for move completion
+        };
+
+        ws.onmessage = event => {
+          try {
+            const data = JSON.parse(event.data);
+
+            // Check if this message is for our move
+            if (data.uuid !== moveUuid) return;
+
+            if (data.type === 'move_completed') {
+              finish();
+            } else if (data.type === 'move_failed') {
+              finish(new Error(`Move failed: ${data.details || 'Unknown error'}`));
+            } else if (data.type === 'move_cancelled') {
+              finish(new Error('Move was cancelled'));
+            }
+            // Ignore move_started - we're already waiting
+          } catch (err) {
+            console.warn('[WakeSleep] Failed to parse WebSocket message:', err);
+          }
+        };
+
+        ws.onerror = error => {
+          console.warn('[WakeSleep] WebSocket error:', error);
+          // Don't fail on WebSocket error, let timeout handle it
+        };
+
+        ws.onclose = () => {
+          // If WebSocket closes unexpectedly and we haven't resolved yet,
+          // wait a bit and resolve (assume animation completed)
+          if (!resolved) {
+            console.warn('[WakeSleep] WebSocket closed unexpectedly, using fallback timeout');
+            setTimeout(() => finish(), 1000);
+          }
+        };
+      } catch (err) {
+        console.error('[WakeSleep] Failed to create WebSocket:', err);
+        // Fall back to fixed timeout
+        cleanup();
+        setTimeout(() => finish(), DAEMON_CONFIG.ANIMATIONS.SLEEP_DURATION);
+      }
+    });
+  }, []);
+
+  /**
+   * Cleanup WebSocket on unmount
+   */
+  const cleanupWebSocket = useCallback(() => {
+    if (wsRef.current) {
+      wsRef.current.close();
+      wsRef.current = null;
+    }
   }, []);
 
   /**
@@ -142,7 +253,7 @@ export function useWakeSleep() {
    * 1. Enable motors
    * 2. Wait for motors to initialize (300ms)
    * 3. Play wake_up animation
-   * 4. Wait for animation to complete
+   * 4. Wait for animation to complete (via WebSocket)
    * 5. Transition to ready state
    */
   const wakeUp = useCallback(async () => {
@@ -162,11 +273,12 @@ export function useWakeSleep() {
       // 2. Small delay for motor initialization
       await new Promise(resolve => setTimeout(resolve, 300));
 
-      // 3. Play wake_up animation
-      await playWakeUpAnimation();
+      // 3. Play wake_up animation and get UUID
+      const moveData = await playWakeUpAnimation();
+      const moveUuid = moveData?.uuid;
 
-      // 4. Wait for animation to complete
-      await waitForAnimation();
+      // 4. Wait for animation to complete (via WebSocket polling)
+      await waitForMoveCompletion(moveUuid, 10000);
 
       // 5. Transition to ready
       transitionTo.ready();
@@ -181,15 +293,17 @@ export function useWakeSleep() {
     } finally {
       setTransitioningState(false);
       setOptimisticAwake(false); // Clear optimistic state (real state takes over)
+      cleanupWebSocket();
     }
   }, [
     canToggle,
     isSleeping,
     enableMotors,
     playWakeUpAnimation,
-    waitForAnimation,
+    waitForMoveCompletion,
     transitionTo,
     setTransitioningState,
+    cleanupWebSocket,
   ]);
 
   /**
@@ -198,7 +312,7 @@ export function useWakeSleep() {
    * Sequence:
    * 1. Transition to sleeping state (blocks all actions immediately, but NOT safe to shutdown yet)
    * 2. Play goto_sleep animation
-   * 3. Wait for animation to complete
+   * 3. Wait for animation to complete (via WebSocket)
    * 4. Disable motors
    * 5. Mark as safe to shutdown
    */
@@ -215,11 +329,12 @@ export function useWakeSleep() {
       // 1. Transition immediately to sleeping (blocks all actions, but NOT safe to shutdown yet)
       transitionTo.sleeping({ safeToShutdown: false });
 
-      // 2. Play goto_sleep animation
-      await playGoToSleepAnimation();
+      // 2. Play goto_sleep animation and get UUID
+      const moveData = await playGoToSleepAnimation();
+      const moveUuid = moveData?.uuid;
 
-      // 3. Wait for animation to complete
-      await waitForAnimation();
+      // 3. Wait for animation to complete (via WebSocket polling)
+      await waitForMoveCompletion(moveUuid, 10000);
 
       // 4. Disable motors
       await disableMotors();
@@ -236,15 +351,17 @@ export function useWakeSleep() {
       return false;
     } finally {
       setTransitioningState(false);
+      cleanupWebSocket();
     }
   }, [
     canToggle,
     isSleeping,
     transitionTo,
     playGoToSleepAnimation,
-    waitForAnimation,
+    waitForMoveCompletion,
     disableMotors,
     setTransitioningState,
+    cleanupWebSocket,
   ]);
 
   /**


### PR DESCRIPTION
## Summary

Replaces the fixed 4-second timeout with proper WebSocket-based polling for wake/sleep animations.

### Before
```javascript
// Fixed timeout - animation may finish earlier or later
await new Promise(resolve => setTimeout(resolve, 4000));
```

### After
```javascript
// Wait for actual move_completed event via WebSocket
await waitForMoveCompletion(moveUuid, 10000);
```

### How it works

1. When `wake_up` or `goto_sleep` animation is triggered, the API returns a move UUID
2. We connect to `/api/move/ws/updates` WebSocket
3. Wait for `move_completed` event with matching UUID
4. Handle `move_failed` / `move_cancelled` as errors
5. Fallback to 10s timeout if WebSocket connection fails

### Benefits

- ⚡ **Faster transitions** when animations finish early
- 🎯 **More reliable** - waits exactly until animation completes
- 🔄 **Graceful fallback** - timeout if WebSocket unavailable
- 🧹 **Proper cleanup** - WebSocket closed after use