### PR TITLE
feat: relocatable venv + permissions cleanup

### DIFF
--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -116,60 +116,7 @@ jobs:
         run: |
           TARGET_TRIPLET=${{ matrix.target }} bash ./scripts/build/build-sidecar-unix.sh || echo "Sidecar build skipped"
 
-      - name: Update macOS resources config with cpython folder name
-        if: matrix.os == 'macos-latest' || matrix.os == 'macos-15-intel'
-        shell: bash
-        run: |
-          # Find the actual cpython folder name created by uv-bundle
-          CPYTHON_FOLDER=$(ls -d src-tauri/binaries/cpython-* 2>/dev/null | head -1 | xargs basename || echo "")
-          
-          if [ -z "$CPYTHON_FOLDER" ]; then
-            echo "⚠️  No cpython folder found in src-tauri/binaries/, skipping config update"
-            exit 0
-          fi
-          
-          echo "🔧 Found cpython folder: $CPYTHON_FOLDER"
-          echo "   Updating tauri.macos.conf.json..."
-          
-          # Update the tauri.macos.conf.json with the exact cpython folder name
-          # The config has hardcoded aarch64 path, we need to replace it with the actual folder
-          sed -i '' "s|cpython-3.12[^\"]*|$CPYTHON_FOLDER|g" src-tauri/tauri.macos.conf.json
-          
-          echo "✅ Updated tauri.macos.conf.json:"
-          cat src-tauri/tauri.macos.conf.json
-          
-          # Verify the binaries directory contents
-          echo ""
-          echo "📦 Contents of src-tauri/binaries/:"
-          ls -la src-tauri/binaries/
-
-      - name: Update Linux resources config with cpython folder name
-        if: matrix.os == 'ubuntu-22.04'
-        shell: bash
-        run: |
-          # Find the actual cpython folder name created by uv-bundle
-          CPYTHON_FOLDER=$(ls -d src-tauri/binaries/cpython-* 2>/dev/null | head -1 | xargs basename || echo "")
-          
-          if [ -z "$CPYTHON_FOLDER" ]; then
-            echo "⚠️  No cpython folder found in src-tauri/binaries/, skipping config update"
-            exit 0
-          fi
-          
-          echo "🔧 Found cpython folder: $CPYTHON_FOLDER"
-          echo "   Updating tauri.linux.conf.json..."
-          
-          # Update the tauri.linux.conf.json with the exact cpython folder name
-          # Replace glob patterns with the actual folder name using sed
-          sed -i "s|cpython-3.12\*-linux-x86_64\*|$CPYTHON_FOLDER|g" src-tauri/tauri.linux.conf.json
-          sed -i "s|cpython-3.12-linux-x86_64|$CPYTHON_FOLDER|g" src-tauri/tauri.linux.conf.json
-          
-          echo "✅ Updated tauri.linux.conf.json:"
-          cat src-tauri/tauri.linux.conf.json
-          
-          # Verify the binaries directory contents
-          echo ""
-          echo "📦 Contents of src-tauri/binaries/:"
-          ls -la src-tauri/binaries/
+      # Note: cpython steps removed - venv is now self-contained with --relocatable
 
       - name: Build sidecar (Windows)
         if: matrix.os == 'windows-latest'
@@ -241,32 +188,6 @@ jobs:
             Write-Host "❌ ERROR: site-packages directory not found!"
             exit 1
           }
-
-      - name: Update Windows resources config with cpython folder name
-        if: matrix.os == 'windows-latest'
-        shell: pwsh
-        run: |
-          # Find the actual cpython folder name created by uv-bundle
-          $CPYTHON_FOLDER = (Get-ChildItem -Directory "src-tauri/binaries/cpython-*" -ErrorAction SilentlyContinue | Select-Object -First 1).Name
-          
-          if (-not $CPYTHON_FOLDER) {
-            Write-Host "❌ No cpython folder found in src-tauri/binaries/"
-            Write-Host "   This is required for Windows build"
-            Get-ChildItem src-tauri/binaries/ -ErrorAction SilentlyContinue
-            exit 1
-          }
-          
-          Write-Host "🔧 Found cpython folder: $CPYTHON_FOLDER"
-          Write-Host "   Updating tauri.windows.conf.json..."
-          
-          # Update the tauri.windows.conf.json with the exact cpython folder name
-          $content = Get-Content src-tauri/tauri.windows.conf.json -Raw
-          $content = $content -replace 'cpython-3\.12\*-windows-x86_64\*', $CPYTHON_FOLDER
-          $content = $content -replace 'cpython-3\.12-windows-x86_64', $CPYTHON_FOLDER
-          $content | Set-Content src-tauri/tauri.windows.conf.json
-          
-          Write-Host "✅ Updated tauri.windows.conf.json:"
-          Get-Content src-tauri/tauri.windows.conf.json
 
       - name: Setup Apple Code Signing (macOS only)
         if: matrix.os == 'macos-latest'

--- a/scripts/utils/reset-macos-permissions.sh
+++ b/scripts/utils/reset-macos-permissions.sh
@@ -109,23 +109,6 @@ else
     fi
 fi
 
-# Also reset All permissions (more comprehensive)
-echo "🔄 Resetting All permissions..."
-
-# Always try with bundle identifier first (works in production, may work in dev too)
-if tccutil reset All "$IDENTIFIER" >/dev/null 2>&1; then
-    echo "   ✅ All permissions reset (bundle identifier)"
-else
-    # In dev mode, if bundle identifier doesn't work, don't reset all apps
-    # (unsigned apps may not be in TCC with bundle identifier)
-    if [ "$IS_DEV" = true ]; then
-        echo "   ⚠️  Could not reset All permissions for $IDENTIFIER (app may not be in TCC)"
-        echo "      In dev mode, unsigned apps may not be registered in TCC with bundle identifier"
-        echo "      Try running the app first to register it, then run this script again"
-    else
-        echo "   ⚠️  Could not reset All permissions for $IDENTIFIER"
-    fi
-fi
 
 # In dev mode, also reset permissions for IDEs and terminals
 if [ "$IS_DEV" = true ]; then
@@ -136,19 +119,18 @@ if [ "$IS_DEV" = true ]; then
     
     reset_count=0
     for launcher in "${DEV_LAUNCHERS[@]}"; do
-        # Try to reset Camera and Microphone for each launcher
-        camera_reset=false
-        mic_reset=false
+        # Try to reset Camera and Microphone permissions for each launcher
+        any_reset=false
         
         if tccutil reset Camera "$launcher" >/dev/null 2>&1; then
-            camera_reset=true
+            any_reset=true
         fi
         if tccutil reset Microphone "$launcher" >/dev/null 2>&1; then
-            mic_reset=true
+            any_reset=true
         fi
         
         # Only show if at least one permission was reset
-        if [ "$camera_reset" = true ] || [ "$mic_reset" = true ]; then
+        if [ "$any_reset" = true ]; then
             echo "   ✅ $launcher"
             ((reset_count++)) || true
         fi

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3587,7 +3587,7 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "reachy-mini-control"
-version = "0.8.10"
+version = "0.9.0"
 dependencies = [
  "block",
  "cocoa",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -143,6 +143,7 @@ pub fn run() {
             permissions::open_camera_settings,
             permissions::open_microphone_settings,
             permissions::open_wifi_settings,
+            permissions::open_files_settings,
             wifi::scan_local_wifi_networks,
             wifi::get_current_wifi_ssid,
             update::check_daemon_update,

--- a/src-tauri/src/permissions/mod.rs
+++ b/src-tauri/src/permissions/mod.rs
@@ -96,6 +96,25 @@ pub fn open_wifi_settings() -> Result<(), String> {
     Ok(())
 }
 
+/// Open System Settings to Privacy & Security > Files and Folders (macOS)
+#[tauri::command]
+#[cfg(target_os = "macos")]
+pub fn open_files_settings() -> Result<(), String> {
+    use std::process::Command;
+    
+    let output = Command::new("open")
+        .arg("x-apple.systempreferences:com.apple.preference.security?Privacy_FilesAndFolders")
+        .output()
+        .map_err(|e| format!("Failed to open System Settings: {}", e))?;
+    
+    if !output.status.success() {
+        return Err(format!("Failed to open System Settings: {}", 
+            String::from_utf8_lossy(&output.stderr)));
+    }
+    
+    Ok(())
+}
+
 // ============================================================================
 // Windows Implementation
 // ============================================================================
@@ -131,6 +150,18 @@ pub fn open_wifi_settings() -> Result<(), String> {
     // Open Windows Settings > Network & Internet > Wi-Fi
     Command::new("cmd")
         .args(["/C", "start", "ms-settings:network-wifi"])
+        .spawn()
+        .map_err(|e| format!("Failed to open Settings: {}", e))?;
+    Ok(())
+}
+
+#[tauri::command]
+#[cfg(target_os = "windows")]
+pub fn open_files_settings() -> Result<(), String> {
+    use std::process::Command;
+    // Open Windows Settings > Privacy > File System
+    Command::new("cmd")
+        .args(["/C", "start", "ms-settings:privacy-broadfilesystemaccess"])
         .spawn()
         .map_err(|e| format!("Failed to open Settings: {}", e))?;
     Ok(())
@@ -178,6 +209,18 @@ pub fn open_wifi_settings() -> Result<(), String> {
     Ok(())
 }
 
+#[tauri::command]
+#[cfg(target_os = "linux")]
+pub fn open_files_settings() -> Result<(), String> {
+    // Linux doesn't have centralized file access permissions
+    // Best effort: open file manager or GNOME privacy settings
+    use std::process::Command;
+    let _ = Command::new("gnome-control-center")
+        .arg("privacy")
+        .spawn();
+    Ok(())
+}
+
 // ============================================================================
 // Fallback for other platforms (no-op)
 // ============================================================================
@@ -197,5 +240,11 @@ pub fn open_microphone_settings() -> Result<(), String> {
 #[tauri::command]
 #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
 pub fn open_wifi_settings() -> Result<(), String> {
+    Ok(())
+}
+
+#[tauri::command]
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+pub fn open_files_settings() -> Result<(), String> {
     Ok(())
 }

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -3,9 +3,7 @@
     "resources": {
       "binaries/uv": "uv",
       "binaries/uvx": "uvx",
-      "binaries/.venv": ".venv",
-      "binaries/cpython-3.12*-linux-x86_64*": "cpython-3.12-linux-x86_64",
-      "binaries/cpython-3.12*-linux-x86_64*/lib": ".venv/lib"
+      "binaries/.venv": ".venv"
     },
     "linux": {
       "deb": {
@@ -17,4 +15,3 @@
     }
   }
 }
-

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -4,8 +4,6 @@
       "binaries/uv": "uv",
       "binaries/uvx": "uvx",
       "binaries/.venv": ".venv",
-      "binaries/cpython-3.12.12-macos-aarch64-none": "cpython-3.12.12-macos-aarch64-none",
-      "binaries/cpython-3.12.12-macos-aarch64-none/lib": ".venv/lib",
       "python-entitlements.plist": "python-entitlements.plist"
     },
     "macOS": {
@@ -18,4 +16,3 @@
     }
   }
 }
-

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -4,9 +4,7 @@
       "binaries/uv.exe": "uv.exe",
       "binaries/uvx.exe": "uvx.exe",
       "binaries/.venv": ".venv",
-      "binaries/.venv/*": ".venv/",
-      "binaries/cpython-3.12.12-windows-x86_64-none": "cpython-3.12-windows-x86_64",
-      "binaries/cpython-3.12.12-windows-x86_64-none/*": "cpython-3.12-windows-x86_64/"
+      "binaries/.venv/*": ".venv/"
     },
     "windows": {
       "certificateThumbprint": null,
@@ -15,4 +13,3 @@
     }
   }
 }
-

--- a/src/views/permissions-required/PermissionsRequiredView.jsx
+++ b/src/views/permissions-required/PermissionsRequiredView.jsx
@@ -1,9 +1,8 @@
-import React, { useReducer, useRef, useEffect } from 'react';
-import { Box, Typography, Stack } from '@mui/material';
+import React, { useReducer, useRef, useEffect, useCallback } from 'react';
+import { Box, Typography, useTheme, alpha } from '@mui/material';
 import CameraAltOutlinedIcon from '@mui/icons-material/CameraAltOutlined';
-import PulseButton from '@components/PulseButton';
 import MicNoneOutlinedIcon from '@mui/icons-material/MicNoneOutlined';
-import CheckCircleOutlinedIcon from '@mui/icons-material/CheckCircleOutlined';
+import CheckRoundedIcon from '@mui/icons-material/CheckRounded';
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 import useAppStore from '../../store/useAppStore';
@@ -16,104 +15,103 @@ import SleepingReachy from '../../assets/sleeping-reachy.svg';
 
 /**
  * Permission Card Component
- * Reusable card for displaying permission status and actions
+ * Square card similar to ConnectionCard in FindingRobotView
  */
-const PermissionCard = ({
-  icon: Icon,
-  title,
-  granted,
-  requested,
-  onRequest,
-  onOpenSettings,
-  darkMode,
-}) => {
+const PermissionCard = ({ icon: Icon, label, subtitle, granted, onClick, darkMode }) => {
+  const theme = useTheme();
+  // Colors - primary from theme for interactive, success (green) for granted
+  const primaryColor = theme.palette.primary.main;
+  const successColor = theme.palette.success?.main || '#22c55e';
+
   return (
     <Box
+      onClick={onClick}
       sx={{
-        width: '50%',
+        position: 'relative',
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
         justifyContent: 'center',
-        padding: 3,
-        borderRadius: 2,
-        backgroundColor: granted
-          ? darkMode
-            ? 'rgba(34, 197, 94, 0.06)'
-            : 'rgba(34, 197, 94, 0.04)'
-          : 'transparent',
-        border: granted
-          ? `1px solid ${darkMode ? 'rgba(34, 197, 94, 0.5)' : 'rgba(34, 197, 94, 0.4)'}`
-          : `2px dashed ${darkMode ? '#555' : '#ccc'}`,
-        transition: 'all 0.3s ease',
+        gap: 0.5,
+        p: 2,
+        borderRadius: '12px',
+        border: '1px solid',
+        borderColor: granted ? successColor : primaryColor,
+        bgcolor: granted
+          ? alpha(successColor, darkMode ? 0.1 : 0.05)
+          : alpha(primaryColor, darkMode ? 0.1 : 0.05),
+        cursor: granted ? 'default' : 'pointer',
+        transition: 'all 0.2s ease',
+        flex: 1,
+        minWidth: 110,
+        minHeight: 110,
+        '&:hover': granted
+          ? {}
+          : {
+              bgcolor: alpha(primaryColor, darkMode ? 0.15 : 0.1),
+            },
       }}
     >
-      <Icon
-        sx={{
-          fontSize: 20,
-          color: granted ? (darkMode ? '#22c55e' : '#16a34a') : darkMode ? '#666' : '#999',
-          mb: 1.5,
-          transition: 'color 0.3s ease',
-        }}
-      />
-      <Typography
-        variant="body1"
-        sx={{
-          fontWeight: 600,
-          color: granted
-            ? darkMode
-              ? 'rgba(255, 255, 255, 0.9)'
-              : 'rgba(0, 0, 0, 0.85)'
-            : darkMode
-              ? '#fff'
-              : '#1a1a1a',
-          mb: 2,
-          textAlign: 'center',
-        }}
-      >
-        {title}
-      </Typography>
-      {granted ? (
+      {/* Granted checkmark - top right */}
+      {granted && (
         <Box
           sx={{
+            position: 'absolute',
+            top: 6,
+            right: 6,
+            width: 16,
+            height: 16,
+            borderRadius: '50%',
+            bgcolor: darkMode ? 'rgba(26, 26, 26, 1)' : 'rgba(253, 252, 250, 1)',
+            border: `1.5px solid ${successColor}`,
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
-            gap: 0.75,
-            width: '100%',
-            px: 2,
-            py: 0.75,
-            borderRadius: '10px',
-            bgcolor: 'transparent',
-            border: `1px solid ${darkMode ? 'rgba(34, 197, 94, 0.5)' : 'rgba(34, 197, 94, 0.4)'}`,
+            animation: 'checkmarkPop 0.25s cubic-bezier(0.34, 1.56, 0.64, 1)',
+            '@keyframes checkmarkPop': {
+              '0%': { transform: 'scale(0)', opacity: 0 },
+              '100%': { transform: 'scale(1)', opacity: 1 },
+            },
           }}
         >
-          <CheckCircleOutlinedIcon
-            sx={{
-              fontSize: 16,
-              color: darkMode ? '#22c55e' : '#16a34a',
-            }}
-          />
-          <Typography
-            sx={{
-              fontSize: 11,
-              fontWeight: 600,
-              color: darkMode ? '#22c55e' : '#16a34a',
-              textTransform: 'none',
-            }}
-          >
-            Granted
-          </Typography>
+          <CheckRoundedIcon sx={{ fontSize: 10, color: successColor }} />
         </Box>
-      ) : (
-        <PulseButton
-          onClick={requested ? onOpenSettings : onRequest}
-          darkMode={darkMode}
-          size="small"
-          fullWidth
+      )}
+
+      {/* Icon */}
+      <Icon
+        sx={{
+          fontSize: 28,
+          color: granted ? successColor : primaryColor,
+        }}
+      />
+
+      {/* Label */}
+      <Typography
+        sx={{
+          fontSize: 13,
+          fontWeight: 600,
+          color: granted ? successColor : primaryColor,
+          textAlign: 'center',
+          lineHeight: 1.2,
+        }}
+      >
+        {label}
+      </Typography>
+
+      {/* Subtitle */}
+      {subtitle && (
+        <Typography
+          sx={{
+            fontSize: 10,
+            fontWeight: 400,
+            color: granted ? successColor : alpha(primaryColor, 0.7),
+            textAlign: 'center',
+            lineHeight: 1.1,
+          }}
         >
-          {requested ? 'Open Settings' : 'Ask Access'}
-        </PulseButton>
+          {subtitle}
+        </Typography>
       )}
     </Box>
   );
@@ -121,16 +119,13 @@ const PermissionCard = ({
 
 /**
  * Reducer for managing permissions view state
- * Handles permission requests, restart flow, and UI state
  */
 const permissionsViewReducer = (state, action) => {
   switch (action.type) {
     case 'SET_CAMERA_REQUESTED':
       return { ...state, cameraRequested: true };
-
     case 'SET_MICROPHONE_REQUESTED':
       return { ...state, microphoneRequested: true };
-
     default:
       return state;
   }
@@ -139,11 +134,9 @@ const permissionsViewReducer = (state, action) => {
 /**
  * PermissionsRequiredView
  * Blocks the app until permissions are granted
- * Uses usePermissions hook for real-time detection (checks every 2 seconds)
  */
 export default function PermissionsRequiredView({ isRestarting: externalIsRestarting }) {
   const { darkMode } = useAppStore();
-  // Use the hook for real-time permission detection
   const {
     cameraGranted,
     microphoneGranted,
@@ -157,8 +150,8 @@ export default function PermissionsRequiredView({ isRestarting: externalIsRestar
     restartStarted: false,
   });
 
-  // Ref to track permission polling interval for cleanup
   const permissionPollingRef = useRef(null);
+  const unlistenRustLogRef = useRef(null);
 
   // Cleanup polling interval on unmount
   useEffect(() => {
@@ -170,14 +163,11 @@ export default function PermissionsRequiredView({ isRestarting: externalIsRestar
     };
   }, []);
 
-  // Listen to Rust logs from backend (only show errors)
-  const unlistenRustLogRef = useRef(null);
-
+  // Listen to Rust logs
   useEffect(() => {
     let isMounted = true;
 
     const setupRustLogListener = async () => {
-      // Cleanup previous listener if any
       if (unlistenRustLogRef.current) {
         unlistenRustLogRef.current();
         unlistenRustLogRef.current = null;
@@ -186,11 +176,8 @@ export default function PermissionsRequiredView({ isRestarting: externalIsRestar
       try {
         const unlisten = await listen('rust-log', event => {
           if (!isMounted) return;
-
           const message =
             typeof event.payload === 'string' ? event.payload : event.payload?.toString() || '';
-
-          // Only show errors from Rust backend
           if (message.includes('❌') || message.includes('error') || message.includes('Error')) {
             logError(message);
           }
@@ -217,12 +204,9 @@ export default function PermissionsRequiredView({ isRestarting: externalIsRestar
     };
   }, []);
 
-  // Test plugin availability on mount (silent) - macOS only
-  React.useEffect(() => {
-    if (!isMacOS()) {
-      return; // Skip on non-macOS platforms
-    }
-
+  // Test plugin availability on mount (macOS only)
+  useEffect(() => {
+    if (!isMacOS()) return;
     const testPlugin = async () => {
       try {
         await invoke('plugin:macos-permissions|check_camera_permission');
@@ -235,96 +219,84 @@ export default function PermissionsRequiredView({ isRestarting: externalIsRestar
   }, []);
 
   // Generic permission request handler
-  const requestPermission = async type => {
-    // Skip on non-macOS platforms - permissions are handled by the webview
-    if (!isMacOS()) {
-      logInfo(`[Permissions] ℹ️ Non-macOS platform - permissions handled automatically`);
-      return;
-    }
-
-    try {
-      const checkCommand = `plugin:macos-permissions|check_${type}_permission`;
-      const requestCommand = `plugin:macos-permissions|request_${type}_permission`;
-      const settingsCommand = `open_${type}_settings`;
-
-      // Check current status
-      const currentStatus = await invoke(checkCommand);
-
-      if (currentStatus === true) {
+  const requestPermission = useCallback(
+    async type => {
+      if (!isMacOS()) {
+        logInfo(`[Permissions] ℹ️ Non-macOS platform - permissions handled automatically`);
         return;
       }
 
-      // Request permission
-      const result = await invoke(requestCommand);
+      try {
+        const checkCommand = `plugin:macos-permissions|check_${type}_permission`;
+        const requestCommand = `plugin:macos-permissions|request_${type}_permission`;
+        const settingsCommand = `open_${type}_settings`;
 
-      if (type === 'camera') {
-        dispatch({ type: 'SET_CAMERA_REQUESTED' });
-      } else {
-        dispatch({ type: 'SET_MICROPHONE_REQUESTED' });
-      }
+        const currentStatus = await invoke(checkCommand);
+        if (currentStatus === true) return;
 
-      if (result === null) {
-        // Popup shown, start polling silently
-        // Clear any existing interval first
-        if (permissionPollingRef.current) {
-          clearInterval(permissionPollingRef.current);
+        const result = await invoke(requestCommand);
+
+        if (type === 'camera') {
+          dispatch({ type: 'SET_CAMERA_REQUESTED' });
+        } else if (type === 'microphone') {
+          dispatch({ type: 'SET_MICROPHONE_REQUESTED' });
         }
 
-        let checkCount = 0;
-        const maxChecks = 20;
-        const permCheckCommand =
-          type === 'camera'
-            ? 'plugin:macos-permissions|check_camera_permission'
-            : 'plugin:macos-permissions|check_microphone_permission';
+        if (result === null) {
+          if (permissionPollingRef.current) {
+            clearInterval(permissionPollingRef.current);
+          }
 
-        permissionPollingRef.current = setInterval(async () => {
-          checkCount++;
-          await refreshPermissions();
+          let checkCount = 0;
+          const maxChecks = 20;
 
-          try {
-            const status = await invoke(permCheckCommand);
-            if (status === true) {
+          permissionPollingRef.current = setInterval(async () => {
+            checkCount++;
+            await refreshPermissions();
+
+            try {
+              const status = await invoke(checkCommand);
+              if (status === true) {
+                if (permissionPollingRef.current) {
+                  clearInterval(permissionPollingRef.current);
+                  permissionPollingRef.current = null;
+                }
+                await refreshPermissions();
+              }
+            } catch (error) {
+              // Ignore errors during polling
+            }
+
+            if (checkCount >= maxChecks) {
               if (permissionPollingRef.current) {
                 clearInterval(permissionPollingRef.current);
                 permissionPollingRef.current = null;
               }
-              await refreshPermissions();
             }
-          } catch (error) {
-            // Ignore errors during polling
-          }
+          }, 500);
 
-          if (checkCount >= maxChecks) {
-            if (permissionPollingRef.current) {
-              clearInterval(permissionPollingRef.current);
-              permissionPollingRef.current = null;
-            }
-          }
-        }, 500);
+          return;
+        }
 
-        return;
+        if (result === false) {
+          await invoke(settingsCommand);
+        }
+      } catch (error) {
+        const errorMsg = error?.message || error?.toString() || 'Unknown error';
+        logError(`[Permissions] ${type}: ${errorMsg}`);
+        try {
+          await invoke(`open_${type}_settings`);
+        } catch (settingsError) {
+          const settingsErrorMsg =
+            settingsError?.message || settingsError?.toString() || 'Unknown error';
+          logError(`[Permissions] ❌ Failed to open settings: ${settingsErrorMsg}`);
+        }
       }
+    },
+    [refreshPermissions]
+  );
 
-      if (result === false) {
-        // Permission denied, open settings
-        await invoke(settingsCommand);
-      }
-    } catch (error) {
-      const errorMsg = error?.message || error?.toString() || 'Unknown error';
-      logError(`[Permissions]${type}: ${errorMsg}`);
-      // Try to open settings as fallback
-      try {
-        await invoke(`open_${type}_settings`);
-      } catch (settingsError) {
-        const settingsErrorMsg =
-          settingsError?.message || settingsError?.toString() || 'Unknown error';
-        logError(`[Permissions] ❌ Failed to open settings: ${settingsErrorMsg}`);
-      }
-    }
-  };
-
-  const openSettings = async type => {
-    // Skip on non-macOS platforms
+  const openSettings = useCallback(async type => {
     if (!isMacOS()) {
       logInfo(`[Permissions] ℹ️ Non-macOS platform - no settings to open`);
       return;
@@ -336,22 +308,19 @@ export default function PermissionsRequiredView({ isRestarting: externalIsRestar
       const errorMsg = error?.message || error?.toString() || 'Unknown error';
       logError(`[Permissions] ❌ Failed to open ${type} settings: ${errorMsg}`);
     }
-  };
+  }, []);
 
-  // Track previous permission states to detect actual changes
-  const prevCameraGranted = React.useRef(null);
-  const prevMicrophoneGranted = React.useRef(null);
+  // Track permission changes for logging
+  const prevCameraGranted = useRef(null);
+  const prevMicrophoneGranted = useRef(null);
 
-  // Only log when a permission is granted (not initial state)
-  React.useEffect(() => {
-    // Skip initial render
+  useEffect(() => {
     if (prevCameraGranted.current === null) {
       prevCameraGranted.current = cameraGranted;
       prevMicrophoneGranted.current = microphoneGranted;
       return;
     }
 
-    // Log only when permission changes from false to true
     if (!prevCameraGranted.current && cameraGranted) {
       logInfo('✅ Camera permission granted');
     }
@@ -363,23 +332,21 @@ export default function PermissionsRequiredView({ isRestarting: externalIsRestar
     prevMicrophoneGranted.current = microphoneGranted;
   }, [cameraGranted, microphoneGranted]);
 
+  const bgColor = darkMode ? 'rgba(26, 26, 26, 0.95)' : 'rgba(253, 252, 250, 0.85)';
+
   return (
     <Box
       sx={{
-        width: '100%',
+        width: '100vw',
         height: '100vh',
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        backgroundColor: darkMode ? '#1a1a1a' : '#f5f5f5',
-        padding: 3,
-        paddingLeft: 6,
-        paddingRight: 6,
+        background: bgColor,
+        backdropFilter: 'blur(40px)',
+        WebkitBackdropFilter: 'blur(40px)',
+        overflow: 'hidden',
         position: 'relative',
       }}
     >
-      {/* Temporary LogConsole for debugging permissions */}
+      {/* LogConsole at bottom */}
       <Box
         sx={{
           position: 'fixed',
@@ -389,11 +356,9 @@ export default function PermissionsRequiredView({ isRestarting: externalIsRestar
           width: 'calc(100% - 32px)',
           maxWidth: '420px',
           zIndex: 1000,
-          opacity: 0.2, // Very subtle by default
+          opacity: 0.2,
           transition: 'opacity 0.3s ease-in-out',
-          '&:hover': {
-            opacity: 1, // Full opacity on hover
-          },
+          '&:hover': { opacity: 1 },
         }}
       >
         <LogConsole
@@ -412,26 +377,35 @@ export default function PermissionsRequiredView({ isRestarting: externalIsRestar
         />
       </Box>
 
-      <Box sx={{ maxWidth: 700, textAlign: 'center' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          height: '100vh',
+          position: 'relative',
+          zIndex: 2,
+          px: 4,
+        }}
+      >
         {state.isRestarting || externalIsRestarting ? (
           <>
             {/* Restarting view */}
             <Box
               sx={{
+                width: 140,
+                height: 140,
+                mb: 2,
                 display: 'flex',
+                alignItems: 'center',
                 justifyContent: 'center',
-                mb: 3,
               }}
             >
-              <Box
-                component="img"
+              <img
                 src={SleepingReachy}
                 alt="Reachy Mini"
-                sx={{
-                  width: 160,
-                  height: 'auto',
-                  opacity: darkMode ? 0.8 : 0.9,
-                }}
+                style={{ width: '100%', height: '100%', objectFit: 'contain' }}
               />
             </Box>
             <Typography
@@ -446,11 +420,7 @@ export default function PermissionsRequiredView({ isRestarting: externalIsRestar
               Restarting...
             </Typography>
             <Typography
-              variant="body2"
-              sx={{
-                color: darkMode ? '#aaa' : '#666',
-                mb: 3,
-              }}
+              sx={{ fontSize: 12, color: darkMode ? '#888' : '#666', textAlign: 'center', mb: 2.5 }}
             >
               All permissions granted. The app will restart in a moment.
             </Typography>
@@ -460,20 +430,18 @@ export default function PermissionsRequiredView({ isRestarting: externalIsRestar
             {/* Normal permissions view */}
             <Box
               sx={{
+                width: 140,
+                height: 140,
+                mb: 2,
                 display: 'flex',
+                alignItems: 'center',
                 justifyContent: 'center',
-                mb: 3,
               }}
             >
-              <Box
-                component="img"
+              <img
                 src={LockedReachy}
                 alt="Reachy Mini"
-                sx={{
-                  width: 160,
-                  height: 'auto',
-                  opacity: darkMode ? 0.8 : 0.9,
-                }}
+                style={{ width: '100%', height: '100%', objectFit: 'contain' }}
               />
             </Box>
 
@@ -490,51 +458,55 @@ export default function PermissionsRequiredView({ isRestarting: externalIsRestar
             </Typography>
 
             <Typography
-              variant="body2"
-              sx={{
-                color: darkMode ? '#aaa' : '#666',
-                mb: 3,
-                lineHeight: 1.5,
-              }}
+              sx={{ fontSize: 12, color: darkMode ? '#888' : '#666', textAlign: 'center', mb: 2.5 }}
             >
-              <Box component="span" sx={{ fontWeight: 600 }}>
-                Reachy
-              </Box>{' '}
-              requires{' '}
-              <Box component="span" sx={{ fontWeight: 600 }}>
-                access
-              </Box>{' '}
-              to your{' '}
-              <Box component="span" sx={{ fontWeight: 600 }}>
-                camera
-              </Box>{' '}
-              and{' '}
-              <Box component="span" sx={{ fontWeight: 600 }}>
-                microphone
-              </Box>{' '}
-              to function properly.
+              Grant permissions to use Reachy
             </Typography>
 
-            <Stack direction="row" spacing={2} sx={{ mb: 3, width: '100%' }}>
+            {/* Permission cards - 2 square cards */}
+            <Box
+              sx={{
+                display: 'flex',
+                justifyContent: 'center',
+                gap: 1.5,
+                width: '100%',
+                maxWidth: 280,
+                mb: 2.5,
+              }}
+            >
               <PermissionCard
                 icon={CameraAltOutlinedIcon}
-                title="Camera"
+                label="Camera"
+                subtitle={cameraGranted ? 'Granted' : 'Required'}
                 granted={cameraGranted}
-                requested={state.cameraRequested}
-                onRequest={() => requestPermission('camera')}
-                onOpenSettings={() => openSettings('camera')}
+                onClick={() => {
+                  if (!cameraGranted) {
+                    state.cameraRequested ? openSettings('camera') : requestPermission('camera');
+                  }
+                }}
                 darkMode={darkMode}
               />
+
               <PermissionCard
                 icon={MicNoneOutlinedIcon}
-                title="Microphone"
+                label="Microphone"
+                subtitle={microphoneGranted ? 'Granted' : 'Required'}
                 granted={microphoneGranted}
-                requested={state.microphoneRequested}
-                onRequest={() => requestPermission('microphone')}
-                onOpenSettings={() => openSettings('microphone')}
+                onClick={() => {
+                  if (!microphoneGranted) {
+                    state.microphoneRequested
+                      ? openSettings('microphone')
+                      : requestPermission('microphone');
+                  }
+                }}
                 darkMode={darkMode}
               />
-            </Stack>
+            </Box>
+
+            {/* Helper text */}
+            <Typography sx={{ fontSize: 11, color: darkMode ? '#555' : '#aaa' }}>
+              Click on a card to grant access
+            </Typography>
           </>
         )}
       </Box>

--- a/uv-wrapper/src/bin/uv-bundle.rs
+++ b/uv-wrapper/src/bin/uv-bundle.rs
@@ -70,13 +70,53 @@ fn main() {
     ))
     .expect("Failed to install python");
 
-    // Creating a venv
+    // Creating a venv with --relocatable to avoid hardcoded paths
     #[cfg(not(target_os = "windows"))]
-    run_command("UV_PYTHON_INSTALL_DIR=. UV_WORKING_DIR=. ./uv venv")
+    run_command("UV_PYTHON_INSTALL_DIR=. UV_WORKING_DIR=. ./uv venv --relocatable")
         .expect("Failed to create virtual environment");
     #[cfg(target_os = "windows")]
-    run_command("$env:UV_PYTHON_INSTALL_DIR = '.'; $env:UV_WORKING_DIR = '.'; ./uv.exe venv")
+    run_command("$env:UV_PYTHON_INSTALL_DIR = '.'; $env:UV_WORKING_DIR = '.'; ./uv.exe venv --relocatable")
         .expect("Failed to create virtual environment");
+
+    // Copy libpython to .venv/lib/ so the venv is fully self-contained
+    // This allows us to NOT bundle the entire cpython folder
+    #[cfg(target_os = "macos")]
+    {
+        // Find cpython folder and copy libpython3.12.dylib
+        let cpython_lib = std::fs::read_dir(".")
+            .expect("Failed to read current directory")
+            .filter_map(|e| e.ok())
+            .find(|e| e.file_name().to_string_lossy().starts_with("cpython-"))
+            .map(|e| e.path().join("lib").join("libpython3.12.dylib"));
+        
+        if let Some(src_lib) = cpython_lib {
+            if src_lib.exists() {
+                let dst_lib = std::path::Path::new(".venv/lib/libpython3.12.dylib");
+                std::fs::create_dir_all(".venv/lib").expect("Failed to create .venv/lib");
+                std::fs::copy(&src_lib, dst_lib).expect("Failed to copy libpython3.12.dylib");
+                println!("✅ Copied libpython3.12.dylib to .venv/lib/");
+            }
+        }
+    }
+    
+    #[cfg(target_os = "linux")]
+    {
+        // Find cpython folder and copy libpython3.12.so
+        let cpython_lib = std::fs::read_dir(".")
+            .expect("Failed to read current directory")
+            .filter_map(|e| e.ok())
+            .find(|e| e.file_name().to_string_lossy().starts_with("cpython-"))
+            .map(|e| e.path().join("lib").join("libpython3.12.so.1.0"));
+        
+        if let Some(src_lib) = cpython_lib {
+            if src_lib.exists() {
+                let dst_lib = std::path::Path::new(".venv/lib/libpython3.12.so.1.0");
+                std::fs::create_dir_all(".venv/lib").expect("Failed to create .venv/lib");
+                std::fs::copy(&src_lib, dst_lib).expect("Failed to copy libpython3.12.so");
+                println!("✅ Copied libpython3.12.so to .venv/lib/");
+            }
+        }
+    }
 
     // Installing dependencies
     if !args.dependencies.is_empty() {

--- a/uv-wrapper/src/bin/uv-trampoline.rs
+++ b/uv-wrapper/src/bin/uv-trampoline.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use std::process::{Command, ExitCode};
 use std::fs;
 
-use uv_wrapper::{find_cpython_folder, lookup_bin_folder, patching_pyvenv_cfg};
+use uv_wrapper::lookup_bin_folder;
 
 #[cfg(target_os = "windows")]
 use uv_wrapper::{get_local_app_data_dir, is_program_files_path, setup_local_venv_windows};
@@ -44,7 +44,7 @@ fn get_possible_bin_folders() -> Vec<&'static str> {
     //   ├── uv-trampoline-*.exe  (sidecar)
     //   ├── uv.exe               (resource)
     //   ├── .venv/               (resource)
-    //   └── cpython-*/           (resource)
+    //   └── .venv/               (resource, self-contained with --relocatable)
     //
     // BUT: Program Files is read-only, so we copy to %LOCALAPPDATA%\Reachy Mini Control\
     // The local copy has patched pyvenv.cfg with correct paths
@@ -329,7 +329,7 @@ fn main() -> ExitCode {
     };
     
     // On Windows, if we're running from Program Files, setup local venv first
-    // This copies .venv and cpython to %LOCALAPPDATA% where we can write
+    // This copies .venv to %LOCALAPPDATA% where we can write
     #[cfg(target_os = "windows")]
     {
         let exe_dir = env::current_exe()
@@ -352,7 +352,7 @@ fn main() -> ExitCode {
     }
     
     // On Linux, if running from /usr/lib/, copy venv to ~/.local/share/
-    // This copies .venv and cpython to XDG_DATA_HOME where we can write
+    // This copies .venv to XDG_DATA_HOME where we can write
     #[cfg(target_os = "linux")]
     {
         let exe_dir = env::current_exe()
@@ -400,31 +400,9 @@ fn main() -> ExitCode {
     }
 
     println!("📂 Running from {:?}", uv_folder);
-
-    let cpython_folder = match find_cpython_folder(&uv_folder) {
-        Ok(folder) => folder,
-        Err(e) => {
-            eprintln!("❌ Error: Unable to find cpython folder: {}", e);
-            return ExitCode::FAILURE;
-        }
-    };
     
-    if let Err(e) = patching_pyvenv_cfg(&uv_folder, &cpython_folder) {
-        // Check if this is an AppTranslocation error
-        if e.contains("APP_TRANSLOCATION_ERROR") {
-            eprintln!("❌ AppTranslocation Error: {}", e);
-            eprintln!("");
-            eprintln!("📱 Please move the app to the Applications folder:");
-            eprintln!("   1. Open Finder");
-            eprintln!("   2. Drag 'Reachy Mini Control.app' to Applications");
-            eprintln!("   3. Launch from Applications");
-            eprintln!("");
-            eprintln!("This is required because macOS isolates apps downloaded from the internet.");
-            return ExitCode::FAILURE;
-        }
-        eprintln!("⚠️  Warning: Unable to patch pyvenv.cfg: {}", e);
-        // Continue anyway, this is not fatal
-    }
+    // Note: With --relocatable venv, we no longer need to find cpython or patch pyvenv.cfg
+    // The venv is self-contained and works from any location
     
     // Get the absolute working directory for environment variables
     let working_dir = match env::current_dir() {

--- a/uv-wrapper/src/lib.rs
+++ b/uv-wrapper/src/lib.rs
@@ -92,31 +92,19 @@ pub fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> Resul
 
 /// Setup local venv on Windows by copying from Program Files to %LOCALAPPDATA%
 /// Returns the local directory path if setup was successful or already done
+/// Note: With --relocatable venv, we no longer need cpython or pyvenv.cfg patching
 #[cfg(target_os = "windows")]
 pub fn setup_local_venv_windows(program_files_dir: &std::path::Path) -> Result<PathBuf, String> {
     let local_dir = get_local_app_data_dir()
         .ok_or_else(|| "LOCALAPPDATA environment variable not set".to_string())?;
     
-    // Check if local venv already exists and is valid
+    // Check if local venv already exists
     let local_venv = local_dir.join(".venv");
-    let local_pyvenv_cfg = local_venv.join("pyvenv.cfg");
+    let local_python = local_venv.join("Scripts").join("python.exe");
     
-    if local_pyvenv_cfg.exists() {
-        // Check if the pyvenv.cfg points to a valid cpython
-        let content = fs::read_to_string(&local_pyvenv_cfg)
-            .map_err(|e| format!("Failed to read local pyvenv.cfg: {}", e))?;
-        
-        // Check if home path exists
-        for line in content.lines() {
-            if line.starts_with("home = ") {
-                let home_path = line.trim_start_matches("home = ");
-                if std::path::Path::new(home_path).exists() {
-                    println!("✅ Local venv already configured at {:?}", local_dir);
-                    return Ok(local_dir);
-                }
-            }
-        }
-        println!("⚠️  Local venv exists but has invalid paths, reconfiguring...");
+    if local_python.exists() {
+        println!("✅ Local venv already configured at {:?}", local_dir);
+        return Ok(local_dir);
     }
     
     println!("📦 Setting up local Python environment...");
@@ -127,7 +115,7 @@ pub fn setup_local_venv_windows(program_files_dir: &std::path::Path) -> Result<P
     fs::create_dir_all(&local_dir)
         .map_err(|e| format!("Failed to create local directory: {}", e))?;
     
-    // Copy .venv
+    // Copy .venv (self-contained with --relocatable)
     let src_venv = program_files_dir.join(".venv");
     if src_venv.exists() {
         println!("   📁 Copying .venv...");
@@ -142,23 +130,6 @@ pub fn setup_local_venv_windows(program_files_dir: &std::path::Path) -> Result<P
         return Err(format!(".venv not found at {:?}", src_venv));
     }
     
-    // Copy cpython folder
-    let cpython_folder = find_cpython_folder(program_files_dir)?;
-    let src_cpython = program_files_dir.join(&cpython_folder);
-    let dst_cpython = local_dir.join(&cpython_folder);
-    
-    if src_cpython.exists() {
-        println!("   📁 Copying {}...", cpython_folder);
-        if dst_cpython.exists() {
-            fs::remove_dir_all(&dst_cpython)
-                .map_err(|e| format!("Failed to remove old cpython: {}", e))?;
-        }
-        copy_dir_recursive(&src_cpython, &dst_cpython)?;
-        println!("   ✅ {} copied", cpython_folder);
-    } else {
-        return Err(format!("cpython folder not found at {:?}", src_cpython));
-    }
-    
     // Copy uv.exe and uvx.exe
     for exe in &["uv.exe", "uvx.exe"] {
         let src_exe = program_files_dir.join(exe);
@@ -169,11 +140,6 @@ pub fn setup_local_venv_windows(program_files_dir: &std::path::Path) -> Result<P
             println!("   ✅ {} copied", exe);
         }
     }
-    
-    // Patch pyvenv.cfg with local paths
-    println!("   🔧 Patching pyvenv.cfg...");
-    patching_pyvenv_cfg(&local_dir, &cpython_folder)?;
-    println!("   ✅ pyvenv.cfg patched");
     
     println!("✅ Local Python environment ready at {:?}", local_dir);
     Ok(local_dir)
@@ -186,31 +152,19 @@ pub fn setup_local_venv_windows(_program_files_dir: &std::path::Path) -> Result<
 
 /// Setup local venv on Linux by copying from /usr/lib/ to ~/.local/share/
 /// Returns the local directory path if setup was successful or already done
+/// Note: With --relocatable venv, we no longer need cpython or pyvenv.cfg patching
 #[cfg(target_os = "linux")]
 pub fn setup_local_venv_linux(system_lib_dir: &std::path::Path) -> Result<PathBuf, String> {
     let local_dir = get_xdg_data_home()
         .ok_or_else(|| "HOME environment variable not set".to_string())?;
     
-    // Check if local venv already exists and is valid
+    // Check if local venv already exists
     let local_venv = local_dir.join(".venv");
-    let local_pyvenv_cfg = local_venv.join("pyvenv.cfg");
+    let local_python = local_venv.join("bin").join("python3");
     
-    if local_pyvenv_cfg.exists() {
-        // Check if the pyvenv.cfg points to a valid cpython
-        let content = fs::read_to_string(&local_pyvenv_cfg)
-            .map_err(|e| format!("Failed to read local pyvenv.cfg: {}", e))?;
-        
-        // Check if home path exists
-        for line in content.lines() {
-            if line.starts_with("home = ") {
-                let home_path = line.trim_start_matches("home = ");
-                if std::path::Path::new(home_path).exists() {
-                    println!("✅ Local venv already configured at {:?}", local_dir);
-                    return Ok(local_dir);
-                }
-            }
-        }
-        println!("⚠️  Local venv exists but has invalid paths, reconfiguring...");
+    if local_python.exists() {
+        println!("✅ Local venv already configured at {:?}", local_dir);
+        return Ok(local_dir);
     }
     
     println!("📦 Setting up local Python environment...");
@@ -221,7 +175,7 @@ pub fn setup_local_venv_linux(system_lib_dir: &std::path::Path) -> Result<PathBu
     fs::create_dir_all(&local_dir)
         .map_err(|e| format!("Failed to create local directory: {}", e))?;
     
-    // Copy .venv
+    // Copy .venv (self-contained with --relocatable)
     let src_venv = system_lib_dir.join(".venv");
     if src_venv.exists() {
         println!("   📁 Copying .venv...");
@@ -234,23 +188,6 @@ pub fn setup_local_venv_linux(system_lib_dir: &std::path::Path) -> Result<PathBu
         println!("   ✅ .venv copied");
     } else {
         return Err(format!(".venv not found at {:?}", src_venv));
-    }
-    
-    // Copy cpython folder
-    let cpython_folder = find_cpython_folder(system_lib_dir)?;
-    let src_cpython = system_lib_dir.join(&cpython_folder);
-    let dst_cpython = local_dir.join(&cpython_folder);
-    
-    if src_cpython.exists() {
-        println!("   📁 Copying {}...", cpython_folder);
-        if dst_cpython.exists() {
-            fs::remove_dir_all(&dst_cpython)
-                .map_err(|e| format!("Failed to remove old cpython: {}", e))?;
-        }
-        copy_dir_recursive(&src_cpython, &dst_cpython)?;
-        println!("   ✅ {} copied", cpython_folder);
-    } else {
-        return Err(format!("cpython folder not found at {:?}", src_cpython));
     }
     
     // Copy uv and uvx binaries
@@ -274,11 +211,6 @@ pub fn setup_local_venv_linux(system_lib_dir: &std::path::Path) -> Result<PathBu
             println!("   ✅ {} copied", bin);
         }
     }
-    
-    // Patch pyvenv.cfg with local paths
-    println!("   🔧 Patching pyvenv.cfg...");
-    patching_pyvenv_cfg(&local_dir, &cpython_folder)?;
-    println!("   ✅ pyvenv.cfg patched");
     
     println!("✅ Local Python environment ready at {:?}", local_dir);
     Ok(local_dir)
@@ -351,87 +283,6 @@ pub fn run_command(cmd: &str) -> Result<std::process::ExitStatus, std::io::Error
     Ok(status)
 }
 
-pub fn find_cpython_folder(uv_folder: &std::path::Path) -> Result<String, String> {
-    let entries = std::fs::read_dir(uv_folder)
-        .map_err(|e| format!("Unable to read uv folder for cpython lookup: {}", e))?;
-
-    for entry in entries {
-        let entry = entry
-            .map_err(|e| format!("Unable to read entry in uv folder: {}", e))?;
-        let file_name = entry.file_name();
-        let file_name_str = file_name.to_string_lossy();
-
-        if file_name_str.starts_with("cpython-") && entry.path().is_dir() {
-            return Ok(file_name_str.to_string());
-        }
-    }
-
-    Err(format!(
-        "Unable to find cpython folder in {:?}",
-        uv_folder
-    ))
-}
-
-/// Check if the current path is in AppTranslocation (macOS security feature)
-#[cfg(target_os = "macos")]
-pub fn is_app_translocation_path(path: &std::path::Path) -> bool {
-    path.to_string_lossy().contains("AppTranslocation")
-}
-
-#[cfg(not(target_os = "macos"))]
-pub fn is_app_translocation_path(_path: &std::path::Path) -> bool {
-    false
-}
-
-pub fn patching_pyvenv_cfg(uv_folder: &std::path::Path, cpython_folder: &str) -> Result<(), String> {
-    let pyvenv_cfg_path = uv_folder.join(".venv").join("pyvenv.cfg");
-    
-    // Check if file exists before trying to patch it
-    if !pyvenv_cfg_path.exists() {
-        return Err(format!(
-            "pyvenv.cfg file does not exist at {:?}",
-            pyvenv_cfg_path
-        ));
-    }
-    
-    println!("🔧 Patching pyvenv.cfg at {:?}", pyvenv_cfg_path);
-
-    let content = std::fs::read_to_string(&pyvenv_cfg_path)
-        .map_err(|e| format!("Unable to read pyvenv.cfg for patching: {}", e))?;
-
-    #[cfg(target_os = "windows")]
-    let home = uv_folder.join(cpython_folder);
-    #[cfg(not(target_os = "windows"))]
-    let home = uv_folder.join(cpython_folder).join("bin");
-
-    let new_content = content
-        .lines()
-        .map(|line| {
-            if line.starts_with("home = ") {
-                format!("home = {}", home.display())
-            } else {
-                line.to_string()
-            }
-        })
-        .collect::<Vec<String>>()
-        .join("\n");
-
-    // Try to write the patched file
-    match std::fs::write(&pyvenv_cfg_path, new_content) {
-        Ok(_) => Ok(()),
-        Err(e) => {
-            let error_msg = format!("Unable to write patched pyvenv.cfg: {}", e);
-    
-            // Check if we're in AppTranslocation and the error is read-only
-            #[cfg(target_os = "macos")]
-            {
-                if is_app_translocation_path(uv_folder) && error_msg.contains("Read-only") {
-                    return Err(format!("APP_TRANSLOCATION_ERROR: {}", error_msg));
-                }
-            }
-            
-            Err(error_msg)
-        }
-    }
-}
+// Note: find_cpython_folder and patching_pyvenv_cfg have been removed
+// With --relocatable venv, the venv is self-contained and doesn't need cpython or patching
 


### PR DESCRIPTION
## Summary
- **Python Bundle Optimization**: Use `--relocatable` venv to make it self-contained, removing the need for separate cpython folder (~100MB saved)
- **Permissions Cleanup**: Remove Files permission card (not needed), simplify reset script to Camera + Microphone only

## Test plan
- [ ] Test `yarn build:sidecar-macos` creates working venv
- [ ] Test permissions view shows only Camera + Microphone cards
- [ ] Test `yarn reset-permissions` resets only Camera/Microphone
- [ ] Test app launches correctly on macOS