### PR TITLE
Release 0.9.3

### DIFF
--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -116,7 +116,60 @@ jobs:
         run: |
           TARGET_TRIPLET=${{ matrix.target }} bash ./scripts/build/build-sidecar-unix.sh || echo "Sidecar build skipped"
 
-      # Note: cpython steps removed - venv is now self-contained with --relocatable
+      - name: Update macOS resources config with cpython folder name
+        if: startsWith(matrix.os, 'macos')
+        shell: bash
+        run: |
+          # Find the actual cpython folder name created by uv-bundle
+          CPYTHON_FOLDER=$(ls -d src-tauri/binaries/cpython-* 2>/dev/null | head -1 | xargs basename || echo "")
+          
+          if [ -z "$CPYTHON_FOLDER" ]; then
+            echo "⚠️  No cpython folder found in src-tauri/binaries/, skipping config update"
+            exit 0
+          fi
+          
+          echo "🔧 Found cpython folder: $CPYTHON_FOLDER"
+          echo "   Updating tauri.macos.conf.json..."
+          
+          # Update the tauri.macos.conf.json with the exact cpython folder name
+          # The config has hardcoded aarch64 path, we need to replace it with the actual folder
+          sed -i '' "s|cpython-3.12[^\"]*|$CPYTHON_FOLDER|g" src-tauri/tauri.macos.conf.json
+          
+          echo "✅ Updated tauri.macos.conf.json:"
+          cat src-tauri/tauri.macos.conf.json
+          
+          # Verify the binaries directory contents
+          echo ""
+          echo "📦 Contents of src-tauri/binaries/:"
+          ls -la src-tauri/binaries/
+
+      - name: Update Linux resources config with cpython folder name
+        if: matrix.os == 'ubuntu-22.04'
+        shell: bash
+        run: |
+          # Find the actual cpython folder name created by uv-bundle
+          CPYTHON_FOLDER=$(ls -d src-tauri/binaries/cpython-* 2>/dev/null | head -1 | xargs basename || echo "")
+          
+          if [ -z "$CPYTHON_FOLDER" ]; then
+            echo "⚠️  No cpython folder found in src-tauri/binaries/, skipping config update"
+            exit 0
+          fi
+          
+          echo "🔧 Found cpython folder: $CPYTHON_FOLDER"
+          echo "   Updating tauri.linux.conf.json..."
+          
+          # Update the tauri.linux.conf.json with the exact cpython folder name
+          # Replace glob patterns with the actual folder name using sed
+          sed -i "s|cpython-3.12\*-linux-x86_64\*|$CPYTHON_FOLDER|g" src-tauri/tauri.linux.conf.json
+          sed -i "s|cpython-3.12-linux-x86_64|$CPYTHON_FOLDER|g" src-tauri/tauri.linux.conf.json
+          
+          echo "✅ Updated tauri.linux.conf.json:"
+          cat src-tauri/tauri.linux.conf.json
+          
+          # Verify the binaries directory contents
+          echo ""
+          echo "📦 Contents of src-tauri/binaries/:"
+          ls -la src-tauri/binaries/
 
       - name: Build sidecar (Windows)
         if: matrix.os == 'windows-latest'
@@ -188,6 +241,32 @@ jobs:
             Write-Host "❌ ERROR: site-packages directory not found!"
             exit 1
           }
+
+      - name: Update Windows resources config with cpython folder name
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          # Find the actual cpython folder name created by uv-bundle
+          $CPYTHON_FOLDER = (Get-ChildItem -Directory "src-tauri/binaries/cpython-*" -ErrorAction SilentlyContinue | Select-Object -First 1).Name
+          
+          if (-not $CPYTHON_FOLDER) {
+            Write-Host "❌ No cpython folder found in src-tauri/binaries/"
+            Write-Host "   This is required for Windows build"
+            Get-ChildItem src-tauri/binaries/ -ErrorAction SilentlyContinue
+            exit 1
+          }
+          
+          Write-Host "🔧 Found cpython folder: $CPYTHON_FOLDER"
+          Write-Host "   Updating tauri.windows.conf.json..."
+          
+          # Update the tauri.windows.conf.json with the exact cpython folder name
+          $content = Get-Content src-tauri/tauri.windows.conf.json -Raw
+          $content = $content -replace 'cpython-3\.12\*-windows-x86_64\*', $CPYTHON_FOLDER
+          $content = $content -replace 'cpython-3\.12-windows-x86_64', $CPYTHON_FOLDER
+          $content | Set-Content src-tauri/tauri.windows.conf.json
+          
+          Write-Host "✅ Updated tauri.windows.conf.json:"
+          Get-Content src-tauri/tauri.windows.conf.json
 
       - name: Setup Apple Code Signing (macOS only)
         if: startsWith(matrix.os, 'macos')

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -3,7 +3,9 @@
     "resources": {
       "binaries/uv": "uv",
       "binaries/uvx": "uvx",
-      "binaries/.venv": ".venv"
+      "binaries/.venv": ".venv",
+      "binaries/cpython-3.12*-linux-x86_64*": "cpython-3.12-linux-x86_64",
+      "binaries/cpython-3.12*-linux-x86_64*/lib": ".venv/lib"
     },
     "linux": {
       "deb": {
@@ -15,3 +17,4 @@
     }
   }
 }
+

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -4,6 +4,8 @@
       "binaries/uv": "uv",
       "binaries/uvx": "uvx",
       "binaries/.venv": ".venv",
+      "binaries/cpython-3.12.12-macos-aarch64-none": "cpython-3.12.12-macos-aarch64-none",
+      "binaries/cpython-3.12.12-macos-aarch64-none/lib": ".venv/lib",
       "python-entitlements.plist": "python-entitlements.plist"
     },
     "macOS": {
@@ -16,3 +18,4 @@
     }
   }
 }
+

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -4,7 +4,9 @@
       "binaries/uv.exe": "uv.exe",
       "binaries/uvx.exe": "uvx.exe",
       "binaries/.venv": ".venv",
-      "binaries/.venv/*": ".venv/"
+      "binaries/.venv/*": ".venv/",
+      "binaries/cpython-3.12.12-windows-x86_64-none": "cpython-3.12-windows-x86_64",
+      "binaries/cpython-3.12.12-windows-x86_64-none/*": "cpython-3.12-windows-x86_64/"
     },
     "windows": {
       "certificateThumbprint": null,
@@ -13,3 +15,4 @@
     }
   }
 }
+

--- a/src/views/update/UpdateView.jsx
+++ b/src/views/update/UpdateView.jsx
@@ -329,8 +329,8 @@ export default function UpdateView({
       </Box>
 
       {/* Internet connectivity indicator - discrete pastille above logs */}
-      {/* Only display after first check is complete */}
-      {hasInternetChecked && (
+      {/* Only display during initial check, hide when update is being downloaded */}
+      {hasInternetChecked && !updateAvailable && !isDownloading && (
         <Box
           sx={{
             position: 'absolute',


### PR DESCRIPTION
## Summary
Release 0.9.3 - Critical fix for daemon startup

### 🐛 Bug Fixes
- **Fix daemon crash**: Restore cpython bundling (stdlib is required for Python to start)
- **Fix UpdateView**: Hide online indicator during update download

### 🔧 Technical
- Revert relocatable venv optimization (doesn't work without stdlib)
- Keep Intel macOS signing fix from 0.9.2