### PR TITLE
fix(ci): correct sed regex to preserve /lib suffix

### DIFF
--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -133,7 +133,8 @@ jobs:
           
           # Update the tauri.macos.conf.json with the exact cpython folder name
           # The config has hardcoded aarch64 path, we need to replace it with the actual folder
-          sed -i '' "s|cpython-3.12[^\"]*|$CPYTHON_FOLDER|g" src-tauri/tauri.macos.conf.json
+          # IMPORTANT: Only replace the exact folder name, not /lib suffix
+          sed -i '' "s|cpython-3.12.12-macos-aarch64-none|$CPYTHON_FOLDER|g" src-tauri/tauri.macos.conf.json
           
           echo "✅ Updated tauri.macos.conf.json:"
           cat src-tauri/tauri.macos.conf.json


### PR DESCRIPTION
## Summary
Fix the sed regex that was breaking cpython bundling in CI.

**Bug**: `cpython-3.12[^"]*` matched too much, including `/lib`, causing:
- `binaries/cpython.../lib` → `binaries/cpython...` (no /lib!)
- Duplicate JSON keys (invalid)
- cpython folder not bundled correctly

**Fix**: Use exact match `cpython-3.12.12-macos-aarch64-none`

## Test
```bash
# Before (broken)
sed "s|cpython-3.12[^\"]*|NEW|g"
# binaries/cpython-old/lib → binaries/NEW  ❌

# After (fixed)  
sed "s|cpython-3.12.12-macos-aarch64-none|NEW|g"
# binaries/cpython-old/lib → binaries/NEW/lib  ✅
```