### PR TITLE
Release 0.9.4

### DIFF
--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -133,7 +133,8 @@ jobs:
           
           # Update the tauri.macos.conf.json with the exact cpython folder name
           # The config has hardcoded aarch64 path, we need to replace it with the actual folder
-          sed -i '' "s|cpython-3.12[^\"]*|$CPYTHON_FOLDER|g" src-tauri/tauri.macos.conf.json
+          # IMPORTANT: Only replace the exact folder name, not /lib suffix
+          sed -i '' "s|cpython-3.12.12-macos-aarch64-none|$CPYTHON_FOLDER|g" src-tauri/tauri.macos.conf.json
           
           echo "✅ Updated tauri.macos.conf.json:"
           cat src-tauri/tauri.macos.conf.json


### PR DESCRIPTION
## Summary
Release 0.9.4 - Fix cpython bundling in CI

### 🐛 Bug Fix
- **Fix cpython bundling**: The sed regex was breaking the /lib path, preventing cpython from being bundled correctly

This fixes the "Unable to find cpython folder" error in 0.9.3.