### PR TITLE
feat: preload expressions datasets at daemon startup

### DIFF
--- a/src-tauri/src/python/mod.rs
+++ b/src-tauri/src/python/mod.rs
@@ -15,6 +15,7 @@ pub fn build_daemon_args(sim_mode: bool) -> Result<Vec<String>, String> {
         "reachy_mini.daemon.app.main".to_string(),
         "--desktop-app-daemon".to_string(),
         "--no-wake-up-on-start".to_string(), // Robot starts sleeping, toggle controls wake
+        "--preload-datasets".to_string(),    // Pre-download emotions/dances at startup
     ];
     
     if sim_mode {


### PR DESCRIPTION
## Summary
Add `--preload-datasets` flag to daemon startup to pre-download emotions and dances at startup.

This improves UX by having expressions ready to use immediately.

## Changes
- Add `--preload-datasets` argument in `build_daemon_args()`