### PR TITLE
fix: Prevent false daemon crashes when window loses focus

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,7 +23,8 @@
         "transparent": false,
         "hiddenTitle": true,
         "titleBarStyle": "Transparent",
-        "devtools": true
+        "devtools": true,
+        "backgroundThrottling": "disabled"
       }
     ],
     "security": {


### PR DESCRIPTION
## 🐛 Problème

En production, quand l'utilisateur minimise la fenêtre ou perd le focus sur l'application, des **faux crashes** sont détectés alors que le daemon fonctionne correctement.

**Cause** : Les WebViews (Chromium/WebKit) throttlent les timers et requêtes réseau quand une fenêtre est en arrière-plan. Les health checks timeout → 3 timeouts consécutifs → crash détecté 💥

## ✅ Solution Multi-Couches

### 1️⃣ Solution Native (macOS 14+)
- Ajout de `"backgroundThrottling": "disabled"` dans `tauri.conf.json`
- Désactive le throttling nativement sur macOS Sonoma et plus récent
- ⚠️ Non supporté sur Windows/Linux

### 2️⃣ Fallback JavaScript (toutes plateformes)
- Track `document.visibilityState` pour détecter si la fenêtre est cachée
- **Pause** le health check polling quand `hidden`
- **Reset** le compteur de timeouts au retour (`visible`)
- Listeners sur `visibilitychange` + `blur/focus` pour tous les cas edge
- **Critique pour Windows/Linux** où le throttling natif ne peut pas être désactivé

### 3️⃣ Protection Wake/Sleep (existante)
- Garde la protection `isWakeSleepTransitioning` pour les animations

## 📊 Résultat Attendu

| Scénario | macOS 14+ | macOS < 14 | Windows/Linux |
|----------|-----------|------------|---------------|
| Fenêtre visible | ✅ Polling normal | ✅ Polling normal | ✅ Polling normal |
| Fenêtre minimisée | ✅ Continue (natif) | ⏸️ Pause (JS) + reset au retour | ⏸️ Pause (JS) + reset au retour |
| Wake/Sleep | ⏸️ Pause | ⏸️ Pause | ⏸️ Pause |

**Plus de faux crashes ! 🎉**

## 🧪 Test Plan

- [ ] macOS : Minimiser la fenêtre 30s+ → revenir → daemon toujours actif
- [ ] macOS : Changer d'app (Cmd+Tab) 30s+ → revenir → daemon toujours actif
- [ ] Windows : Minimiser la fenêtre 30s+ → revenir → daemon toujours actif
- [ ] Linux : Minimiser la fenêtre 30s+ → revenir → daemon toujours actif
- [ ] Vérifier les logs console : messages "👁️ Window hidden/visible" sur Windows/Linux
- [ ] macOS 14+ : Les messages 👁️ ne devraient pas apparaître (throttling désactivé nativement)

## 📝 Changements

- **src-tauri/tauri.conf.json** : Ajout `backgroundThrottling: "disabled"`
- **src/hooks/daemon/useDaemonHealthCheck.js** : Ajout window visibility tracking + pause logic

## 🔗 Références

- [Tauri backgroundThrottling docs](https://docs.rs/tauri-utils/latest/tauri_utils/config/struct.WindowConfig.html)
- [MDN Page Visibility API](https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API)