### PR TITLE
fix(windows): copy scripts folder to local venv directory

### DIFF
--- a/uv-wrapper/src/lib.rs
+++ b/uv-wrapper/src/lib.rs
@@ -170,6 +170,19 @@ pub fn setup_local_venv_windows(program_files_dir: &std::path::Path) -> Result<P
         }
     }
     
+    // Copy scripts folder (contains avast_ssl_fix.py for Windows)
+    let src_scripts = program_files_dir.join("scripts");
+    let dst_scripts = local_dir.join("scripts");
+    if src_scripts.exists() {
+        println!("   📁 Copying scripts...");
+        if dst_scripts.exists() {
+            fs::remove_dir_all(&dst_scripts)
+                .map_err(|e| format!("Failed to remove old scripts: {}", e))?;
+        }
+        copy_dir_recursive(&src_scripts, &dst_scripts)?;
+        println!("   ✅ scripts copied");
+    }
+    
     // Patch pyvenv.cfg with local paths
     println!("   🔧 Patching pyvenv.cfg...");
     patching_pyvenv_cfg(&local_dir, &cpython_folder)?;


### PR DESCRIPTION
## Problem

When the Reachy Mini Control app is installed to `C:\Program Files\` on Windows, it needs to copy Python environment files to `%LOCALAPPDATA%\Reachy Mini Control\` because Program Files is read-only. However, the `scripts/` folder (containing `avast_ssl_fix.py`) was not being copied during this setup process.

This caused the Control App to fail when starting the daemon with the error:

`scripts\avast_ssl_fix.py [Errno 2] No such file or directory`


The daemon startup process requires `avast_ssl_fix.py` to prevent Avast antivirus SSL injection issues on Windows.

## Solution

Added the `scripts/` folder to the copy operation in `setup_local_venv_windows()`. The function now copies:
- `.venv/` folder
- `cpython-*/` folder
- `uv.exe` and `uvx.exe`
- **`scripts/` folder** (NEW)

## Changes

- Modified `uv-wrapper/src/lib.rs` to include scripts folder copy in `setup_local_venv_windows()`
- The copy operation uses the existing `copy_dir_recursive()` helper function
- Includes proper error handling and informative console output

## Testing

To verify this fix:
1. Install the app to `C:\Program Files\Reachy Mini Control\`
2. Launch the Control App
3. Verify that the daemon starts successfully without the "No such file or directory" error
4. Check that `%LOCALAPPDATA%\Reachy Mini Control\scripts\avast_ssl_fix.py` exists

## Related

Fixes the issue where Windows users cannot start the daemon when the app is installed to Program Files.