### PR TITLE
Add zenoh port on port forwarding

### DIFF
--- a/src-tauri/src/local_proxy.rs
+++ b/src-tauri/src/local_proxy.rs
@@ -16,7 +16,7 @@ use tokio_tungstenite::tungstenite::handshake::server::{Request, Response};
 use futures_util::{StreamExt, SinkExt};
 
 /// Ports to proxy (local -> remote with same port)
-const PROXY_PORTS: &[u16] = &[8000, 8042];
+const PROXY_PORTS: &[u16] = &[8000, 8042, 7447];
 
 /// Shared state for the proxy
 pub struct LocalProxyState {


### PR DESCRIPTION
This PR makes it possible to connect to Zenoh directly on `localhost:7447` instead of `reachy_mini.local`.

## Example

- Connect with Desktop App on Wifi
- Connect the daemon with:

```python
from reachy_mini import ReachyMini
mini = ReachyMini(connection_mode="localhost_only", media_backend="no_media")
```

## Fixes 

- Should help fix WSL Issue 