### PR TITLE
fix(rust): suppress compiler warnings

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,6 @@
+// Suppress warnings from objc crate's msg_send! macro (uses deprecated cfg checks)
+#![allow(unexpected_cfgs)]
+
 // Modules
 #[macro_use]
 mod daemon;

--- a/src-tauri/src/usb/monitor.rs
+++ b/src-tauri/src/usb/monitor.rs
@@ -3,6 +3,7 @@
 /// This module provides event-driven USB device detection using Windows WM_DEVICECHANGE messages.
 /// This completely eliminates the need for polling, preventing terminal flicker issues on Windows.
 
+#[cfg(target_os = "windows")]
 use std::sync::{Arc, Mutex};
 
 #[cfg(target_os = "windows")]
@@ -14,6 +15,7 @@ use windows::{
 };
 
 /// Shared state for USB device monitoring
+#[cfg(target_os = "windows")]
 pub struct UsbMonitorState {
     /// Current Reachy Mini port (VID:PID = 1a86:55d3)
     pub reachy_port: Option<String>,
@@ -21,6 +23,7 @@ pub struct UsbMonitorState {
     pub available_ports: Vec<serialport::SerialPortInfo>,
 }
 
+#[cfg(target_os = "windows")]
 impl UsbMonitorState {
     pub fn new() -> Self {
         UsbMonitorState {
@@ -89,12 +92,10 @@ pub fn get_reachy_port() -> Option<String> {
 }
 
 /// Force an immediate update of the USB device list
+#[cfg(target_os = "windows")]
 pub fn force_update() {
-    #[cfg(target_os = "windows")]
-    {
-        if let Ok(mut state) = USB_MONITOR.lock() {
-            state.update();
-        }
+    if let Ok(mut state) = USB_MONITOR.lock() {
+        state.update();
     }
 }
 


### PR DESCRIPTION
## Description

Cette PR supprime les warnings du compilateur Rust qui apparaissaient lors du build.

### Changements

- **`src-tauri/src/lib.rs`**: Ajout de `#![allow(unexpected_cfgs)]` au niveau du crate pour supprimer les warnings venant de la macro `msg_send!` du crate `objc` (version 0.2)

- **`src-tauri/src/usb/monitor.rs`**: 
  - Déplacement des imports `Arc` et `Mutex` sous `#[cfg(target_os = "windows")]`
  - Ajout de `#[cfg(target_os = "windows")]` à `UsbMonitorState` et son impl
  - Ajout de `#[cfg(target_os = "windows")]` à la fonction `force_update()`

### Warnings corrigés

- `unexpected cfg condition value: cargo-clippy` (6 occurrences) - warnings du crate objc
- `unused imports: Arc and Mutex`
- `struct UsbMonitorState is never constructed`
- `associated items new and update are never used`
- `function force_update is never used`

### Vérification

```
cargo check
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.12s
```

Aucun warning ! ✅