### PR TITLE
fix(telemetry): restore manual context merge for os property

### DIFF
--- a/src/utils/telemetry/index.js
+++ b/src/utils/telemetry/index.js
@@ -76,51 +76,46 @@ const getOSType = () => {
 };
 
 /**
+ * Global context to include in ALL events
+ * This replaces PostHog.register() which is NOT available in tauri-plugin-posthog-api
+ */
+let globalContext = {
+  os: getOSType(),
+  app_version: 'unknown',
+  daemon_version: 'unknown',
+};
+
+/**
  * Initialize telemetry context with app metadata
  * Should be called once at app startup
- * Uses PostHog.register() to set super properties sent with ALL events
  * @param {{ appVersion: string, daemonVersion?: string }} context
  */
 export const initTelemetry = async context => {
   try {
-    const os = getOSType();
-
-    // Register super properties (automatically included in ALL events)
-    const superProps = {
-      os,
+    globalContext = {
+      os: getOSType(),
       app_version: context.appVersion || 'unknown',
       daemon_version: context.daemonVersion || 'unknown',
     };
 
-    await PostHog.register(superProps);
-
     if (import.meta.env.DEV) {
-      console.log('[Telemetry] Super properties registered:', superProps);
+      console.log('[Telemetry] Context initialized:', globalContext);
     }
   } catch (error) {
     if (import.meta.env.DEV) {
-      console.warn('[Telemetry] Failed to register super properties:', error);
+      console.warn('[Telemetry] Failed to initialize context:', error);
     }
   }
 };
 
 /**
  * Update telemetry context (e.g., when daemon version becomes available)
- * Uses PostHog.register() to update super properties
  * @param {Object} updates - Context updates (e.g., { daemon_version: '1.2.8' })
  */
 export const updateTelemetryContext = async updates => {
-  try {
-    // Update super properties (will merge with existing)
-    await PostHog.register(updates);
-
-    if (import.meta.env.DEV) {
-      console.log('[Telemetry] Super properties updated:', updates);
-    }
-  } catch (error) {
-    if (import.meta.env.DEV) {
-      console.warn('[Telemetry] Failed to update super properties:', error);
-    }
+  globalContext = { ...globalContext, ...updates };
+  if (import.meta.env.DEV) {
+    console.log('[Telemetry] Context updated:', globalContext);
   }
 };
 
@@ -164,11 +159,16 @@ const track = async (event, props = {}) => {
   }
 
   try {
+    // Merge global context with event properties
+    // This is necessary because tauri-plugin-posthog-api doesn't support PostHog.register()
+    const propsWithContext = {
+      ...globalContext,
+      ...props,
+    };
+
     // Filter out undefined/null values
-    // Note: Super properties (os, app_version, daemon_version) are automatically
-    // added to every event by PostHog.register() - no need to merge manually
     const cleanProps = Object.fromEntries(
-      Object.entries(props).filter(([_, v]) => v !== undefined && v !== null)
+      Object.entries(propsWithContext).filter(([_, v]) => v !== undefined && v !== null)
     );
 
     await PostHog.capture(event, cleanProps);


### PR DESCRIPTION
## Problem

The refactor in commit d538fc72a (Jan 15, 2026) broke telemetry by using `PostHog.register()` to set super properties.

**However, `tauri-plugin-posthog-api` v0.2.2 does NOT support the `register()` method!**

The available methods are: `capture`, `identify`, `alias`, `reset`, `getDistinctId`, `groupIdentify`, `setPersonProperties`, etc. - but no `register()`.

This caused all events since Jan 16 to be missing the `os`, `app_version`, and `daemon_version` properties (the error was silently caught).

## Impact

- **14 janvier**: 40% missing `os` (6 with OS, 4 without)
- **15 janvier**: 73% missing `os` (59 with OS, 162 without)  
- **16 janvier**: ❌ 100% missing `os` (0 with OS, 477 without)
- **17 janvier**: ❌ 100% missing `os` (0 with OS, 162 without)

The "OS Distribution" insight in PostHog shows "None" everywhere because of this regression.

## Solution

Restore the previous working approach:
- Use a `globalContext` object to store `os`, `app_version`, `daemon_version`
- Manually merge `globalContext` with event props in `track()`
- Initialize context at app startup via `initTelemetry()`
- Update context dynamically via `updateTelemetryContext()`

This is the same pattern that was working before the Jan 15 refactor.