### PR TITLE
fix(windows): sync scripts folder on upgrade for existing installations

### DIFF
--- a/uv-wrapper/src/lib.rs
+++ b/uv-wrapper/src/lib.rs
@@ -111,6 +111,23 @@ pub fn setup_local_venv_windows(program_files_dir: &std::path::Path) -> Result<P
             if line.starts_with("home = ") {
                 let home_path = line.trim_start_matches("home = ");
                 if std::path::Path::new(home_path).exists() {
+                    // Sync scripts folder if missing (handles upgrades from older versions)
+                    // This ensures avast_ssl_fix.py is present even for existing installations
+                    let dst_avast_fix = local_dir.join("scripts").join("avast_ssl_fix.py");
+                    if !dst_avast_fix.exists() {
+                        let src_scripts = program_files_dir.join("scripts");
+                        let dst_scripts = local_dir.join("scripts");
+                        if src_scripts.exists() {
+                            println!("📁 Syncing scripts folder (upgrade)...");
+                            let _ = fs::create_dir_all(&dst_scripts);
+                            if let Err(e) = copy_dir_recursive(&src_scripts, &dst_scripts) {
+                                println!("⚠️  Failed to sync scripts: {}", e);
+                            } else {
+                                println!("✅ scripts synced");
+                            }
+                        }
+                    }
+                    
                     println!("✅ Local venv already configured at {:?}", local_dir);
                     return Ok(local_dir);
                 }


### PR DESCRIPTION
## Problem

When users upgrade from older versions (pre-v0.9.9), the local venv in `%LOCALAPPDATA%` already exists with a valid `pyvenv.cfg`. This causes `setup_local_venv_windows()` to **early-return at line 115** BEFORE reaching the scripts folder copy logic (added in #107).

### Error reported by user:
```
C:\Users\Ming Tao\AppData\Local\Reachy Mini Control\cpython-3.12.12-windows-x86_64-none\python.exe: 
can't open file 'C:\Users\Ming Tao\AppData\Local\Reachy Mini Control\scripts\avast_ssl_fix.py': 
[Errno 2] No such file or directory
```

### Root cause analysis:
| Commit | What it did | Why it didn't fully work |
|--------|-------------|-------------------------|
| #100 (8d573dce9) | Added `scripts/avast_ssl_fix.py` to Windows bundle | Scripts in Program Files, not copied to LOCALAPPDATA |
| #107 (335f6e70b) | Added code to copy scripts folder | Code placed AFTER early return → only works for NEW installations |

## Solution

Add a check for `avast_ssl_fix.py` **BEFORE** the early return, ensuring scripts are synced even for existing installations:

```rust
// Inside the early return block
let dst_avast_fix = local_dir.join("scripts").join("avast_ssl_fix.py");
if !dst_avast_fix.exists() {
    // Copy scripts from Program Files
}
```

## Testing

- [ ] Fresh install on Windows → scripts copied during initial setup
- [ ] Upgrade from v0.9.8 to v0.9.x → scripts synced on first launch
- [ ] Existing v0.9.9+ install → no-op (scripts already present)