### PR TITLE
fix(telemetry): properly track connection errors and successes

### DIFF
--- a/src/hooks/daemon/useDaemon.js
+++ b/src/hooks/daemon/useDaemon.js
@@ -86,6 +86,8 @@ export const useDaemon = () => {
         const errorObject = createErrorFromConfig(data.errorConfig, data.errorLine);
         setHardwareError(errorObject);
         transitionTo.starting();
+        // 📊 Telemetry - Track known hardware errors (NO_MOTORS, CAMERA_ERROR, etc.)
+        handleDaemonError('hardware', data.errorLine, { code: data.errorConfig.code });
       } else if (data.isGeneric) {
         const currentError = currentState.hardwareError;
         if (!currentError || !currentError.type) {
@@ -348,8 +350,9 @@ export const useDaemon = () => {
         eventBus.emit('daemon:start:success', { existing: true, wifi: true });
       } catch (e) {
         console.error('[Daemon] WiFi connection failed:', e.message);
-        resetAll();
+        // ⚠️ IMPORTANT: Emit error BEFORE resetAll() so telemetry captures the connectionMode
         eventBus.emit('daemon:start:error', new Error(`WiFi daemon error: ${e.message}`));
+        resetAll();
       }
       return;
     }

--- a/src/store/slices/robotSlice.js
+++ b/src/store/slices/robotSlice.js
@@ -11,6 +11,7 @@
  * All boolean states (isActive, isStarting, etc.) are DERIVED from robotStatus
  */
 import { logConnect, logDisconnect, logReset, logReady, logBusy, logCrash } from '../storeLogger';
+import { telemetry } from '../../utils/telemetry';
 
 // ============================================================================
 // SELECTORS - Derive boolean states from robotStatus
@@ -227,6 +228,12 @@ export const createRobotSlice = (set, get) => ({
         return;
       }
 
+      // 📊 Telemetry - Track successful connection (only when coming from 'starting')
+      // This ensures we only count ACTUAL successful connections, not reconnects
+      if (state.robotStatus === 'starting') {
+        telemetry.robotConnected({ mode: state.connectionMode });
+      }
+
       set({
         robotStatus: 'sleeping',
         busyReason: null,
@@ -268,6 +275,12 @@ export const createRobotSlice = (set, get) => ({
       if (state.robotStatus === 'ready') {
         console.warn('[Store] ⚠️ BLOCKED: already ready');
         return;
+      }
+
+      // 📊 Telemetry - Track successful connection (only when coming from 'starting')
+      // This ensures we only count ACTUAL successful connections, not wake-ups
+      if (state.robotStatus === 'starting') {
+        telemetry.robotConnected({ mode: state.connectionMode });
       }
 
       logReady();

--- a/src/store/storeLogger.js
+++ b/src/store/storeLogger.js
@@ -47,8 +47,8 @@ export const logConnect = (mode, options = {}) => {
   const target = mode === 'wifi' ? remoteHost : portName || 'local';
   log('🔌', 'CONNECT', `mode=${mode} target=${target}`);
 
-  // 📊 Telemetry
-  telemetry.robotConnected({ mode });
+  // 📊 Telemetry - NOTE: robot_connected is now emitted when connection is ESTABLISHED
+  // (in robotSlice.js transitionTo.sleeping/ready), not at connection ATTEMPT
 };
 
 export const logDisconnect = (prevMode, reason = '') => {


### PR DESCRIPTION
## Summary

Fixes telemetry tracking for connection errors and successes to enable accurate reliability metrics in PostHog dashboard.

## Changes

### 1. WiFi errors: emit error BEFORE resetAll()
- **Problem**: `resetAll()` was called before emitting the error event, causing `connectionMode` to be `null`
- **Fix**: Swapped the order so telemetry captures the correct mode

### 2. Hardware errors: track known errors
- **Problem**: Known hardware errors (NO_MOTORS, CAMERA_ERROR, etc.) were not tracked in telemetry
- **Fix**: Added `handleDaemonError()` call for known hardware errors

### 3. robot_connected: emit only on ESTABLISHED connection
- **Problem**: `robot_connected` was emitted at connection ATTEMPT (click), not when actually established
- **Fix**: Moved telemetry to `transitionTo.sleeping()` and `transitionTo.ready()` when coming from `starting`

## Impact

This enables the new telemetry dashboard to show accurate:
- Connection reliability by mode (USB/WiFi/Simulation)
- Error breakdown by type (timeout, crash, hardware, startup)

## Testing

- [ ] Test USB connection success → should emit `robot_connected` with mode `usb`
- [ ] Test USB connection failure (unplug power) → should emit `connection_error` with mode `usb`
- [ ] Test WiFi connection failure → should emit `connection_error` with mode `wifi`
- [ ] Verify in PostHog that events have correct `mode` property