### PR TITLE
fix(telemetry): track connection errors that were previously missed

### DIFF
--- a/src/hooks/useConnection.js
+++ b/src/hooks/useConnection.js
@@ -31,6 +31,7 @@ import {
   DAEMON_CONFIG,
 } from '../config/daemon';
 import { enableSimulationMode } from '../utils/simulationMode';
+import { telemetry } from '../utils/telemetry';
 
 /**
  * Connection modes
@@ -121,6 +122,17 @@ export function useConnection() {
             resolve(true);
           } catch (e) {
             console.error('Connection failed:', e);
+
+            // 📊 Télémétrie - Track échec de connexion (safety net)
+            // Note: La plupart des erreurs passent par handleDaemonError() via eventBus
+            // Ce catch n'est atteint que pour des erreurs JS inattendues
+            const errorMessage = e?.message || String(e) || 'Unknown error';
+            telemetry.connectionError({
+              mode,
+              error_type: 'connection_failed_unexpected',
+              error_message: errorMessage.slice(0, 200), // Tronquer pour éviter les données sensibles
+            });
+
             resolve(false);
           }
         });

--- a/src/store/slices/robotSlice.js
+++ b/src/store/slices/robotSlice.js
@@ -354,7 +354,16 @@ export const createRobotSlice = (set, get) => ({
     },
 
     crashed: () => {
+      const state = get();
       logCrash();
+
+      // 📊 Télémétrie - Track crash détecté via health check (3 timeouts consécutifs)
+      telemetry.connectionError({
+        mode: state.connectionMode,
+        error_type: 'crash_health_timeout',
+        error_message: `Daemon unresponsive after ${state.consecutiveTimeouts} consecutive health check failures`,
+      });
+
       set({
         robotStatus: 'crashed',
         busyReason: null,

--- a/src/utils/telemetry/index.js
+++ b/src/utils/telemetry/index.js
@@ -256,12 +256,13 @@ export const telemetry = {
 
   /**
    * Track connection error
-   * @param {{ mode?: string, error_type?: string }} props
+   * @param {{ mode?: string, error_type?: string, error_message?: string }} props
    */
   connectionError: (props = {}) => {
     track(EVENTS.CONNECTION_ERROR, {
       mode: validateConnectionMode(props.mode),
       error_type: props.error_type,
+      error_message: props.error_message, // Optional: truncated error message for debugging
     });
   },
 


### PR DESCRIPTION
## Summary

- Add telemetry tracking for daemon crashes detected via health check (3 consecutive timeouts)
- Add telemetry tracking for unexpected connection failures in `useConnection` catch block
- Include `error_message` in `connection_error` events for better debugging
- Update `connectionError` API to accept optional `error_message` parameter

## Problem

The PostHog dashboard was showing 100% success rate because certain connection errors were not being tracked:
- **Crash via health check**: When the daemon becomes unresponsive and 3 consecutive health check timeouts trigger `transitionTo.crashed()`, no telemetry was sent
- **Unexpected connection failures**: Errors caught in the `useConnection.js` try/catch were logged to console but not tracked

## Changes

| File | Change |
|------|--------|
| `src/store/slices/robotSlice.js` | Track `crash_health_timeout` in `transitionTo.crashed()` |
| `src/hooks/useConnection.js` | Track `connection_failed_unexpected` in catch block |
| `src/utils/telemetry/index.js` | Add `error_message` parameter to `connectionError()` |

## New error_type values

- `crash_health_timeout`: Daemon unresponsive after 3 consecutive health check failures
- `connection_failed_unexpected`: Unexpected JS error during connection (safety net)

## Test plan

- [x] Lint passes (prettier + eslint via lint-staged)
- [ ] Test dashboard shows new error types after deployment