### PR TITLE
fix(websocket): prevent multiple WebSocket instances accumulation

### DIFF
--- a/src/hooks/robot/useActiveMoves.js
+++ b/src/hooks/robot/useActiveMoves.js
@@ -2,6 +2,9 @@ import { useEffect, useRef } from 'react';
 import useAppStore from '../../store/useAppStore';
 import { getWsBaseUrl, buildApiUrl, fetchWithTimeout, DAEMON_CONFIG } from '../../config/daemon';
 
+// 🔒 Delay before reconnection to avoid race conditions during HMR
+const WS_CLEANUP_DELAY_MS = 100;
+
 /**
  * 🎯 Real-time hook for active moves via WebSocket
  *
@@ -23,42 +26,46 @@ export function useActiveMoves(isActive) {
   const reconnectTimeoutRef = useRef(null);
   const isMountedRef = useRef(true);
   const reconnectAttemptsRef = useRef(0);
+  const isConnectingRef = useRef(false); // 🔒 Prevent multiple simultaneous connections
+  const isDaemonCrashedRef = useRef(isDaemonCrashed); // 🔒 Use ref to avoid effect re-runs
+  const setActiveMovesRef = useRef(setActiveMoves); // 🔒 Stable ref for callback
   const MAX_RECONNECT_ATTEMPTS = 5;
 
+  // Keep refs in sync
+  useEffect(() => {
+    isDaemonCrashedRef.current = isDaemonCrashed;
+    // If daemon crashes while connected, close the WebSocket
+    if (isDaemonCrashed && wsRef.current) {
+      wsRef.current.close();
+      wsRef.current = null;
+    }
+  }, [isDaemonCrashed]);
+
+  useEffect(() => {
+    setActiveMovesRef.current = setActiveMoves;
+  }, [setActiveMoves]);
+
+  // Main effect: connect/disconnect based on isActive
+  // 🔒 Only depends on isActive - other values accessed via refs to prevent reconnection storms
   useEffect(() => {
     isMountedRef.current = true;
+    reconnectAttemptsRef.current = 0;
+    isConnectingRef.current = false;
 
-    return () => {
-      isMountedRef.current = false;
-
-      // Cleanup WebSocket
-      if (wsRef.current) {
-        wsRef.current.close();
-        wsRef.current = null;
-      }
-
-      // Clear reconnect timeout
-      if (reconnectTimeoutRef.current) {
-        clearTimeout(reconnectTimeoutRef.current);
-        reconnectTimeoutRef.current = null;
-      }
-    };
-  }, []);
-
-  useEffect(() => {
-    // Don't connect if not active or daemon crashed
-    if (!isActive || isDaemonCrashed) {
+    if (!isActive) {
       // Cleanup existing connection
       if (wsRef.current) {
         wsRef.current.close();
         wsRef.current = null;
       }
 
-      // Clear active moves when not active
-      if (!isActive) {
-        setActiveMoves([]);
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current);
+        reconnectTimeoutRef.current = null;
       }
 
+      // Clear active moves when not active
+      setActiveMovesRef.current([]);
       return;
     }
 
@@ -75,7 +82,7 @@ export function useActiveMoves(isActive) {
         if (response.ok && isMountedRef.current) {
           const data = await response.json();
           if (Array.isArray(data)) {
-            setActiveMoves(data);
+            setActiveMovesRef.current(data);
           }
         }
       } catch (err) {
@@ -84,17 +91,49 @@ export function useActiveMoves(isActive) {
     };
 
     const connectWebSocket = () => {
+      // 🔒 Check if daemon crashed (via ref, not dependency)
+      if (isDaemonCrashedRef.current) {
+        console.warn('[ActiveMoves] Daemon crashed, not connecting');
+        return;
+      }
+
       // Check max reconnection attempts
       if (reconnectAttemptsRef.current >= MAX_RECONNECT_ATTEMPTS) {
         console.warn('⚠️ [ActiveMoves] Max reconnection attempts reached');
         return;
       }
 
+      // 🔒 Prevent multiple simultaneous connections
+      if (isConnectingRef.current) {
+        console.warn('[ActiveMoves] Connection already in progress, skipping');
+        return;
+      }
+
+      // 🔒 Check if WebSocket already exists and is connecting or open
+      if (wsRef.current) {
+        const state = wsRef.current.readyState;
+        if (state === WebSocket.CONNECTING || state === WebSocket.OPEN) {
+          console.warn('[ActiveMoves] WebSocket already active, skipping new connection');
+          return;
+        }
+        // Close stale WebSocket
+        wsRef.current.close();
+        wsRef.current = null;
+      }
+
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current);
+        reconnectTimeoutRef.current = null;
+      }
+
+      isConnectingRef.current = true;
+
       try {
         const wsUrl = `${getWsBaseUrl()}/api/move/ws/updates`;
         const ws = new WebSocket(wsUrl);
 
         ws.onopen = () => {
+          isConnectingRef.current = false;
           reconnectAttemptsRef.current = 0; // Reset on successful connection
 
           // Fetch initial list of active moves via HTTP
@@ -116,7 +155,7 @@ export function useActiveMoves(isActive) {
 
             if (data.type === 'move_started') {
               // Add new move
-              setActiveMoves(prev => {
+              setActiveMovesRef.current(prev => {
                 const exists = prev.some(m => m.uuid === data.uuid);
                 if (exists) return prev;
                 return [...prev, { uuid: data.uuid }];
@@ -127,46 +166,58 @@ export function useActiveMoves(isActive) {
               data.type === 'move_cancelled'
             ) {
               // Remove completed/failed/cancelled move
-              setActiveMoves(prev => prev.filter(m => m.uuid !== data.uuid));
+              setActiveMovesRef.current(prev => prev.filter(m => m.uuid !== data.uuid));
             }
           } catch (err) {
             console.warn('[ActiveMoves] Failed to parse WebSocket message:', err);
           }
         };
 
-        ws.onerror = error => {
-          console.warn('[ActiveMoves] WebSocket error:', error);
+        ws.onerror = () => {
+          isConnectingRef.current = false;
         };
 
-        ws.onclose = () => {
-          if (!isMountedRef.current) return;
-
+        ws.onclose = event => {
+          isConnectingRef.current = false;
           wsRef.current = null;
 
-          // Attempt to reconnect if still active
-          if (isActive && !isDaemonCrashed) {
-            reconnectAttemptsRef.current += 1;
-            const delay = Math.min(1000 * Math.pow(2, reconnectAttemptsRef.current), 10000);
+          if (!isMountedRef.current) return;
+          if (event.code === 1000) return; // Clean close, no reconnect
 
-            reconnectTimeoutRef.current = setTimeout(() => {
-              if (isMountedRef.current && isActive && !isDaemonCrashed) {
-                connectWebSocket();
-              }
-            }, delay);
-          }
+          // 🔒 Don't reconnect if daemon crashed
+          if (isDaemonCrashedRef.current) return;
+
+          reconnectAttemptsRef.current += 1;
+          const delay = Math.min(1000 * Math.pow(2, reconnectAttemptsRef.current), 10000);
+
+          // 🔒 Add small delay to avoid race conditions during HMR/fast remounts
+          reconnectTimeoutRef.current = setTimeout(() => {
+            if (isMountedRef.current && !isDaemonCrashedRef.current) {
+              connectWebSocket();
+            }
+          }, delay + WS_CLEANUP_DELAY_MS);
         };
 
         wsRef.current = ws;
       } catch (err) {
+        isConnectingRef.current = false;
         console.error('[ActiveMoves] Failed to create WebSocket:', err);
       }
     };
 
-    // Connect to WebSocket
-    connectWebSocket();
+    // 🔒 Small delay before initial connection to let cleanup complete during HMR
+    const initialConnectTimeout = setTimeout(() => {
+      if (isMountedRef.current && !isDaemonCrashedRef.current) {
+        connectWebSocket();
+      }
+    }, WS_CLEANUP_DELAY_MS);
 
     return () => {
-      // Cleanup on unmount or when isActive changes
+      isMountedRef.current = false;
+      isConnectingRef.current = false;
+
+      clearTimeout(initialConnectTimeout);
+
       if (wsRef.current) {
         wsRef.current.close();
         wsRef.current = null;
@@ -177,5 +228,5 @@ export function useActiveMoves(isActive) {
         reconnectTimeoutRef.current = null;
       }
     };
-  }, [isActive, isDaemonCrashed, setActiveMoves]);
+  }, [isActive]); // 🔒 Only depends on isActive - other values accessed via refs
 }

--- a/src/hooks/robot/useRobotStateWebSocket.js
+++ b/src/hooks/robot/useRobotStateWebSocket.js
@@ -8,6 +8,7 @@ const WS_FREQUENCY = 20; // 20Hz for smooth 3D visualization
 const WS_RECONNECT_DELAY_MS = 1000;
 const WS_MAX_RECONNECT_ATTEMPTS = 5;
 const WS_MAX_WIFI_RECONNECT_ATTEMPTS = 3;
+const WS_CLEANUP_DELAY_MS = 100; // Delay before reconnection to avoid race conditions
 
 /**
  * 🚀 Unified WebSocket hook for ALL robot state data
@@ -35,12 +36,14 @@ export function useRobotStateWebSocket(isActive) {
   const isMountedRef = useRef(true);
   const isWiFiRef = useRef(false);
   const dataVersionRef = useRef(0);
+  const isConnectingRef = useRef(false); // 🔒 Prevent multiple simultaneous connections
 
-  // Store refs for stable callbacks
+  // Store refs for stable callbacks (avoid dependency changes triggering reconnections)
   const setRobotStateFullRef = useRef(setRobotStateFull);
   const eventBusRef = useRef(eventBus);
+  const isDaemonCrashedRef = useRef(isDaemonCrashed); // 🔒 Use ref to avoid effect re-runs
 
-  // Keep refs in sync
+  // Keep refs in sync (without triggering effect re-runs)
   useEffect(() => {
     setRobotStateFullRef.current = setRobotStateFull;
   }, [setRobotStateFull]);
@@ -48,6 +51,16 @@ export function useRobotStateWebSocket(isActive) {
   useEffect(() => {
     eventBusRef.current = eventBus;
   }, [eventBus]);
+
+  useEffect(() => {
+    isDaemonCrashedRef.current = isDaemonCrashed;
+    // If daemon crashes while connected, close the WebSocket
+    if (isDaemonCrashed && wsRef.current) {
+      console.warn('[RobotState WS] Daemon crashed, closing WebSocket');
+      wsRef.current.close(1000);
+      wsRef.current = null;
+    }
+  }, [isDaemonCrashed]);
 
   /**
    * Build WebSocket URL with all required parameters
@@ -111,10 +124,12 @@ export function useRobotStateWebSocket(isActive) {
   }, []); // No dependencies - uses refs
 
   // Main effect: connect/disconnect based on isActive
+  // 🔒 Only depends on isActive - other values accessed via refs to prevent reconnection storms
   useEffect(() => {
     isMountedRef.current = true;
     reconnectAttemptsRef.current = 0;
     isWiFiRef.current = isWiFiMode();
+    isConnectingRef.current = false;
 
     if (!isActive) {
       // Clear state when inactive
@@ -136,17 +151,14 @@ export function useRobotStateWebSocket(isActive) {
       return;
     }
 
-    if (isDaemonCrashed) {
-      console.warn('[RobotState WS] Daemon crashed, not connecting');
-      if (wsRef.current) {
-        wsRef.current.close(1000);
-        wsRef.current = null;
-      }
-      return;
-    }
-
     // Connect WebSocket
     const connectWebSocket = () => {
+      // 🔒 Check if daemon crashed (via ref, not dependency)
+      if (isDaemonCrashedRef.current) {
+        console.warn('[RobotState WS] Daemon crashed, not connecting');
+        return;
+      }
+
       const maxAttempts = isWiFiRef.current
         ? WS_MAX_WIFI_RECONNECT_ATTEMPTS
         : WS_MAX_RECONNECT_ATTEMPTS;
@@ -156,7 +168,20 @@ export function useRobotStateWebSocket(isActive) {
         return;
       }
 
+      // 🔒 Prevent multiple simultaneous connections
+      if (isConnectingRef.current) {
+        console.warn('[RobotState WS] Connection already in progress, skipping');
+        return;
+      }
+
+      // 🔒 Check if WebSocket already exists and is connecting or open
       if (wsRef.current) {
+        const state = wsRef.current.readyState;
+        if (state === WebSocket.CONNECTING || state === WebSocket.OPEN) {
+          console.warn('[RobotState WS] WebSocket already active, skipping new connection');
+          return;
+        }
+        // Close stale WebSocket
         wsRef.current.close();
         wsRef.current = null;
       }
@@ -166,11 +191,14 @@ export function useRobotStateWebSocket(isActive) {
         reconnectTimeoutRef.current = null;
       }
 
+      isConnectingRef.current = true;
+
       try {
         const wsUrl = buildWsUrl();
         const ws = new WebSocket(wsUrl);
 
         ws.onopen = () => {
+          isConnectingRef.current = false;
           reconnectAttemptsRef.current = 0;
           console.log('[RobotState WS] Connected');
         };
@@ -186,35 +214,51 @@ export function useRobotStateWebSocket(isActive) {
           }
         };
 
-        ws.onerror = () => {};
+        ws.onerror = () => {
+          isConnectingRef.current = false;
+        };
 
         ws.onclose = event => {
+          isConnectingRef.current = false;
           wsRef.current = null;
 
           if (!isMountedRef.current) return;
-          if (event.code === 1000) return;
+          if (event.code === 1000) return; // Clean close, no reconnect
+
+          // 🔒 Don't reconnect if daemon crashed
+          if (isDaemonCrashedRef.current) return;
 
           reconnectAttemptsRef.current++;
 
           if (reconnectAttemptsRef.current < maxAttempts) {
+            // 🔒 Add small delay to avoid race conditions during HMR/fast remounts
             reconnectTimeoutRef.current = setTimeout(() => {
-              if (isMountedRef.current) {
+              if (isMountedRef.current && !isDaemonCrashedRef.current) {
                 connectWebSocket();
               }
-            }, WS_RECONNECT_DELAY_MS);
+            }, WS_RECONNECT_DELAY_MS + WS_CLEANUP_DELAY_MS);
           }
         };
 
         wsRef.current = ws;
       } catch (err) {
+        isConnectingRef.current = false;
         console.error('[RobotState WS] Failed to connect:', err);
       }
     };
 
-    connectWebSocket();
+    // 🔒 Small delay before initial connection to let cleanup complete during HMR
+    const initialConnectTimeout = setTimeout(() => {
+      if (isMountedRef.current && !isDaemonCrashedRef.current) {
+        connectWebSocket();
+      }
+    }, WS_CLEANUP_DELAY_MS);
 
     return () => {
       isMountedRef.current = false;
+      isConnectingRef.current = false;
+
+      clearTimeout(initialConnectTimeout);
 
       if (reconnectTimeoutRef.current) {
         clearTimeout(reconnectTimeoutRef.current);
@@ -226,7 +270,7 @@ export function useRobotStateWebSocket(isActive) {
         wsRef.current = null;
       }
     };
-  }, [isActive, isDaemonCrashed, buildWsUrl, processData]);
+  }, [isActive, buildWsUrl, processData]); // 🔒 Removed isDaemonCrashed - accessed via ref
 
   return {
     isConnected: wsRef.current?.readyState === WebSocket.OPEN,

--- a/src/views/active-robot/controller/hooks/useControllerAPI.js
+++ b/src/views/active-robot/controller/hooks/useControllerAPI.js
@@ -7,6 +7,7 @@ const SEND_THROTTLE_MS = 50;
 // WebSocket reconnection settings
 const WS_RECONNECT_DELAY_MS = 1000;
 const WS_MAX_RECONNECT_ATTEMPTS = 5;
+const WS_CLEANUP_DELAY_MS = 100; // 🔒 Delay before reconnection to avoid race conditions
 
 /**
  * Controller API hook with WebSocket support
@@ -21,21 +22,42 @@ export function useControllerAPI() {
   const wsRef = useRef(null);
   const wsReconnectAttempts = useRef(0);
   const wsReconnectTimeoutRef = useRef(null);
+  const isMountedRef = useRef(true);
+  const isConnectingRef = useRef(false); // 🔒 Prevent multiple simultaneous connections
+
+  // 🔒 Store buildApiUrl in ref to avoid dependency changes
+  const buildApiUrlRef = useRef(buildApiUrl);
+  useEffect(() => {
+    buildApiUrlRef.current = buildApiUrl;
+  }, [buildApiUrl]);
 
   /**
    * Build WebSocket URL from HTTP URL
    */
   const buildWsUrl = useCallback(() => {
-    const httpUrl = buildApiUrl('/api/move/ws/set_target');
+    const httpUrl = buildApiUrlRef.current('/api/move/ws/set_target');
     // Convert http(s):// to ws(s)://
     return httpUrl.replace(/^http/, 'ws');
-  }, [buildApiUrl]);
+  }, []); // 🔒 No dependencies - uses ref
 
   /**
    * Connect to WebSocket
    */
   const connectWebSocket = useCallback(() => {
+    // 🔒 Prevent multiple simultaneous connections
+    if (isConnectingRef.current) {
+      console.warn('[Controller] Connection already in progress, skipping');
+      return;
+    }
+
+    // 🔒 Check if WebSocket already exists and is connecting or open
     if (wsRef.current) {
+      const state = wsRef.current.readyState;
+      if (state === WebSocket.CONNECTING || state === WebSocket.OPEN) {
+        console.warn('[Controller] WebSocket already active, skipping new connection');
+        return;
+      }
+      // Close stale WebSocket
       wsRef.current.close();
       wsRef.current = null;
     }
@@ -45,24 +67,38 @@ export function useControllerAPI() {
       wsReconnectTimeoutRef.current = null;
     }
 
+    isConnectingRef.current = true;
+
     try {
       const ws = new WebSocket(buildWsUrl());
 
       ws.onopen = () => {
+        isConnectingRef.current = false;
         wsReconnectAttempts.current = 0;
       };
 
       ws.onclose = event => {
+        isConnectingRef.current = false;
         wsRef.current = null;
 
+        if (!isMountedRef.current) return;
+        if (event.code === 1000) return; // Clean close, no reconnect
+
         // Auto-reconnect if not a clean close
-        if (event.code !== 1000 && wsReconnectAttempts.current < WS_MAX_RECONNECT_ATTEMPTS) {
+        if (wsReconnectAttempts.current < WS_MAX_RECONNECT_ATTEMPTS) {
           wsReconnectAttempts.current++;
-          wsReconnectTimeoutRef.current = setTimeout(connectWebSocket, WS_RECONNECT_DELAY_MS);
+          // 🔒 Add small delay to avoid race conditions during HMR/fast remounts
+          wsReconnectTimeoutRef.current = setTimeout(() => {
+            if (isMountedRef.current) {
+              connectWebSocket();
+            }
+          }, WS_RECONNECT_DELAY_MS + WS_CLEANUP_DELAY_MS);
         }
       };
 
-      ws.onerror = () => {};
+      ws.onerror = () => {
+        isConnectingRef.current = false;
+      };
 
       ws.onmessage = event => {
         try {
@@ -77,6 +113,7 @@ export function useControllerAPI() {
 
       wsRef.current = ws;
     } catch {
+      isConnectingRef.current = false;
       // Will fallback to HTTP
     }
   }, [buildWsUrl]);
@@ -97,13 +134,26 @@ export function useControllerAPI() {
   }, []);
 
   // Connect WebSocket on mount
+  // 🔒 Empty dependency array - only runs on mount/unmount
   useEffect(() => {
-    connectWebSocket();
+    isMountedRef.current = true;
+    isConnectingRef.current = false;
+    wsReconnectAttempts.current = 0;
+
+    // 🔒 Small delay before initial connection to let cleanup complete during HMR
+    const initialConnectTimeout = setTimeout(() => {
+      if (isMountedRef.current) {
+        connectWebSocket();
+      }
+    }, WS_CLEANUP_DELAY_MS);
 
     return () => {
+      isMountedRef.current = false;
+      isConnectingRef.current = false;
+      clearTimeout(initialConnectTimeout);
       disconnectWebSocket();
     };
-  }, [connectWebSocket, disconnectWebSocket]);
+  }, []); // 🔒 Empty deps - mount/unmount only
 
   /**
    * Send command via WebSocket (fast path)


### PR DESCRIPTION
## Summary

- Fix app freeze (white screen) that occurs after leaving the app running for extended periods in dev mode
- Prevent WebSocket connections from accumulating due to React effect re-runs and HMR
- Add protection mechanisms against race conditions during fast component remounts

## Problem

When the app runs for a long time in dev mode, WebSocket connections accumulate because:
1. React effect re-runs triggered by dependency changes (`isDaemonCrashed`, `setActiveMoves`)
2. Hot Module Replacement (HMR) causing fast component remounts
3. Race conditions where new connections start before cleanup completes

This leads to:
- Memory leaks (accumulated event handlers)
- Bandwidth waste (duplicate data streams)
- Eventually, a frozen white screen

## Solution

Added multiple protection mechanisms:

| Protection | Description |
|------------|-------------|
| `isConnectingRef` | Prevents multiple simultaneous connections |
| `readyState` check | Skips new WS if already `CONNECTING` or `OPEN` |
| `WS_CLEANUP_DELAY_MS` | 100ms delay to let cleanup complete |
| Refs for callbacks | Avoids re-renders triggering reconnections |
| `isMountedRef` | Verifies component is still mounted |

## Affected hooks

- `useRobotStateWebSocket` - main 20Hz state streaming
- `useActiveMoves` - real-time move updates  
- `useControllerAPI` - controller commands WebSocket

## Test plan

- [ ] Run app in dev mode for extended period (30+ min)
- [ ] Check DevTools Network > WS tab for connection count (should stay at 2-3 max)
- [ ] Verify no white screen freeze occurs
- [ ] Test hot reload multiple times - connections should not accumulate