### PR TITLE
feat: add audio device selection UI

### DIFF
--- a/src/config/daemon.js
+++ b/src/config/daemon.js
@@ -157,6 +157,9 @@ export const DAEMON_CONFIG = {
     VOLUME_SET: '/api/volume/set',
     MICROPHONE_CURRENT: '/api/volume/microphone/current',
     MICROPHONE_SET: '/api/volume/microphone/set',
+    AUDIO_DEVICES: '/api/audio/devices',
+    AUDIO_SPEAKER_SET_DEVICE: '/api/audio/speaker/set-device',
+    AUDIO_MICROPHONE_SET_DEVICE: '/api/audio/microphone/set-device',
   },
 
   // Endpoints to NOT log (frequent calls)
@@ -164,6 +167,7 @@ export const DAEMON_CONFIG = {
     '/api/state/full', // Used during startup (HardwareScanView)
     '/api/daemon/status', // Health check every 2.5s
     '/api/apps/list-available/installed', // Called frequently when fetching apps
+    '/api/audio/devices', // Audio device list (polled on dropdown open)
   ],
 };
 

--- a/src/views/active-robot/ActiveRobotView.jsx
+++ b/src/views/active-robot/ActiveRobotView.jsx
@@ -190,6 +190,13 @@ function ActiveRobotView({
     handleMicrophoneVolumeChange,
     handleSpeakerMute,
     handleMicrophoneMute,
+    deviceSelectionSupported,
+    availableSpeakers,
+    availableMicrophones,
+    devicesLoading,
+    fetchAudioDevices,
+    handleSpeakerDeviceChange,
+    handleMicrophoneDeviceChange,
   } = useAudioControls(isActive);
 
   // ✅ Apps loading state (for internal UI if needed)
@@ -557,6 +564,13 @@ function ActiveRobotView({
                 darkMode={darkMode}
                 disabled={isBusyState}
                 isSleeping={robotStatus === 'sleeping'}
+                deviceSelectionSupported={deviceSelectionSupported}
+                availableSpeakers={availableSpeakers}
+                availableMicrophones={availableMicrophones}
+                devicesLoading={devicesLoading}
+                onRefreshDevices={fetchAudioDevices}
+                onSpeakerDeviceChange={handleSpeakerDeviceChange}
+                onMicrophoneDeviceChange={handleMicrophoneDeviceChange}
               />
             </Box>
 

--- a/src/views/active-robot/audio/AudioControls.jsx
+++ b/src/views/active-robot/audio/AudioControls.jsx
@@ -1,5 +1,14 @@
 import React from 'react';
-import { Box, Typography, IconButton, Slider, Tooltip } from '@mui/material';
+import {
+  Box,
+  Typography,
+  IconButton,
+  Slider,
+  Tooltip,
+  Select,
+  MenuItem,
+  CircularProgress,
+} from '@mui/material';
 import MicIcon from '@mui/icons-material/Mic';
 import MicOffIcon from '@mui/icons-material/MicOff';
 import VolumeUpIcon from '@mui/icons-material/VolumeUp';
@@ -30,6 +39,13 @@ function AudioControls({
   darkMode,
   disabled = false,
   isSleeping = false, // Hide DoA and audio visualizer when robot is sleeping
+  deviceSelectionSupported = false,
+  availableSpeakers = [],
+  availableMicrophones = [],
+  devicesLoading = false,
+  onRefreshDevices,
+  onSpeakerDeviceChange,
+  onMicrophoneDeviceChange,
 }) {
   const isMicActive = microphoneVolume > 0 && !disabled;
 
@@ -107,7 +123,9 @@ function AudioControls({
     onMute,
     onVolumeChange,
     extraIndicator = null,
-    externalAudioLevel = null
+    externalAudioLevel = null,
+    devices = [],
+    onDeviceChange = null
   ) => (
     <Box
       sx={{
@@ -160,7 +178,7 @@ function AudioControls({
             minWidth: 0,
           }}
         >
-          {/* Device info */}
+          {/* Device info - Select dropdown if supported, otherwise read-only text */}
           <Box
             sx={{
               flex: 1,
@@ -171,8 +189,86 @@ function AudioControls({
               overflow: 'hidden',
             }}
           >
-            <Typography sx={deviceTextStyle}>{device}</Typography>
-            {platform && <Typography sx={platformTextStyle}>{platform}</Typography>}
+            {deviceSelectionSupported && devices.length > 0 ? (
+              <Select
+                variant="standard"
+                disableUnderline
+                value={devices.find(d => d.name === device)?.id || ''}
+                onChange={e => onDeviceChange?.(e.target.value)}
+                onOpen={() => onRefreshDevices?.()}
+                disabled={disabled}
+                size="small"
+                sx={{
+                  ...deviceTextStyle,
+                  fontSize: 9,
+                  minWidth: 0,
+                  '& .MuiSelect-select': {
+                    padding: '0 16px 0 0 !important',
+                    minHeight: 'unset',
+                    lineHeight: 1.4,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  },
+                  '& .MuiSelect-icon': {
+                    fontSize: 14,
+                    right: 0,
+                    color: darkMode ? 'rgba(255,255,255,0.3)' : 'rgba(0,0,0,0.3)',
+                  },
+                }}
+                MenuProps={{
+                  PaperProps: {
+                    sx: {
+                      maxHeight: 200,
+                      bgcolor: darkMode ? '#1e1e1e' : '#fff',
+                      '&::-webkit-scrollbar': { width: '6px' },
+                      '&::-webkit-scrollbar-track': { bgcolor: 'transparent' },
+                      '&::-webkit-scrollbar-thumb': {
+                        bgcolor: darkMode ? 'rgba(255,255,255,0.2)' : 'rgba(0,0,0,0.15)',
+                        borderRadius: '3px',
+                        '&:hover': {
+                          bgcolor: darkMode ? 'rgba(255,255,255,0.3)' : 'rgba(0,0,0,0.25)',
+                        },
+                      },
+                    },
+                  },
+                }}
+                renderValue={val => {
+                  if (devicesLoading && devices.length === 0) return 'Loading...';
+                  const selected = devices.find(d => d.id === val);
+                  return selected?.name || device || 'Select device';
+                }}
+              >
+                {devicesLoading && devices.length === 0 ? (
+                  <MenuItem value="" disabled sx={{ fontSize: 11 }}>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                      <CircularProgress size={12} thickness={3} />
+                      <em>Scanning devices...</em>
+                    </Box>
+                  </MenuItem>
+                ) : (
+                  devices.map(d => (
+                    <MenuItem
+                      key={d.id}
+                      value={d.id}
+                      sx={{
+                        fontSize: 11,
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {d.name}
+                    </MenuItem>
+                  ))
+                )}
+              </Select>
+            ) : (
+              <>
+                <Typography sx={deviceTextStyle}>{device}</Typography>
+                {platform && <Typography sx={platformTextStyle}>{platform}</Typography>}
+              </>
+            )}
           </Box>
 
           {/* Mute button and slider */}
@@ -272,7 +368,11 @@ function AudioControls({
         volume,
         volume > 0,
         onSpeakerMute,
-        onVolumeChange
+        onVolumeChange,
+        null,
+        null,
+        availableSpeakers,
+        onSpeakerDeviceChange
       )}
       {renderControl(
         'Microphone',
@@ -293,7 +393,9 @@ function AudioControls({
           />
         ) : null,
         // Audio waveform only in WiFi mode AND when robot is awake
-        isWifiMode && !isSleeping ? microphoneLevel : null
+        isWifiMode && !isSleeping ? microphoneLevel : null,
+        availableMicrophones,
+        onMicrophoneDeviceChange
       )}
     </Box>
   );

--- a/src/views/active-robot/audio/hooks/useAudioControls.js
+++ b/src/views/active-robot/audio/hooks/useAudioControls.js
@@ -21,6 +21,12 @@ export function useAudioControls(isActive) {
   const [speakerPlatform, setSpeakerPlatform] = useState(null);
   const [microphonePlatform, setMicrophonePlatform] = useState(null);
 
+  // Device selection support (optional daemon capability)
+  const [deviceSelectionSupported, setDeviceSelectionSupported] = useState(false);
+  const [availableSpeakers, setAvailableSpeakers] = useState([]);
+  const [availableMicrophones, setAvailableMicrophones] = useState([]);
+  const [devicesLoading, setDevicesLoading] = useState(false);
+
   // Debounce timeouts refs (to cancel previous API calls when slider moves)
   const volumeDebounceTimeoutRef = useRef(null);
   const microphoneDebounceTimeoutRef = useRef(null);
@@ -71,7 +77,87 @@ export function useAudioControls(isActive) {
       setMicrophonePlatform,
       'microphone volume'
     );
+
+    // Check if daemon supports device selection (optional endpoint)
+    fetchAudioDevices();
   }, [isActive]);
+
+  // Fetch available audio devices from daemon (optional capability)
+  const fetchAudioDevices = useCallback(async () => {
+    setDevicesLoading(true);
+    try {
+      const response = await fetchWithTimeout(
+        buildApiUrl(DAEMON_CONFIG.ENDPOINTS.AUDIO_DEVICES),
+        {},
+        DAEMON_CONFIG.TIMEOUTS.VERSION,
+        { silent: true }
+      );
+      if (response.ok) {
+        const data = await response.json();
+        setDeviceSelectionSupported(true);
+        setAvailableSpeakers(data.speakers || []);
+        setAvailableMicrophones(data.microphones || []);
+      } else {
+        // 404 or other non-ok → daemon doesn't support device selection
+        setDeviceSelectionSupported(false);
+      }
+    } catch (_err) {
+      // Network error or timeout → not supported
+      setDeviceSelectionSupported(false);
+    } finally {
+      setDevicesLoading(false);
+    }
+  }, [buildApiUrl, fetchWithTimeout, DAEMON_CONFIG]);
+
+  // Change speaker device
+  const handleSpeakerDeviceChange = useCallback(
+    async deviceId => {
+      try {
+        const response = await fetchWithTimeout(
+          buildApiUrl(DAEMON_CONFIG.ENDPOINTS.AUDIO_SPEAKER_SET_DEVICE),
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ device_id: deviceId }),
+          },
+          DAEMON_CONFIG.TIMEOUTS.VERSION,
+          { silent: false, label: 'Set speaker device' }
+        );
+        if (response.ok) {
+          const data = await response.json();
+          if (data.device) setSpeakerDevice(data.device);
+        }
+      } catch (err) {
+        console.warn('Failed to set speaker device:', err);
+      }
+    },
+    [buildApiUrl, fetchWithTimeout, DAEMON_CONFIG]
+  );
+
+  // Change microphone device
+  const handleMicrophoneDeviceChange = useCallback(
+    async deviceId => {
+      try {
+        const response = await fetchWithTimeout(
+          buildApiUrl(DAEMON_CONFIG.ENDPOINTS.AUDIO_MICROPHONE_SET_DEVICE),
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ device_id: deviceId }),
+          },
+          DAEMON_CONFIG.TIMEOUTS.VERSION,
+          { silent: false, label: 'Set microphone device' }
+        );
+        if (response.ok) {
+          const data = await response.json();
+          if (data.device) setMicrophoneDevice(data.device);
+        }
+      } catch (err) {
+        console.warn('Failed to set microphone device:', err);
+      }
+    },
+    [buildApiUrl, fetchWithTimeout, DAEMON_CONFIG]
+  );
 
   // Actual API call for volume (extracted for debouncing)
   const updateVolumeInApi = useCallback(async newVolume => {
@@ -306,5 +392,12 @@ export function useAudioControls(isActive) {
     handleMicrophoneVolumeChange,
     handleSpeakerMute,
     handleMicrophoneMute,
+    deviceSelectionSupported,
+    availableSpeakers,
+    availableMicrophones,
+    devicesLoading,
+    fetchAudioDevices,
+    handleSpeakerDeviceChange,
+    handleMicrophoneDeviceChange,
   };
 }


### PR DESCRIPTION
## Summary

- Add dropdown selectors for speaker/microphone devices in the audio controls panel
- Graceful fallback: when daemon returns 404 (endpoint not yet implemented), the existing read-only device text is preserved
- Device list refreshes on dropdown open via `onOpen` callback

## Required Daemon Endpoints (optional — app handles 404 gracefully)

```
GET  /api/audio/devices
→ { "speakers": [{ "id": "...", "name": "..." }], "microphones": [{ "id": "...", "name": "..." }] }

POST /api/audio/speaker/set-device
← { "device_id": "..." }
→ { "device": "...", "device_id": "..." }

POST /api/audio/microphone/set-device
← { "device_id": "..." }
→ { "device": "...", "device_id": "..." }
```

## Files Changed (4)

| File | Change |
|------|--------|
| `src/config/daemon.js` | Add 3 endpoint constants + silent endpoint entry |
| `src/views/active-robot/audio/hooks/useAudioControls.js` | Add device list fetching, capability detection, device change handlers |
| `src/views/active-robot/ActiveRobotView.jsx` | Pass-through 7 new props to AudioControls |
| `src/views/active-robot/audio/AudioControls.jsx` | Conditional Select dropdown (supported) vs Typography (fallback) |

## Test plan

- [ ] `vite build` passes without errors
- [ ] With daemon **not** supporting `/api/audio/devices` (404): existing read-only text displayed as before
- [ ] With daemon supporting the endpoint: dropdown shows available devices, selection triggers set-device API call
- [ ] Dropdown `onOpen` refreshes device list from daemon

🤖 Generated with [Claude Code](https://claude.com/claude-code)