### PR TITLE
feat: add reset apps cache button in settings

### DIFF
--- a/src/components/viewer3d/SettingsOverlay.jsx
+++ b/src/components/viewer3d/SettingsOverlay.jsx
@@ -25,7 +25,8 @@ import { useWakeSleep } from '../../views/active-robot/hooks';
  * Settings Overlay for 3D Viewer Configuration
  */
 export default function SettingsOverlay({ open, onClose, darkMode }) {
-  const { connectionMode, remoteHost, robotStatus, blacklistRobot, resetAll } = useAppStore();
+  const { connectionMode, remoteHost, robotStatus, blacklistRobot, resetAll, clearApps } =
+    useAppStore();
   const isWifiMode = connectionMode === 'wifi';
 
   // Wake/Sleep controls - used to put robot to sleep before update
@@ -88,6 +89,8 @@ export default function SettingsOverlay({ open, onClose, darkMode }) {
   const [showChangeWifiOverlay, setShowChangeWifiOverlay] = useState(false);
   const [showClearNetworksConfirm, setShowClearNetworksConfirm] = useState(false);
   const [isClearingNetworks, setIsClearingNetworks] = useState(false);
+  const [showResetAppsConfirm, setShowResetAppsConfirm] = useState(false);
+  const [isResettingApps, setIsResettingApps] = useState(false);
 
   // ═══════════════════════════════════════════════════════════════════
   // TOAST NOTIFICATIONS (global - rendered in App.jsx)
@@ -407,6 +410,42 @@ export default function SettingsOverlay({ open, onClose, darkMode }) {
     }
   }, [onClose, showToast, remoteHost, blacklistRobot, resetAll]);
 
+  // ═══════════════════════════════════════════════════════════════════
+  // RESET APPS FUNCTIONS
+  // ═══════════════════════════════════════════════════════════════════
+
+  const handleResetAppsClick = useCallback(() => {
+    setShowResetAppsConfirm(true);
+  }, []);
+
+  const confirmResetApps = useCallback(async () => {
+    setShowResetAppsConfirm(false);
+    setIsResettingApps(true);
+
+    try {
+      const response = await fetchWithTimeout(
+        buildApiUrl('/cache/reset-apps'),
+        { method: 'POST' },
+        DAEMON_CONFIG.TIMEOUTS.COMMAND,
+        { label: 'Reset apps cache', silent: true }
+      );
+
+      if (response.ok) {
+        const data = await response.json();
+        clearApps();
+        showToast(data.message || 'Apps cache reset successfully', 'success');
+      } else {
+        const error = await response.json();
+        showToast(error.detail || 'Failed to reset apps cache', 'error');
+      }
+    } catch (err) {
+      console.error('Failed to reset apps cache:', err);
+      showToast('Connection error', 'error');
+    } finally {
+      setIsResettingApps(false);
+    }
+  }, [clearApps, showToast]);
+
   // Connect to WiFi (called from Change Network overlay)
   const handleWifiConnect = useCallback(async () => {
     if (!selectedSSID || !wifiPassword) return;
@@ -669,6 +708,8 @@ export default function SettingsOverlay({ open, onClose, darkMode }) {
               darkMode={darkMode}
               cardStyle={cardStyle}
               buttonStyle={buttonStyle}
+              onResetAppsClick={handleResetAppsClick}
+              isResettingApps={isResettingApps}
             />
           )}
         </Box>
@@ -966,6 +1007,120 @@ export default function SettingsOverlay({ open, onClose, darkMode }) {
               ) : (
                 'Clear all'
               )}
+            </Button>
+          </Box>
+        </Box>
+      </FullscreenOverlay>
+
+      {/* Reset Apps Confirmation Overlay */}
+      <FullscreenOverlay
+        open={showResetAppsConfirm}
+        onClose={() => setShowResetAppsConfirm(false)}
+        darkMode={darkMode}
+        zIndex={10003}
+        backdropOpacity={0.85}
+        debugName="ResetAppsConfirm"
+        backdropBlur={12}
+      >
+        <Box
+          sx={{
+            width: '100%',
+            maxWidth: 380,
+            mx: 'auto',
+            px: 3,
+            textAlign: 'center',
+          }}
+        >
+          {/* Warning icon */}
+          <Box
+            sx={{
+              mb: 3,
+              display: 'flex',
+              justifyContent: 'center',
+            }}
+          >
+            <Box
+              sx={{
+                width: 80,
+                height: 80,
+                borderRadius: '50%',
+                bgcolor: darkMode ? 'rgba(239, 68, 68, 0.15)' : 'rgba(239, 68, 68, 0.1)',
+                border: `2px solid ${darkMode ? 'rgba(239, 68, 68, 0.3)' : 'rgba(239, 68, 68, 0.2)'}`,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <ErrorOutlineIcon sx={{ fontSize: 40, color: '#ef4444' }} />
+            </Box>
+          </Box>
+
+          {/* Title */}
+          <Typography
+            variant="h5"
+            sx={{
+              fontWeight: 600,
+              color: 'text.primary',
+              mb: 2,
+            }}
+          >
+            Reset Apps Cache?
+          </Typography>
+
+          {/* Description */}
+          <Typography
+            sx={{
+              color: 'text.secondary',
+              fontSize: 14,
+              lineHeight: 1.6,
+              mb: 3,
+            }}
+          >
+            This will{' '}
+            <strong style={{ color: darkMode ? '#fff' : '#333' }}>
+              remove all installed applications
+            </strong>{' '}
+            from the robot. You will need to reinstall them individually from the app store.
+          </Typography>
+
+          {/* Actions */}
+          <Box sx={{ display: 'flex', gap: 3, justifyContent: 'center', alignItems: 'center' }}>
+            <Button
+              onClick={() => setShowResetAppsConfirm(false)}
+              variant="text"
+              sx={{
+                color: 'text.secondary',
+                textTransform: 'none',
+                textDecoration: 'underline',
+                textUnderlineOffset: '3px',
+                '&:hover': {
+                  bgcolor: 'transparent',
+                  textDecoration: 'underline',
+                },
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={confirmResetApps}
+              variant="contained"
+              disabled={isResettingApps}
+              sx={{
+                minWidth: 160,
+                bgcolor: '#ef4444',
+                color: '#fff',
+                textTransform: 'none',
+                fontWeight: 600,
+                '&:hover': {
+                  bgcolor: '#dc2626',
+                },
+                '&:disabled': {
+                  bgcolor: darkMode ? 'rgba(239, 68, 68, 0.3)' : 'rgba(239, 68, 68, 0.5)',
+                  color: darkMode ? 'rgba(255,255,255,0.5)' : 'rgba(255,255,255,0.8)',
+                },
+              }}
+            >
+              Reset all apps
             </Button>
           </Box>
         </Box>

--- a/src/components/viewer3d/settings/SettingsCacheCard.jsx
+++ b/src/components/viewer3d/settings/SettingsCacheCard.jsx
@@ -7,9 +7,15 @@ import { useToast } from '../../../hooks/useToast';
 
 /**
  * Cache Card Component
- * Allows clearing HuggingFace cache on the robot
+ * Allows clearing HuggingFace cache and resetting apps on the robot
  */
-export default function SettingsCacheCard({ darkMode, cardStyle, buttonStyle }) {
+export default function SettingsCacheCard({
+  darkMode,
+  cardStyle,
+  buttonStyle,
+  onResetAppsClick,
+  isResettingApps,
+}) {
   const [isClearing, setIsClearing] = useState(false);
   const { showToast } = useToast();
 
@@ -77,6 +83,39 @@ export default function SettingsCacheCard({ darkMode, cardStyle, buttonStyle }) 
           }}
         >
           {isClearing ? 'Clearing...' : 'Clear HuggingFace Cache'}
+        </Button>
+
+        <Typography sx={{ fontSize: 12, color: textSecondary, lineHeight: 1.5 }}>
+          Remove all installed applications from the robot. They will need to be reinstalled from
+          the app store.
+        </Typography>
+
+        <Button
+          variant="outlined"
+          onClick={onResetAppsClick}
+          disabled={isResettingApps}
+          startIcon={
+            isResettingApps ? <CircularProgress size={16} color="inherit" /> : <DeleteOutlineIcon />
+          }
+          sx={{
+            ...buttonStyle,
+            fontSize: 12,
+            py: 0.75,
+            px: 2,
+            borderRadius: '8px',
+            color: darkMode ? '#f87171' : '#dc2626',
+            borderColor: darkMode ? 'rgba(248, 113, 113, 0.5)' : 'rgba(220, 38, 38, 0.5)',
+            '&:hover': {
+              borderColor: darkMode ? '#f87171' : '#dc2626',
+              bgcolor: darkMode ? 'rgba(248, 113, 113, 0.1)' : 'rgba(220, 38, 38, 0.08)',
+            },
+            '&:disabled': {
+              borderColor: darkMode ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)',
+              color: darkMode ? '#555' : '#bbb',
+            },
+          }}
+        >
+          {isResettingApps ? 'Resetting...' : 'Reset Apps Cache'}
         </Button>
       </Box>
     </Box>


### PR DESCRIPTION
Adds a button in the Cache Management settings card that calls the daemon's /cache/reset-apps endpoint to remove all installed applications. Clears the local Zustand apps cache on success so the UI reflects the change immediately without requiring a restart.

This is only accessible for Wireless version.