### PR TITLE
fix/proxy detected as external daemon

### DIFF
--- a/src/hooks/daemon/useDaemon.js
+++ b/src/hooks/daemon/useDaemon.js
@@ -474,6 +474,13 @@ export const useDaemon = () => {
         // Continue with reset
       }
 
+      // Clear the local proxy so discovery doesn't detect a stale forwarded daemon
+      try {
+        await invoke('clear_local_proxy_target');
+      } catch (e) {
+        // Continue with reset
+      }
+
       setTimeout(() => {
         resetAll();
       }, DAEMON_CONFIG.ANIMATIONS.STOP_DAEMON_DELAY);

--- a/src/views/finding-robot/FindingRobotView.jsx
+++ b/src/views/finding-robot/FindingRobotView.jsx
@@ -251,6 +251,9 @@ export default function FindingRobotView() {
   useEffect(() => {
     if (isBusy) return;
 
+    // Reset immediately so stale state from a previous session doesn't linger
+    setExternalDaemonAvailable(false);
+
     const checkExternalDaemon = async () => {
       try {
         const response = await fetchWithTimeout(


### PR DESCRIPTION
Start the desktop app, connect to a wireless,
come back to main screen, unkilled proxy shall now be properly stopped and not display as an external daemon