### PR TITLE
Disable gstreamer plugin scan.

### DIFF
--- a/src-tauri/src/daemon/mod.rs
+++ b/src-tauri/src/daemon/mod.rs
@@ -500,7 +500,10 @@ pub fn spawn_and_monitor_sidecar(
         .sidecar("uv-trampoline")
         .map_err(|e| e.to_string())?
         .args(daemon_args_refs)
-        .env("PYTHONIOENCODING", "utf-8");
+        .env("PYTHONIOENCODING", "utf-8")
+        // Disable GStreamer external plugin scanner to prevent 30s+ hang
+        // caused by libgstpython.dylib trying to load a missing system Python framework
+        .env("GST_PLUGIN_SCANNER", "");
 
     let (mut rx, child) = sidecar_command.spawn().map_err(|e| e.to_string())?;
 
@@ -628,6 +631,7 @@ pub fn spawn_and_monitor_sidecar(
                         match sidecar_cmd
                             .args(daemon_args_refs)
                             .env("PYTHONIOENCODING", "utf-8")
+                            .env("GST_PLUGIN_SCANNER", "")
                             .spawn()
                         {
                             Ok((mut new_rx, new_child)) => {


### PR DESCRIPTION
Scan for plugins was taking too much time and make the simulation mode timeout.