### PR TITLE
Increase signing timeout to 60m

### DIFF
--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -1251,10 +1251,10 @@ jobs:
             --key-id "$APPLE_API_KEY" \
             --issuer "$APPLE_API_ISSUER" \
             --wait \
-            --timeout 30m 2>&1) || NOTARIZATION_EXIT_CODE=$?
-          
+            --timeout 60m 2>&1) || NOTARIZATION_EXIT_CODE=$?
+
           echo "$NOTARIZATION_OUTPUT"
-          
+
           # Check if notarization was successful
           if echo "$NOTARIZATION_OUTPUT" | grep -q "status: Accepted"; then
             echo "✅ App notarization successful!"
@@ -1396,10 +1396,10 @@ jobs:
             --key-id "$APPLE_API_KEY" \
             --issuer "$APPLE_API_ISSUER" \
             --wait \
-            --timeout 30m 2>&1) || NOTARIZATION_EXIT_CODE=$?
-          
+            --timeout 60m 2>&1) || NOTARIZATION_EXIT_CODE=$?
+
           echo "$NOTARIZATION_OUTPUT"
-          
+
           # Check if notarization was successful
           if echo "$NOTARIZATION_OUTPUT" | grep -q "status: Accepted"; then
             echo "✅ DMG notarization successful!"


### PR DESCRIPTION
Due to binary increase size (adding gstreamer wheel), we need to increase macOS notarization timeout to 60m (in practice it seems to take about ~45m). 