### PR TITLE
feat: embed app web UI in right panel

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -28,7 +28,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self' ipc: asset: https://asset.localhost; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https: asset: https://asset.localhost; font-src 'self' data: asset: https://asset.localhost; media-src 'self' blob: mediastream:; worker-src 'self' blob:; connect-src 'self' ipc: https://ipc.localhost http: https: ws: wss: data: blob:",
+      "csp": "default-src 'self' ipc: asset: https://asset.localhost; script-src 'self' 'unsafe-inline' 'unsafe-eval' http://localhost:* http://127.0.0.1:*; style-src 'self' 'unsafe-inline' http://localhost:* http://127.0.0.1:*; img-src 'self' data: blob: https: asset: https://asset.localhost http://localhost:* http://127.0.0.1:*; font-src 'self' data: asset: https://asset.localhost http://localhost:* http://127.0.0.1:*; media-src 'self' blob: mediastream:; worker-src 'self' blob:; connect-src 'self' ipc: https://ipc.localhost http: https: ws: wss: data: blob:; frame-src http://localhost:* http://127.0.0.1:*",
       "dangerousDisableAssetCspModification": ["style-src"]
     },
     "macOSPrivateApi": true

--- a/src/hooks/daemon/useDaemon.js
+++ b/src/hooks/daemon/useDaemon.js
@@ -522,6 +522,7 @@ export const useDaemon = () => {
       }
     }
     await closeAllAppWindows();
+    useAppStore.getState().closeEmbeddedApp();
 
     // Wait for any daemon goto_target to complete
     await new Promise(resolve => setTimeout(resolve, 500));

--- a/src/hooks/useActiveRobotAdapter.js
+++ b/src/hooks/useActiveRobotAdapter.js
@@ -37,6 +37,7 @@ export function useActiveRobotAdapter() {
   const activeMoves = useAppStore(state => state.activeMoves);
   const isDaemonCrashed = useAppStore(state => state.isDaemonCrashed);
   const rightPanelView = useAppStore(state => state.rightPanelView);
+  const embeddedAppUrl = useAppStore(state => state.embeddedAppUrl);
   const activeEffect = useAppStore(state => state.activeEffect);
   const effectTimestamp = useAppStore(state => state.effectTimestamp);
 
@@ -79,6 +80,7 @@ export function useActiveRobotAdapter() {
       activeMoves,
       isDaemonCrashed,
       rightPanelView,
+      embeddedAppUrl,
       activeEffect,
       effectTimestamp,
 
@@ -117,6 +119,7 @@ export function useActiveRobotAdapter() {
       activeMoves,
       isDaemonCrashed,
       rightPanelView,
+      embeddedAppUrl,
       activeEffect,
       effectTimestamp,
       availableApps,
@@ -178,6 +181,8 @@ export function useActiveRobotAdapter() {
 
       // UI
       setRightPanelView: store.setRightPanelView,
+      openEmbeddedApp: store.openEmbeddedApp,
+      closeEmbeddedApp: store.closeEmbeddedApp,
       setDarkMode: store.setDarkMode,
       toggleDarkMode: store.toggleDarkMode,
 

--- a/src/hooks/useWebActiveRobotAdapter.js
+++ b/src/hooks/useWebActiveRobotAdapter.js
@@ -33,6 +33,7 @@ export function useWebActiveRobotAdapter() {
   const activeMoves = useAppStore(state => state.activeMoves);
   const isDaemonCrashed = useAppStore(state => state.isDaemonCrashed);
   const rightPanelView = useAppStore(state => state.rightPanelView);
+  const embeddedAppUrl = useAppStore(state => state.embeddedAppUrl);
   const activeEffect = useAppStore(state => state.activeEffect);
   const effectTimestamp = useAppStore(state => state.effectTimestamp);
 
@@ -76,6 +77,7 @@ export function useWebActiveRobotAdapter() {
       activeMoves,
       isDaemonCrashed,
       rightPanelView,
+      embeddedAppUrl,
       activeEffect,
       effectTimestamp,
       availableApps,
@@ -110,6 +112,7 @@ export function useWebActiveRobotAdapter() {
       activeMoves,
       isDaemonCrashed,
       rightPanelView,
+      embeddedAppUrl,
       activeEffect,
       effectTimestamp,
       availableApps,
@@ -157,6 +160,8 @@ export function useWebActiveRobotAdapter() {
       resetTimeouts: store.resetTimeouts,
       incrementTimeouts: store.incrementTimeouts,
       setRightPanelView: store.setRightPanelView,
+      openEmbeddedApp: store.openEmbeddedApp,
+      closeEmbeddedApp: store.closeEmbeddedApp,
       setDarkMode: store.setDarkMode,
       toggleDarkMode: store.toggleDarkMode,
       setAvailableApps: store.setAvailableApps,

--- a/src/store/slices/uiSlice.js
+++ b/src/store/slices/uiSlice.js
@@ -30,7 +30,9 @@ const getInitialDarkMode = () => {
 export const uiInitialState = {
   darkMode: getInitialDarkMode(),
   openWindows: [],
-  rightPanelView: null, // null | 'controller' | 'expressions'
+  rightPanelView: null, // null | 'controller' | 'expressions' | 'embedded-app'
+  embeddedAppUrl: null, // URL to display in the right panel iframe when rightPanelView === 'embedded-app'
+  embeddedAppDismissed: false, // true when user manually closed the embedded view (prevents auto-reopen)
   showFirstTimeWifiSetup: false, // true when showing first time WiFi setup view
   showBluetoothSupportView: false, // true when showing Bluetooth support/reset view
   // 🔄 Update view state - user can skip proposed updates
@@ -73,6 +75,15 @@ export const createUISlice = (set, get) => ({
 
   // Right panel view management
   setRightPanelView: view => set({ rightPanelView: view }),
+
+  // Embedded app management
+  setEmbeddedAppUrl: url => set({ embeddedAppUrl: url }),
+  openEmbeddedApp: url =>
+    set({ rightPanelView: 'embedded-app', embeddedAppUrl: url, embeddedAppDismissed: false }),
+  closeEmbeddedApp: () => set({ rightPanelView: null, embeddedAppUrl: null }),
+  dismissEmbeddedApp: () =>
+    set({ rightPanelView: null, embeddedAppUrl: null, embeddedAppDismissed: true }),
+  resetEmbeddedAppDismissed: () => set({ embeddedAppDismissed: false }),
 
   // First time WiFi setup view management
   setShowFirstTimeWifiSetup: value => set({ showFirstTimeWifiSetup: value }),

--- a/src/views/active-robot/application-store/hooks/useAppsStore.js
+++ b/src/views/active-robot/application-store/hooks/useAppsStore.js
@@ -322,9 +322,11 @@ export function useAppsStore(isActive) {
 
           if (appState === 'done') {
             setCurrentApp(null);
+            store.closeEmbeddedApp();
           } else if (appState === 'error') {
             // Keep error visible in the UI; close the dead Tauri window
             closeAppWindow(appName).catch(() => {});
+            store.closeEmbeddedApp();
 
             // Auto-clear the error after a delay so the user can launch another app
             if (!errorClearTimerRef.current) {
@@ -342,10 +344,11 @@ export function useAppsStore(isActive) {
         if (store.isAppRunning && store.busyReason === 'app-running') {
           const lastAppName = store.currentAppName || 'unknown';
 
-          // Close the dead Tauri window if one was open
+          // Close the dead Tauri window / embedded view if one was open
           if (lastAppName !== 'unknown') {
             closeAppWindow(lastAppName).catch(() => {});
           }
+          store.closeEmbeddedApp();
 
           logger.warning(`App ${lastAppName} stopped unexpectedly`);
           store.unlockApp();
@@ -545,11 +548,12 @@ export function useAppsStore(isActive) {
 
       const message = await response.json();
 
-      // Close the app's Tauri window if it was open
+      // Close the app's Tauri window / embedded view if it was open
       const appInfo = useAppStore.getState().currentApp?.info;
       if (appInfo?.name) {
         closeAppWindow(appInfo.name).catch(() => {});
       }
+      useAppStore.getState().closeEmbeddedApp();
 
       // Reset state immediately
       setCurrentApp(null);

--- a/src/views/active-robot/application-store/installed/InstalledAppsSection.jsx
+++ b/src/views/active-robot/application-store/installed/InstalledAppsSection.jsx
@@ -21,7 +21,6 @@ import CheckCircleOutlinedIcon from '@mui/icons-material/CheckCircleOutlined';
 import DiscoverAppsButton from '../discover/Button';
 import ReachiesCarousel from '@components/ReachiesCarousel';
 import { getDaemonHostname } from '../../../../config/daemon';
-import { openAppWindow } from '../../../../utils/windowManager';
 import useAppStore from '../../../../store/useAppStore';
 
 // ✅ Timeout for app to transition from "starting" to "running"
@@ -250,12 +249,30 @@ function OpenAppButton({
     60000 // 60 seconds timeout (doubled for slow app startups)
   );
 
-  // Reset timeout state when app stops/starts
+  // Reset state when app stops/starts
   useEffect(() => {
     if (!isStartingOrRunning) {
       setHasTimedOut(false);
+      // Reset dismissed flag so next app launch can auto-open
+      useAppStore.getState().resetEmbeddedAppDismissed();
     }
   }, [isStartingOrRunning]);
+
+  // Auto-open the embedded view as soon as the URL becomes accessible
+  useEffect(() => {
+    if (!isAccessible || !customAppUrl) return;
+    const store = useAppStore.getState();
+    // Don't auto-open if user dismissed, or if already embedded
+    if (store.embeddedAppDismissed) return;
+    if (store.rightPanelView === 'embedded-app') return;
+    try {
+      const url = new URL(customAppUrl);
+      url.hostname = getDaemonHostname();
+      store.openEmbeddedApp(url.toString());
+    } catch {
+      // URL parsing failed — user can still open manually
+    }
+  }, [isAccessible, customAppUrl]);
 
   // Don't show button if no URL
   if (!customAppUrl) return null;
@@ -266,24 +283,16 @@ function OpenAppButton({
   // Don't show button if timed out (app will be in error state)
   if (hasTimedOut) return null;
 
-  // Only show button if still checking (waiting)
-  // Once accessible, show the active button
+  // Don't show button if already embedded
+  const store = useAppStore.getState();
+  if (store.rightPanelView === 'embedded-app' && store.embeddedAppUrl) return null;
+
   const handleClick = async e => {
     e.stopPropagation();
     try {
       const url = new URL(customAppUrl);
       url.hostname = getDaemonHostname();
-
-      // Open in a dedicated Tauri window (falls back to browser if not in Tauri)
-      const appWindow = await openAppWindow(appName, url.toString());
-      if (!appWindow) {
-        try {
-          const { open } = await import('@tauri-apps/plugin-shell');
-          await open(url.toString());
-        } catch {
-          window.open(url.toString(), '_blank', 'noopener,noreferrer');
-        }
-      }
+      useAppStore.getState().openEmbeddedApp(url.toString());
     } catch (err) {
       console.error('Failed to open app web interface:', err);
     }

--- a/src/views/active-robot/right-panel/EmbeddedAppView.jsx
+++ b/src/views/active-robot/right-panel/EmbeddedAppView.jsx
@@ -1,0 +1,257 @@
+import React, { useMemo, useState, useEffect, useRef } from 'react';
+import { Box, Typography, IconButton, Tooltip } from '@mui/material';
+import StopCircleOutlinedIcon from '@mui/icons-material/StopCircleOutlined';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import { useActiveRobotContext } from '../context';
+import { openAppWindow, closeAppWindow } from '../../../utils/windowManager';
+import useAppStore from '../../../store/useAppStore';
+import { buildApiUrl, fetchWithTimeout, DAEMON_CONFIG } from '../../../config/daemon';
+
+/**
+ * Build the iframe URL with theme query parameters so apps can adapt their styling.
+ *
+ * Apps receive:
+ *   ?embedded=1          — signals the app is rendered inside the desktop panel
+ *   &theme=dark|light    — current theme
+ *   &accent=FF9500       — primary accent color (hex without #)
+ *   &bg=1a1a1a|fafafc    — panel background color
+ *   &fg=f5f5f5|333333    — foreground text color
+ */
+function buildEmbeddedUrl(baseUrl, darkMode) {
+  try {
+    const url = new URL(baseUrl);
+    url.searchParams.set('embedded', '1');
+    url.searchParams.set('theme', darkMode ? 'dark' : 'light');
+    url.searchParams.set('accent', 'FF9500');
+    url.searchParams.set('bg', darkMode ? '1a1a1a' : 'fafafc');
+    url.searchParams.set('fg', darkMode ? 'f5f5f5' : '333333');
+    url.searchParams.set('_t', Date.now()); // cache-bust: apps often reuse the same port
+    return url.toString();
+  } catch {
+    return baseUrl;
+  }
+}
+
+/**
+ * Bust the WebView cache for an app's static resources.
+ *
+ * Different apps reuse the same localhost port, so the WebView may serve
+ * stale CSS/JS from a previously-run app.  We fetch the index HTML with
+ * `cache: 'reload'` (bypasses cache, updates it with the fresh response),
+ * extract <script src> and <link rel="stylesheet" href> URLs, and pre-fetch
+ * those too.  By the time the iframe loads, the cache holds the correct files.
+ */
+async function bustCacheForApp(baseUrl) {
+  try {
+    const res = await fetch(baseUrl, { cache: 'reload' });
+    const html = res.ok ? await res.text() : '';
+
+    // Extract src/href from <script src="..."> and <link ... href="...">
+    const resourceUrls = [];
+    const scriptRe = /<script[^>]+src=["']([^"']+)["']/gi;
+    const linkRe = /<link[^>]+href=["']([^"']+)["']/gi;
+    for (const re of [scriptRe, linkRe]) {
+      let m;
+      while ((m = re.exec(html)) !== null) {
+        resourceUrls.push(m[1]);
+      }
+    }
+
+    // Pre-fetch each resource to refresh the cache
+    await Promise.all(
+      resourceUrls.map(path => {
+        const url = new URL(path, baseUrl).toString();
+        return fetch(url, { cache: 'reload' }).catch(() => {});
+      })
+    );
+  } catch {
+    // Best-effort — if this fails the iframe still loads normally
+  }
+}
+
+/**
+ * Embedded App View — displays a running app's web UI in an iframe
+ * inside the right panel, with a toolbar for stop / pop-out actions.
+ */
+export default function EmbeddedAppView({ darkMode = false }) {
+  const { robotState, actions } = useActiveRobotContext();
+  const { embeddedAppUrl, currentAppName } = robotState;
+  const [cacheReady, setCacheReady] = useState(false);
+  const bustKeyRef = useRef(null);
+
+  // Bust cache before showing iframe — ensures subresources match the current app
+  useEffect(() => {
+    if (!embeddedAppUrl) {
+      setCacheReady(false);
+      bustKeyRef.current = null;
+      return;
+    }
+
+    const key = `${embeddedAppUrl}::${currentAppName}`;
+    if (bustKeyRef.current === key) return; // already busted for this app
+    bustKeyRef.current = key;
+    setCacheReady(false);
+
+    bustCacheForApp(embeddedAppUrl).then(() => {
+      // Only mark ready if this is still the current bust (prevents race condition
+      // when apps switch quickly: old promise resolving must not unlock the new app)
+      if (bustKeyRef.current === key) setCacheReady(true);
+    });
+  }, [embeddedAppUrl, currentAppName]);
+
+  const iframeSrc = useMemo(
+    () => (embeddedAppUrl && cacheReady ? buildEmbeddedUrl(embeddedAppUrl, darkMode) : null),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [embeddedAppUrl, darkMode, currentAppName, cacheReady]
+  );
+
+  const handleClose = async () => {
+    const store = useAppStore.getState();
+
+    // Dismiss the embedded view immediately (prevents auto-reopen)
+    store.dismissEmbeddedApp();
+    store.setIsStoppingApp(true);
+
+    try {
+      const response = await fetchWithTimeout(
+        buildApiUrl('/api/apps/stop-current-app'),
+        { method: 'POST' },
+        DAEMON_CONFIG.TIMEOUTS.APP_STOP,
+        { silent: true }
+      );
+
+      if (!response.ok) throw new Error(`Stop failed: ${response.status}`);
+      await response.json();
+
+      // Close any Tauri window that might be open for this app
+      const appInfo = store.currentApp?.info;
+      if (appInfo?.name) {
+        closeAppWindow(appInfo.name).catch(() => {});
+      }
+    } catch {
+      // Stop failed — status polling will eventually clean up
+    } finally {
+      // Always unlock regardless of success/failure
+      const s = useAppStore.getState();
+      s.setCurrentApp(null);
+      s.unlockApp();
+      s.setIsStoppingApp(false);
+    }
+  };
+
+  const handlePopOut = async () => {
+    if (!embeddedAppUrl || !currentAppName) return;
+    await openAppWindow(currentAppName, embeddedAppUrl);
+    useAppStore.getState().dismissEmbeddedApp();
+  };
+
+  if (!iframeSrc) return null;
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
+        minHeight: 0,
+      }}
+    >
+      {/* Toolbar */}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 0.5,
+          px: 2,
+          py: 0.75,
+          flexShrink: 0,
+          borderBottom: `1px solid ${darkMode ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)'}`,
+          bgcolor: darkMode ? 'rgba(255,255,255,0.02)' : 'rgba(0,0,0,0.02)',
+        }}
+      >
+        {/* Green dot — running indicator */}
+        <Box
+          sx={{
+            width: 6,
+            height: 6,
+            borderRadius: '50%',
+            bgcolor: '#22c55e',
+            flexShrink: 0,
+          }}
+        />
+
+        <Typography
+          sx={{
+            flex: 1,
+            fontSize: 12,
+            fontWeight: 600,
+            color: darkMode ? '#ccc' : '#555',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            ml: 0.5,
+          }}
+        >
+          {currentAppName || 'App'}
+        </Typography>
+
+        <Tooltip title="Open in separate window" arrow placement="top">
+          <IconButton
+            size="small"
+            onClick={handlePopOut}
+            sx={{
+              width: 24,
+              height: 24,
+              color: darkMode ? '#888' : '#999',
+              '&:hover': {
+                color: darkMode ? '#ddd' : '#333',
+                bgcolor: darkMode ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.04)',
+              },
+            }}
+          >
+            <OpenInNewIcon sx={{ fontSize: 14 }} />
+          </IconButton>
+        </Tooltip>
+
+        <Tooltip title="Stop app" arrow placement="top">
+          <IconButton
+            size="small"
+            onClick={handleClose}
+            sx={{
+              width: 24,
+              height: 24,
+              color: darkMode ? '#888' : '#999',
+              '&:hover': {
+                color: '#ef4444',
+                bgcolor: 'rgba(239, 68, 68, 0.08)',
+              },
+            }}
+          >
+            <StopCircleOutlinedIcon sx={{ fontSize: 15 }} />
+          </IconButton>
+        </Tooltip>
+      </Box>
+
+      {/* Iframe container */}
+      <Box
+        sx={{
+          flex: 1,
+          minHeight: 0,
+          bgcolor: darkMode ? '#1a1a1a' : '#fafafc',
+        }}
+      >
+        <iframe
+          src={iframeSrc}
+          title={currentAppName || 'App'}
+          style={{
+            width: '100%',
+            height: '100%',
+            border: 'none',
+            display: 'block',
+            colorScheme: darkMode ? 'dark' : 'light',
+          }}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/src/views/active-robot/right-panel/RightPanel.jsx
+++ b/src/views/active-robot/right-panel/RightPanel.jsx
@@ -5,6 +5,7 @@ import ControlButtons from './ControlButtons';
 import HfLoginOverlay from './applications/HfLoginOverlay';
 import { ControllerSection } from './controller';
 import ExpressionsSection from './expressions';
+import EmbeddedAppView from './EmbeddedAppView';
 import { useActiveRobotContext } from '../context';
 import { useHfAuth } from '../../../hooks/auth';
 
@@ -144,7 +145,9 @@ export default function RightPanel({
         )}
 
         {/* Conditional rendering based on rightPanelView */}
-        {rightPanelView === 'controller' ? (
+        {rightPanelView === 'embedded-app' ? (
+          <EmbeddedAppView darkMode={darkMode} />
+        ) : rightPanelView === 'controller' ? (
           <ControllerSection showToast={showToast} isBusy={isBusy} darkMode={darkMode} />
         ) : rightPanelView === 'expressions' ? (
           <ExpressionsSection isBusy={isBusy} darkMode={darkMode} />


### PR DESCRIPTION
## TL: DR

Having app UI opened directly in the right side panel. Started as a quick experiment but seems working quite well already!

## Summary
- Apps with `custom_app_url` now display their web interface in an iframe inside the right panel instead of opening a separate Tauri window
- Toolbar with stop button (kills app + cleanup) and pop-out button (falls back to separate window)
- Auto-opens when app URL becomes accessible, with dismiss tracking to prevent re-open loops
- Cache-busting pre-fetch (`bustCacheForApp`) to handle apps reusing the same localhost port — fetches HTML, extracts `<script>`/`<link>` URLs, and pre-fetches with `cache: 'reload'`
- CSP updated to allow iframe subresources (`script-src`, `style-src`, `img-src`, `font-src`) from `http://localhost:*` and `http://127.0.0.1:*`
- Theme params passed via URL query (`?embedded=1&theme=dark&accent=...`) so apps can adapt styling

## Demo


https://github.com/user-attachments/assets/274676bb-d9e4-44a4-bafb-9a653ce314c1


## Key files
- `EmbeddedAppView.jsx` — new component: iframe + toolbar + cache busting
- `uiSlice.js` — new state: `embeddedAppUrl`, `embeddedAppDismissed`, open/close/dismiss actions
- `InstalledAppsSection.jsx` — `OpenAppButton` auto-opens embedded view when URL accessible
- Both adapters updated to bridge new store state

## Companion change
- `reachy_mini/apps/app.py` — added `Cache-Control: no-store` middleware to prevent WebView from caching static files across different apps on the same port

And I also added a guide to write UI which fits into the desktop app: https://github.com/pollen-robotics/reachy_mini/pull/958
