### PR TITLE
build: support both macOS x86_64 and aarch64 architectures

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This desktop application provides a unified interface to manage your Reachy Mini
 ```bash
 # Clone the repository
 git clone https://github.com/pollen-robotics/reachy-mini-desktop-app.git
-cd reachy-mini-desktop-app/reachy_mini_desktop_app
+cd reachy-mini-desktop-app
 
 # Install dependencies
 yarn install

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -4,8 +4,8 @@
       "binaries/uv": "uv",
       "binaries/uvx": "uvx",
       "binaries/.venv": ".venv",
-      "binaries/cpython-3.12.13-macos-aarch64-none": "cpython-3.12.13-macos-aarch64-none",
-      "binaries/cpython-3.12.13-macos-aarch64-none/lib": ".venv/lib",
+      "binaries/cpython-3.12.13-macos-*-none": ".",
+      "binaries/cpython-3.12.13-macos-*-none/lib": ".venv/lib",
       "python-entitlements.plist": "python-entitlements.plist",
       "../scripts/avast_ssl_fix.py": "scripts/avast_ssl_fix.py"
     },
@@ -19,4 +19,3 @@
     }
   }
 }
-


### PR DESCRIPTION
- Update installation instructions in README.md to fix the directory path.
- Use a wildcard for the cpython runtime folder in tauri.macos.conf.json to dynamically support different macOS architectures during build.
- Map the architecture-specific cpython directory to the resources root while preserving its original folder name.

Using the wildcard binaries/cpython-3.12.13-macos-*-none mapped to . ensure that whichever architecture-specific Python runtime is present in src-tauri/binaries/ after the sidecar build step will be correctly included in the macOS .app bundle's Resources folder. This avoids the need for maintaining separate architecture-specific Tauri configuration files or swapping them via scripts.

The uv-trampoline sidecar correctly resolves this path because it searches for any directory starting with cpython- relative to the bundle's resources.

Another approach could be using the same as Linux :

```
# Use the simplified PyInstaller config (single binary, no venv)
cp src-tauri/tauri.linux.pyinstaller.conf.json src-tauri/tauri.linux.conf.json
```

Tested on :
OS: macOS 26.3.1 25D2128 x86_64
CPU: Intel i5-1038NG7 (8) @ 2.00GHz
GPU: Intel Iris Plus Graphics
Memory : 16Go