### PR TITLE
feat(slides): enabling volume control sliders even when apps run 

### DIFF
--- a/src/views/active-robot/ActiveRobotView.jsx
+++ b/src/views/active-robot/ActiveRobotView.jsx
@@ -518,7 +518,7 @@ function ActiveRobotView({
                 onSpeakerMute={handleSpeakerMute}
                 onMicrophoneMute={handleMicrophoneMute}
                 darkMode={darkMode}
-                disabled={isBusyState}
+                disabled={isBusyState && !isAppRunning}
                 isSleeping={false}
               />
             </Box>


### PR DESCRIPTION
This PR enables the volume control sliders (speakers/microphones) even when apps run. They have been designed to work even in this situation ;)