### PR TITLE
fix(macos): auto-reload WebView when content process is terminated

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -358,6 +358,7 @@ pub fn run() {
                 {
                     if let Some(win) = app.get_webview_window("main") {
                         window::setup_transparent_titlebar(&win);
+                        window::setup_content_process_handler(&win);
                     }
                     permissions::request_all_permissions();
                 }

--- a/src-tauri/src/window/mod.rs
+++ b/src-tauri/src/window/mod.rs
@@ -18,6 +18,92 @@ pub fn setup_transparent_titlebar(window: &tauri::WebviewWindow) {
     }
 }
 
+/// Workaround for WKWebView web content process termination (macOS).
+/// When macOS kills the WebView's render process (memory pressure, idle, sleep),
+/// the WebView goes white with no JS running. This hooks into the WKNavigationDelegate
+/// to auto-reload when that happens.
+/// See: https://github.com/tauri-apps/tauri/issues/14371
+#[cfg(target_os = "macos")]
+pub fn setup_content_process_handler(window: &tauri::WebviewWindow) {
+    use cocoa::base::{id, nil};
+    use objc::runtime::{Class, Object, Sel};
+    use objc::{msg_send, sel, sel_impl};
+    use std::os::raw::c_char;
+
+    extern "C" {
+        fn class_replaceMethod(
+            cls: *const Class,
+            name: Sel,
+            imp: extern "C" fn(&Object, Sel, id),
+            types: *const c_char,
+        ) -> *const std::ffi::c_void;
+    }
+
+    if let Ok(ns_window_ptr) = window.ns_window() {
+        unsafe {
+            let ns_window = ns_window_ptr as id;
+            let content_view: id = msg_send![ns_window, contentView];
+            let wk_webview = find_wkwebview_in_view(content_view);
+
+            if wk_webview == nil {
+                log::warn!("[WKWebView] Could not find WKWebView in view hierarchy");
+                return;
+            }
+
+            let delegate: id = msg_send![wk_webview, navigationDelegate];
+            if delegate == nil {
+                log::warn!("[WKWebView] No navigation delegate on WKWebView");
+                return;
+            }
+
+            let cls: *const Class = objc::runtime::object_getClass(delegate);
+
+            extern "C" fn on_content_process_terminate(_this: &Object, _cmd: Sel, webview: id) {
+                log::warn!("[WKWebView] Web content process terminated - reloading webview");
+                unsafe {
+                    let _: () = msg_send![webview, reload];
+                }
+            }
+
+            let sel = sel!(webViewWebContentProcessDidTerminate:);
+            let types = b"v@:@\0".as_ptr() as *const c_char;
+            class_replaceMethod(cls, sel, on_content_process_terminate, types);
+            log::info!("[WKWebView] Content process termination handler installed");
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn find_wkwebview_in_view(view: cocoa::base::id) -> cocoa::base::id {
+    use cocoa::base::{id, nil, BOOL, YES};
+    use objc::runtime::Class;
+    use objc::{msg_send, sel, sel_impl};
+
+    if view == nil {
+        return nil;
+    }
+
+    if let Some(wk_class) = Class::get("WKWebView") {
+        let is_wkwebview: BOOL = msg_send![view, isKindOfClass: wk_class];
+        if is_wkwebview == YES {
+            return view;
+        }
+    }
+
+    let subviews: id = msg_send![view, subviews];
+    let count: usize = msg_send![subviews, count];
+
+    for i in 0..count {
+        let subview: id = msg_send![subviews, objectAtIndex: i];
+        let found = find_wkwebview_in_view(subview);
+        if found != nil {
+            return found;
+        }
+    }
+
+    nil
+}
+
 #[tauri::command]
 pub fn apply_transparent_titlebar(_app: AppHandle, _window_label: String) -> Result<(), String> {
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Summary

- Workaround for a macOS bug where the WKWebView render process gets killed by the OS (memory pressure, idle timeout, sleep), leaving the app window blank with no JavaScript running
- Hooks into `WKNavigationDelegate` via Objective-C runtime to detect `webContentProcessDidTerminate` and auto-reload the WebView
- Fixes: https://github.com/tauri-apps/tauri/issues/14371

## Test plan

- [ ] Put Mac to sleep, wake it up — app should recover instead of showing a white screen
- [ ] Verify no regression on normal app startup and navigation

Made with [Cursor](https://cursor.com)