### PR TITLE
fix(hmr): clean up event listeners on hot module reload

### DIFF
--- a/src/store/slices/uiSlice.js
+++ b/src/store/slices/uiSlice.js
@@ -169,7 +169,7 @@ export const createUISlice = (set, get) => ({
  * Call this once when the store is created
  */
 export const setupSystemPreferenceListener = (getState, setState) => {
-  if (typeof window === 'undefined') return;
+  if (typeof window === 'undefined') return () => {};
 
   const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
 
@@ -185,4 +185,12 @@ export const setupSystemPreferenceListener = (getState, setState) => {
   } else {
     mediaQuery.addListener(handleSystemPreferenceChange);
   }
+
+  return () => {
+    if (mediaQuery.removeEventListener) {
+      mediaQuery.removeEventListener('change', handleSystemPreferenceChange);
+    } else {
+      mediaQuery.removeListener(handleSystemPreferenceChange);
+    }
+  };
 };

--- a/src/store/useStore.js
+++ b/src/store/useStore.js
@@ -165,12 +165,13 @@ export const useStore = create(
 
 // Side-effect subscriber for robotStatus transitions (telemetry, logging)
 import { subscribeRobotStatus } from './subscribers/robotStatusSubscriber';
-subscribeRobotStatus(useStore);
+const _unsubscribeRobotStatus = subscribeRobotStatus(useStore);
 
 // Setup system preference listener for dark mode
-if (typeof window !== 'undefined') {
-  setupSystemPreferenceListener(useStore.getState, useStore.setState);
-}
+const _cleanupSystemPreference =
+  typeof window !== 'undefined'
+    ? setupSystemPreferenceListener(useStore.getState, useStore.setState)
+    : null;
 
 // ============================================================================
 // HMR STATE PRESERVATION (dev only)
@@ -192,6 +193,8 @@ if (import.meta.hot) {
 
   import.meta.hot.dispose(data => {
     data.storeState = useStore.getState();
+    _unsubscribeRobotStatus?.();
+    _cleanupSystemPreference?.();
   });
 
   import.meta.hot.accept();

--- a/src/utils/diagnosticExport.js
+++ b/src/utils/diagnosticExport.js
@@ -586,9 +586,14 @@ export const setupDiagnosticShortcut = () => {
   return () => window.removeEventListener('keydown', handleKeyDown);
 };
 
-// Auto-setup on import
-if (typeof window !== 'undefined') {
-  setupDiagnosticShortcut();
+// Auto-setup on import (with HMR cleanup to prevent listener stacking)
+const _cleanupDiagnosticShortcut = typeof window !== 'undefined' ? setupDiagnosticShortcut() : null;
+
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    _cleanupDiagnosticShortcut?.();
+  });
+  import.meta.hot.accept();
 }
 
 export default {


### PR DESCRIPTION
## Summary

- `setupSystemPreferenceListener` now returns a cleanup function that removes the `prefers-color-scheme` media query listener
- `setupDiagnosticShortcut` registers an `import.meta.hot.dispose` handler to remove the keydown listener on HMR reload
- `useStore.js` calls both cleanup functions in `hot.dispose` to prevent stacking on every hot reload

## Test plan

- [ ] Open DevTools, trigger HMR (save any file) — verify no duplicate event listener warnings
- [ ] Verify dark mode toggle still works after hot reload
- [ ] Verify diagnostic export shortcut still works after hot reload

Made with [Cursor](https://cursor.com)