### PR TITLE
feat(app-store): virtualize discover grid and redesign installed apps cards

### DIFF
--- a/src/components/FullscreenOverlay.jsx
+++ b/src/components/FullscreenOverlay.jsx
@@ -1,4 +1,5 @@
 import React, { useRef, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import { Box, IconButton, Modal } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 
@@ -28,6 +29,7 @@ import CloseIcon from '@mui/icons-material/Close';
  * @param {function} onBackdropClick - Custom backdrop click handler (default: calls onClose)
  * @param {boolean} hidden - If true, overlay stays mounted but invisible (for modal stacking)
  * @param {boolean} keepMounted - Keep content mounted when closed (default: false)
+ * @param {React.RefObject} scrollRef - Optional ref forwarded to the scrollable container
  * @param {ReactNode} children - Content to display
  */
 export default function FullscreenOverlay({
@@ -44,6 +46,7 @@ export default function FullscreenOverlay({
   onBackdropClick,
   hidden = false,
   keepMounted = false,
+  scrollRef,
   children,
 }) {
   // Track if we've already animated this modal (don't re-animate when coming back from hidden)
@@ -97,84 +100,92 @@ export default function FullscreenOverlay({
   };
 
   return (
-    <Modal
-      open={open}
-      onClose={handleBackdropClick}
-      keepMounted={keepMounted}
-      hideBackdrop // We render our own backdrop for blur support
-      sx={{
-        zIndex,
-        // Hidden state: keep mounted but invisible (for modal stacking)
-        ...(hidden && {
-          visibility: 'hidden',
-          pointerEvents: 'none',
-        }),
-      }}
-    >
-      <Box
+    <>
+      <Modal
+        open={open}
+        onClose={handleBackdropClick}
+        keepMounted={keepMounted}
+        hideBackdrop // We render our own backdrop for blur support
         sx={{
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          right: 0,
-          bottom: 0,
-          outline: 'none',
-          bgcolor: overlayBgColor,
-          backdropFilter: `blur(${backdropBlur}px)`,
-          WebkitBackdropFilter: `blur(${backdropBlur}px)`,
-          display: 'flex',
-          alignItems: isCenteredY ? 'center' : 'flex-start',
-          justifyContent: isCenteredX ? 'center' : 'flex-start',
-          overflow: 'auto',
-          // Only animate on first open, not when returning from hidden
-          ...(shouldAnimate && {
-            animation: 'overlayFadeIn 0.3s ease forwards',
-            '@keyframes overlayFadeIn': {
-              from: { opacity: 0 },
-              to: { opacity: 1 },
-            },
+          zIndex,
+          // Hidden state: keep mounted but invisible (for modal stacking)
+          ...(hidden && {
+            visibility: 'hidden',
+            pointerEvents: 'none',
           }),
-          ...scrollbarStyles,
         }}
       >
-        {/* Close button - top right (orange style) */}
-        {showCloseButton && (
+        <Box
+          ref={scrollRef}
+          sx={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            outline: 'none',
+            bgcolor: overlayBgColor,
+            backdropFilter: `blur(${backdropBlur}px)`,
+            WebkitBackdropFilter: `blur(${backdropBlur}px)`,
+            display: 'flex',
+            alignItems: isCenteredY ? 'center' : 'flex-start',
+            justifyContent: isCenteredX ? 'center' : 'flex-start',
+            overflow: 'auto',
+            // Only animate on first open, not when returning from hidden
+            ...(shouldAnimate && {
+              animation: 'overlayFadeIn 0.3s ease forwards',
+              '@keyframes overlayFadeIn': {
+                from: { opacity: 0 },
+                to: { opacity: 1 },
+              },
+            }),
+            ...scrollbarStyles,
+          }}
+        >
+          {/* Content wrapper */}
+          <Box
+            onClick={e => e.stopPropagation()}
+            sx={{
+              width: '100%',
+              height: isCenteredY ? 'auto' : '100%',
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: isCenteredX ? 'center' : 'stretch',
+              justifyContent: isCenteredY ? 'center' : 'flex-start',
+            }}
+          >
+            {children}
+          </Box>
+        </Box>
+      </Modal>
+
+      {/* Close button - rendered as portal above the drag bar (z-index 10000001) */}
+      {showCloseButton &&
+        open &&
+        !hidden &&
+        createPortal(
           <IconButton
             onClick={onClose}
             sx={{
-              position: 'absolute',
-              top: 16,
+              position: 'fixed',
+              top: 20,
               right: 16,
               color: '#FF9500',
               bgcolor: darkMode ? 'rgba(255, 255, 255, 0.08)' : '#ffffff',
               border: '1px solid #FF9500',
               opacity: 0.7,
+              zIndex: 10000001,
+              WebkitAppRegion: 'no-drag',
               '&:hover': {
                 opacity: 1,
                 bgcolor: darkMode ? 'rgba(255, 255, 255, 0.12)' : '#ffffff',
               },
-              zIndex: 1,
             }}
           >
             <CloseIcon sx={{ fontSize: 20 }} />
-          </IconButton>
+          </IconButton>,
+          document.body
         )}
-
-        {/* Content wrapper */}
-        <Box
-          onClick={e => e.stopPropagation()}
-          sx={{
-            width: '100%',
-            height: isCenteredY ? 'auto' : '100%',
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: isCenteredX ? 'center' : 'stretch',
-            justifyContent: isCenteredY ? 'center' : 'flex-start',
-          }}
-        >
-          {children}
-        </Box>
-      </Box>
-    </Modal>
+    </>
   );
 }

--- a/src/views/active-robot/application-store/discover/Modal.jsx
+++ b/src/views/active-robot/application-store/discover/Modal.jsx
@@ -1,8 +1,8 @@
-import React, { useEffect } from 'react';
+import React, { useRef, useState, useLayoutEffect } from 'react';
 import { Box, CircularProgress, Typography, Button } from '@mui/material';
 import WifiOffIcon from '@mui/icons-material/WifiOff';
 import RefreshIcon from '@mui/icons-material/Refresh';
-import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import FullscreenOverlay from '@components/FullscreenOverlay';
 import Header from './components/Header';
 import SearchBar from './components/SearchBar';
@@ -10,6 +10,10 @@ import CategoryFilters from './components/CategoryFilters';
 import AppCard from './components/AppCard';
 import EmptyState from './components/EmptyState';
 import Footer from './components/Footer';
+
+const COLUMNS = 2;
+const ESTIMATED_ROW_HEIGHT = 240;
+const ROW_GAP = 20;
 
 /**
  * Modal overlay for discovering and installing apps from Hugging Face
@@ -35,26 +39,49 @@ export default function DiscoverModal({
   setSelectedCategory,
   totalAppsCount,
   installedApps = [],
-  onOpenCreateTutorial, // Callback to open Create App Tutorial modal
-  hidden = false, // Hide when another overlay is on top (avoids stacked blur perf hit)
+  onOpenCreateTutorial,
+  hidden = false,
 }) {
-  // Removed debug logs to reduce console spam
-
-  // ✅ Determine if filters are active
   const hasActiveFilter = selectedCategory !== null || (searchQuery && searchQuery.trim());
   const isFiltered = hasActiveFilter && filteredApps.length < totalAppsCount;
+
+  const overlayScrollRef = useRef(null);
+  const gridAnchorRef = useRef(null);
+  const [scrollMargin, setScrollMargin] = useState(0);
+
+  // Measure the offset between the scroll container top and the grid start
+  useLayoutEffect(() => {
+    if (!gridAnchorRef.current || !overlayScrollRef.current) return;
+    const gridTop = gridAnchorRef.current.getBoundingClientRect().top;
+    const scrollTop = overlayScrollRef.current.getBoundingClientRect().top;
+    setScrollMargin(gridTop - scrollTop + overlayScrollRef.current.scrollTop);
+  }, [isOpen, isLoading, filteredApps.length, selectedCategory, searchQuery]);
+
+  const rowCount = Math.ceil(filteredApps.length / COLUMNS);
+
+  const virtualizer = useVirtualizer({
+    count: rowCount,
+    getScrollElement: () => overlayScrollRef.current,
+    estimateSize: () => ESTIMATED_ROW_HEIGHT + ROW_GAP,
+    overscan: 3,
+    scrollMargin,
+  });
+
+  const hasApps = !isLoading && !(error && filteredApps.length === 0) && filteredApps.length > 0;
 
   return (
     <FullscreenOverlay
       open={isOpen}
       onClose={onClose}
       darkMode={darkMode}
-      zIndex={10002} // Above settings overlay
-      centeredX={true} // Center horizontally
+      zIndex={10002}
+      centeredX={true}
       debugName="DiscoverModalLegacy"
-      centeredY={false} // Don't center vertically
+      centeredY={false}
       showCloseButton={true}
       hidden={hidden}
+      backdropBlur={10}
+      scrollRef={overlayScrollRef}
     >
       <Box
         sx={{
@@ -66,10 +93,8 @@ export default function DiscoverModal({
           mb: 4,
         }}
       >
-        {/* Header */}
         <Header darkMode={darkMode} />
 
-        {/* Search Bar */}
         <SearchBar
           darkMode={darkMode}
           searchQuery={searchQuery}
@@ -82,7 +107,6 @@ export default function DiscoverModal({
           isFiltered={isFiltered}
         />
 
-        {/* Category Filters */}
         <CategoryFilters
           darkMode={darkMode}
           categories={categories}
@@ -91,191 +115,175 @@ export default function DiscoverModal({
           totalAppsCount={totalAppsCount}
         />
 
-        {/* Apps List */}
-        <Box
-          sx={{
-            position: 'relative',
-          }}
-        >
-          {/* Warning banner if there's an error but apps are available */}
-          {error && filteredApps.length > 0 && (
-            <Box
+        {/* Warning banner */}
+        {error && filteredApps.length > 0 && (
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1.5,
+              px: 2.5,
+              py: 1.5,
+              mb: 2,
+              borderRadius: '10px',
+              backgroundColor: darkMode ? 'rgba(255, 149, 0, 0.12)' : 'rgba(255, 149, 0, 0.08)',
+              border: `1px solid ${darkMode ? 'rgba(255, 149, 0, 0.3)' : 'rgba(255, 149, 0, 0.25)'}`,
+            }}
+          >
+            <WifiOffIcon
+              sx={{ fontSize: 20, color: darkMode ? '#fbbf24' : '#f59e0b', flexShrink: 0 }}
+            />
+            <Typography
               sx={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 1.5,
-                px: 2.5,
-                py: 1.5,
+                fontSize: 13,
+                color: darkMode ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.8)',
+                fontWeight: 500,
+                flex: 1,
+              }}
+            >
+              {error}
+            </Typography>
+          </Box>
+        )}
+
+        {/* Error state */}
+        {error && filteredApps.length === 0 ? (
+          <Box
+            sx={{
+              py: 10,
+              textAlign: 'center',
+              width: '100%',
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              gap: 2,
+            }}
+          >
+            <WifiOffIcon
+              sx={{ fontSize: 56, color: darkMode ? '#666' : '#999', opacity: 0.7, mb: 1 }}
+            />
+            <Typography
+              sx={{
+                fontSize: 15,
+                color: darkMode ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.87)',
+                fontWeight: 600,
+                mb: 0.5,
+              }}
+            >
+              No Internet Connection
+            </Typography>
+            <Typography
+              sx={{
+                fontSize: 13,
+                color: darkMode ? '#888' : '#666',
+                fontWeight: 400,
+                maxWidth: 320,
+                lineHeight: 1.6,
                 mb: 2,
-                borderRadius: '10px',
-                backgroundColor: darkMode ? 'rgba(255, 149, 0, 0.12)' : 'rgba(255, 149, 0, 0.08)',
-                border: `1px solid ${darkMode ? 'rgba(255, 149, 0, 0.3)' : 'rgba(255, 149, 0, 0.25)'}`,
               }}
             >
-              <WifiOffIcon
-                sx={{
-                  fontSize: 20,
-                  color: darkMode ? '#fbbf24' : '#f59e0b',
-                  flexShrink: 0,
-                }}
-              />
-              <Typography
-                sx={{
-                  fontSize: 13,
-                  color: darkMode ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.8)',
-                  fontWeight: 500,
-                  flex: 1,
-                }}
-              >
-                {error}
-              </Typography>
-            </Box>
-          )}
-
-          {/* Full error screen if there's an error and no apps to show */}
-          {error && filteredApps.length === 0 ? (
-            <Box
+              {error}
+            </Typography>
+            <Button
+              variant="outlined"
+              startIcon={<RefreshIcon />}
+              onClick={() => window.location.reload()}
               sx={{
-                py: 10,
-                textAlign: 'center',
-                width: '100%',
-                display: 'flex',
-                flexDirection: 'column',
-                alignItems: 'center',
-                gap: 2,
+                textTransform: 'none',
+                fontSize: 13,
+                fontWeight: 500,
+                px: 3,
+                py: 1,
+                borderRadius: '8px',
+                borderColor: darkMode ? '#444' : '#ddd',
+                color: darkMode ? '#aaa' : '#666',
+                '&:hover': {
+                  borderColor: darkMode ? '#555' : '#ccc',
+                  backgroundColor: darkMode ? 'rgba(255, 255, 255, 0.05)' : 'rgba(0, 0, 0, 0.03)',
+                },
               }}
             >
-              <WifiOffIcon
-                sx={{
-                  fontSize: 56,
-                  color: darkMode ? '#666' : '#999',
-                  opacity: 0.7,
-                  mb: 1,
-                }}
-              />
-              <Typography
-                sx={{
-                  fontSize: 15,
-                  color: darkMode ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.87)',
-                  fontWeight: 600,
-                  mb: 0.5,
-                }}
-              >
-                No Internet Connection
-              </Typography>
-              <Typography
-                sx={{
-                  fontSize: 13,
-                  color: darkMode ? '#888' : '#666',
-                  fontWeight: 400,
-                  maxWidth: 320,
-                  lineHeight: 1.6,
-                  mb: 2,
-                }}
-              >
-                {error}
-              </Typography>
-              <Button
-                variant="outlined"
-                startIcon={<RefreshIcon />}
-                onClick={() => window.location.reload()}
-                sx={{
-                  textTransform: 'none',
-                  fontSize: 13,
-                  fontWeight: 500,
-                  px: 3,
-                  py: 1,
-                  borderRadius: '8px',
-                  borderColor: darkMode ? '#444' : '#ddd',
-                  color: darkMode ? '#aaa' : '#666',
-                  '&:hover': {
-                    borderColor: darkMode ? '#555' : '#ccc',
-                    backgroundColor: darkMode ? 'rgba(255, 255, 255, 0.05)' : 'rgba(0, 0, 0, 0.03)',
-                  },
-                }}
-              >
-                Retry
-              </Button>
-            </Box>
-          ) : isLoading ? (
-            <Box
-              sx={{
-                py: 10,
-                textAlign: 'center',
+              Retry
+            </Button>
+          </Box>
+        ) : isLoading ? (
+          <Box
+            sx={{
+              py: 10,
+              textAlign: 'center',
+              width: '100%',
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              gap: 2,
+            }}
+          >
+            <CircularProgress size={40} sx={{ color: darkMode ? '#666' : '#999' }} />
+            <Typography sx={{ fontSize: 14, color: darkMode ? '#888' : '#999', fontWeight: 500 }}>
+              Loading apps...
+            </Typography>
+          </Box>
+        ) : filteredApps.length === 0 ? (
+          <EmptyState
+            darkMode={darkMode}
+            searchQuery={searchQuery}
+            setSearchQuery={setSearchQuery}
+          />
+        ) : (
+          /* Virtualized grid - scrolls with the overlay */
+          <Box ref={gridAnchorRef} sx={{ position: 'relative', width: '100%' }}>
+            <div
+              style={{
+                height: virtualizer.getTotalSize(),
                 width: '100%',
-                display: 'flex',
-                flexDirection: 'column',
-                alignItems: 'center',
-                gap: 2,
+                position: 'relative',
               }}
             >
-              <CircularProgress
-                size={40}
-                sx={{
-                  color: darkMode ? '#666' : '#999',
-                }}
-              />
-              <Typography
-                sx={{
-                  fontSize: 14,
-                  color: darkMode ? '#888' : '#999',
-                  fontWeight: 500,
-                }}
-              >
-                Loading apps...
-              </Typography>
-            </Box>
-          ) : (
-            <Box
-              sx={{
-                display: 'flex',
-                flexDirection: 'row',
-                flexWrap: 'wrap',
-                gap: 2.5,
-                width: '100%',
-                mb: 0,
-              }}
-            >
-              {filteredApps.length === 0 ? (
-                <EmptyState
-                  darkMode={darkMode}
-                  searchQuery={searchQuery}
-                  setSearchQuery={setSearchQuery}
-                />
-              ) : (
-                <>
-                  {filteredApps.map((app, index) => {
-                    const installJob = getJobInfo(app.name, 'install');
-                    const isInstalling = isJobRunning(app.name, 'install');
-                    const installFailed = installJob && installJob.status === 'failed';
-                    const isInstalled = app.isInstalled || false;
+              {virtualizer.getVirtualItems().map(virtualRow => {
+                const startIdx = virtualRow.index * COLUMNS;
+                const app1 = filteredApps[startIdx];
+                const app2 = filteredApps[startIdx + 1];
 
-                    return (
-                      <AppCard
-                        key={`${app.name}-${selectedCategory || 'all'}-${searchQuery || ''}-${index}`}
-                        app={app}
-                        darkMode={darkMode}
-                        isBusy={isBusy}
-                        isInstalling={isInstalling}
-                        installFailed={installFailed}
-                        isInstalled={isInstalled}
-                        handleInstall={handleInstall}
-                        selectedCategory={selectedCategory}
-                        searchQuery={searchQuery}
-                        index={index}
-                      />
-                    );
-                  })}
+                const getCardProps = (app, idx) => {
+                  const installJob = getJobInfo(app.name, 'install');
+                  return {
+                    key: app.name,
+                    app,
+                    darkMode,
+                    isBusy,
+                    isInstalling: isJobRunning(app.name, 'install'),
+                    installFailed: installJob && installJob.status === 'failed',
+                    isInstalled: app.isInstalled || false,
+                    handleInstall,
+                    selectedCategory,
+                    searchQuery,
+                    index: idx,
+                  };
+                };
 
-                  {/* Footer */}
-                  {filteredApps.length > 0 && (
-                    <Footer darkMode={darkMode} onOpenCreateTutorial={onOpenCreateTutorial} />
-                  )}
-                </>
-              )}
-            </Box>
-          )}
-        </Box>
+                return (
+                  <div
+                    key={virtualRow.key}
+                    style={{
+                      position: 'absolute',
+                      top: 0,
+                      left: 0,
+                      width: '100%',
+                      transform: `translateY(${virtualRow.start - scrollMargin}px)`,
+                    }}
+                  >
+                    <Box sx={{ display: 'flex', gap: 2.5, pb: `${ROW_GAP}px` }}>
+                      <AppCard {...getCardProps(app1, startIdx)} />
+                      {app2 && <AppCard {...getCardProps(app2, startIdx + 1)} />}
+                    </Box>
+                  </div>
+                );
+              })}
+            </div>
+
+            <Footer darkMode={darkMode} onOpenCreateTutorial={onOpenCreateTutorial} />
+          </Box>
+        )}
       </Box>
     </FullscreenOverlay>
   );

--- a/src/views/active-robot/application-store/discover/components/AppCard.jsx
+++ b/src/views/active-robot/application-store/discover/components/AppCard.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo } from 'react';
 import { Box, Typography, Button, Avatar, Chip, CircularProgress } from '@mui/material';
 import DownloadOutlinedIcon from '@mui/icons-material/DownloadOutlined';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
@@ -12,7 +12,7 @@ import { useActiveRobotContext } from '../../../context';
  * App card component for Discover Modal
  * Supports both Python apps (installable) and Web apps (open in browser)
  */
-export default function AppCard({
+function AppCard({
   app,
   darkMode,
   isBusy,
@@ -47,7 +47,6 @@ export default function AppCard({
 
   return (
     <Box
-      key={`${app.name}-${selectedCategory || 'all'}-${searchQuery || ''}-${index}`}
       sx={{
         display: 'flex',
         flexDirection: 'column',
@@ -64,7 +63,7 @@ export default function AppCard({
             ? '1px solid rgba(255, 149, 0, 0.4)'
             : `1px solid ${darkMode ? 'rgba(255, 255, 255, 0.12)' : 'rgba(0, 0, 0, 0.12)'}`,
         cursor: 'pointer',
-        transition: 'all 0.2s ease',
+        transition: 'transform 0.2s ease, border-color 0.2s ease',
         '&:hover': {
           transform: 'translateY(-2px)',
           borderColor: installFailed
@@ -218,8 +217,8 @@ export default function AppCard({
           py: 2.5,
           display: 'flex',
           flexDirection: 'column',
-          height: '100%',
-          justifyContent: 'center',
+          flex: 1,
+          gap: 2,
         }}
       >
         {/* Title + Description + Date (left) + Emoji (right) */}
@@ -323,7 +322,7 @@ export default function AppCard({
               )
             }
             sx={{
-              mt: 2.5,
+              mt: 'auto',
               width: '100%',
               py: 1,
               fontSize: 12,
@@ -391,7 +390,7 @@ export default function AppCard({
               }
             }}
             sx={{
-              mt: 2.5,
+              mt: 'auto',
               width: '100%',
               py: 1,
               fontSize: 12,
@@ -415,3 +414,5 @@ export default function AppCard({
     </Box>
   );
 }
+
+export default memo(AppCard);

--- a/src/views/active-robot/application-store/hooks/useAppHandlers.js
+++ b/src/views/active-robot/application-store/hooks/useAppHandlers.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { useActiveRobotContext } from '../../context';
 
 /**
@@ -25,82 +25,110 @@ export function useAppHandlers({
   const [expandedApp, setExpandedApp] = useState(null);
   const [startingApp, setStartingApp] = useState(null);
 
-  // ✅ Track if we're waiting for polling to confirm app started
   const waitingForPollingRef = useRef(false);
 
-  // ✅ Helper: Handle installation errors consistently
-  const handleInstallError = (err, appName, action = 'install') => {
-    console.error(`Failed to ${action}:`, err);
-
-    // Reset on error
-    setInstallResult(null);
-    unlockInstall();
-
-    // User-friendly error messages
-    if (err.name === 'PermissionDeniedError' || err.name === 'SystemPopupTimeoutError') {
-      const message = err.userFriendly
-        ? err.message
-        : `${appName}: System permission required. Please accept the permission dialog if it appears.`;
-
-      if (showToast) {
-        showToast(message, 'warning');
-      }
-    } else {
-      if (showToast) {
-        showToast(`Failed to ${action} ${appName}: ${err.message}`, 'error');
-      }
-    }
+  // Stable ref holding latest values for all callbacks.
+  // This allows useCallback([]) handlers to always read fresh deps
+  // without causing re-renders in memoized children.
+  const latest = useRef({});
+  latest.current = {
+    lockForInstall,
+    unlockInstall,
+    setInstallResult,
+    installApp,
+    removeApp,
+    startApp,
+    stopCurrentApp,
+    triggerUpdate,
+    showToast,
+    lockForApp,
+    unlockApp,
+    isCommandRunning,
+    currentApp,
+    DAEMON_CONFIG,
   };
 
-  // ✅ REFACTORED: Simplified install handler
-  const handleInstall = async appInfo => {
+  const handleInstall = useCallback(async appInfo => {
+    const { lockForInstall, installApp, setInstallResult, unlockInstall, showToast } =
+      latest.current;
     try {
-      // Lock store state and start tracking
       lockForInstall(appInfo.name, 'install');
-
-      // Launch installation (async, returns job_id)
       await installApp(appInfo);
-
-      // Note: Job tracking and completion handled by useAppInstallation hook
     } catch (err) {
-      handleInstallError(err, appInfo.name, 'install');
+      console.error('Failed to install:', err);
+      setInstallResult(null);
+      unlockInstall();
+      if (err.name === 'PermissionDeniedError' || err.name === 'SystemPopupTimeoutError') {
+        const message = err.userFriendly
+          ? err.message
+          : `${appInfo.name}: System permission required. Please accept the permission dialog if it appears.`;
+        if (showToast) showToast(message, 'warning');
+      } else {
+        if (showToast) showToast(`Failed to install ${appInfo.name}: ${err.message}`, 'error');
+      }
     }
-  };
+  }, []);
 
-  // ✅ REFACTORED: Simplified uninstall handler
-  const handleUninstall = async appName => {
+  const handleUninstall = useCallback(async appName => {
+    const { lockForInstall, removeApp, setInstallResult, unlockInstall, showToast } =
+      latest.current;
     try {
-      // Lock store state and start tracking
       lockForInstall(appName, 'remove');
-
-      // Launch uninstallation (async, returns job_id)
       await removeApp(appName);
       setExpandedApp(null);
-
-      // Note: Job tracking and completion handled by useAppInstallation hook
     } catch (err) {
-      handleInstallError(err, appName, 'uninstall');
+      console.error('Failed to uninstall:', err);
+      setInstallResult(null);
+      unlockInstall();
+      if (err.name === 'PermissionDeniedError' || err.name === 'SystemPopupTimeoutError') {
+        const message = err.userFriendly
+          ? err.message
+          : `${appName}: System permission required. Please accept the permission dialog if it appears.`;
+        if (showToast) showToast(message, 'warning');
+      } else {
+        if (showToast) showToast(`Failed to uninstall ${appName}: ${err.message}`, 'error');
+      }
     }
-  };
+  }, []);
 
-  // Update handler (same pattern as install/uninstall)
-  const handleUpdate = async appName => {
+  const handleUpdate = useCallback(async appName => {
+    const { lockForInstall, triggerUpdate, setInstallResult, unlockInstall, showToast } =
+      latest.current;
     try {
       lockForInstall(appName, 'update');
       await triggerUpdate(appName);
     } catch (err) {
-      handleInstallError(err, appName, 'update');
+      console.error('Failed to update:', err);
+      setInstallResult(null);
+      unlockInstall();
+      if (err.name === 'PermissionDeniedError' || err.name === 'SystemPopupTimeoutError') {
+        const message = err.userFriendly
+          ? err.message
+          : `${appName}: System permission required. Please accept the permission dialog if it appears.`;
+        if (showToast) showToast(message, 'warning');
+      } else {
+        if (showToast) showToast(`Failed to update ${appName}: ${err.message}`, 'error');
+      }
     }
-  };
+  }, []);
 
-  const handleStartApp = async appName => {
+  const handleStartApp = useCallback(async appName => {
+    const {
+      isCommandRunning,
+      currentApp,
+      showToast,
+      stopCurrentApp,
+      unlockApp,
+      DAEMON_CONFIG,
+      startApp,
+      lockForApp,
+    } = latest.current;
     try {
       if (isCommandRunning) {
         showToast('Please wait for the current action to finish', 'warning');
         return;
       }
 
-      // Only prompt to stop if the current app is truly active (running/starting)
       const isCurrentAppActive =
         currentApp &&
         currentApp.info &&
@@ -119,33 +147,28 @@ export function useAppHandlers({
           setTimeout(resolve, DAEMON_CONFIG.APP_INSTALLATION.HANDLER_DELAY)
         );
       } else if (currentApp && currentApp.info) {
-        // App is in error/done/stopping state — just clear the stale state
         unlockApp();
       }
 
       setStartingApp(appName);
       waitingForPollingRef.current = true;
 
-      const result = await startApp(appName);
-
+      await startApp(appName);
       lockForApp(appName);
     } catch (err) {
       console.error(`Failed to start ${appName}:`, err);
       setStartingApp(null);
       waitingForPollingRef.current = false;
-      unlockApp();
-      if (showToast) {
-        showToast(`Failed to start ${appName}: ${err.message}`, 'error');
+      latest.current.unlockApp();
+      if (latest.current.showToast) {
+        latest.current.showToast(`Failed to start ${appName}: ${err.message}`, 'error');
       }
     }
-  };
+  }, []);
 
-  // ✅ Effect: Clear startingApp when polling confirms app is starting/running
-  // This prevents spinner flicker by keeping the local spinner until polling takes over
   useEffect(() => {
     if (!waitingForPollingRef.current) return;
 
-    // Check if polling has confirmed the app state
     const isPollingConfirmed =
       currentApp &&
       currentApp.info &&
@@ -158,8 +181,6 @@ export function useAppHandlers({
     }
   }, [currentApp, startingApp]);
 
-  // ✅ Safety: Clear startingApp after timeout if polling doesn't confirm
-  // This prevents the spinner from being stuck forever
   useEffect(() => {
     if (!startingApp || !waitingForPollingRef.current) return;
 
@@ -169,30 +190,34 @@ export function useAppHandlers({
         setStartingApp(null);
         waitingForPollingRef.current = false;
       }
-    }, 5000); // 5 seconds max wait for polling
+    }, 5000);
 
     return () => clearTimeout(safetyTimeout);
   }, [startingApp]);
 
-  // Check if an app is being installed/removed
-  const isJobRunning = (appName, jobType) => {
-    for (const [jobId, job] of activeJobs.entries()) {
-      if (job.appName === appName && job.type === jobType) {
-        return true;
+  const isJobRunning = useCallback(
+    (appName, jobType) => {
+      for (const [jobId, job] of activeJobs.entries()) {
+        if (job.appName === appName && job.type === jobType) {
+          return true;
+        }
       }
-    }
-    return false;
-  };
+      return false;
+    },
+    [activeJobs]
+  );
 
-  // Get job info (status + logs). jobType is optional - omit to match any type.
-  const getJobInfo = (appName, jobType) => {
-    for (const [jobId, job] of activeJobs.entries()) {
-      if (job.appName === appName && (jobType === undefined || job.type === jobType)) {
-        return job;
+  const getJobInfo = useCallback(
+    (appName, jobType) => {
+      for (const [jobId, job] of activeJobs.entries()) {
+        if (job.appName === appName && (jobType === undefined || job.type === jobType)) {
+          return job;
+        }
       }
-    }
-    return null;
-  };
+      return null;
+    },
+    [activeJobs]
+  );
 
   return {
     expandedApp,

--- a/src/views/active-robot/application-store/installed/InstalledAppsSection.jsx
+++ b/src/views/active-robot/application-store/installed/InstalledAppsSection.jsx
@@ -4,20 +4,21 @@ import {
   Typography,
   Button,
   Chip,
-  Collapse,
   CircularProgress,
   IconButton,
   Tooltip,
+  Menu,
+  MenuItem,
+  ListItemIcon,
+  ListItemText,
 } from '@mui/material';
 import PlayArrowOutlinedIcon from '@mui/icons-material/PlayArrowOutlined';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import StopCircleOutlinedIcon from '@mui/icons-material/StopCircleOutlined';
-import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import LaunchIcon from '@mui/icons-material/Launch';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
-import CheckCircleOutlinedIcon from '@mui/icons-material/CheckCircleOutlined';
 import DiscoverAppsButton from '../discover/Button';
 import ReachiesCarousel from '@components/ReachiesCarousel';
 import { getDaemonHostname } from '../../../../config/daemon';
@@ -369,9 +370,10 @@ const openExternalUrl = async url => {
 /**
  * Section displaying installed apps with call-to-actions for discovery and creation
  *
- * New compact design:
+ * Compact flat card design:
+ * - Description always visible under app name/author
  * - Actions always visible (Start/Stop, Open if custom_app_url)
- * - Settings button (⚙️) toggles accordion for details/uninstall
+ * - Three-dot context menu on hover for secondary actions (HF link, Uninstall)
  * - Visual indicator when app is running (green accent)
  */
 export default function InstalledAppsSection({
@@ -398,6 +400,20 @@ export default function InstalledAppsSection({
 }) {
   const { robotStatus } = useAppStore();
   const isSleeping = robotStatus === 'sleeping';
+
+  const [menuAnchorEl, setMenuAnchorEl] = useState(null);
+  const [menuAppName, setMenuAppName] = useState(null);
+
+  const handleMenuOpen = (event, appName) => {
+    event.stopPropagation();
+    setMenuAnchorEl(event.currentTarget);
+    setMenuAppName(appName);
+  };
+
+  const handleMenuClose = () => {
+    setMenuAnchorEl(null);
+    setMenuAppName(null);
+  };
 
   // Check if any app is currently running or starting (based on currentApp state)
   const isAnyAppActive =
@@ -509,10 +525,8 @@ export default function InstalledAppsSection({
             }}
           >
             {installedApps.map(app => {
-              const isExpanded = expandedApp === app.name;
               const isRemoving = isJobRunning(app.name, 'remove');
 
-              // Handle all current app states
               const isThisAppCurrent =
                 currentApp && currentApp.info && currentApp.info.name === app.name;
               const appState = isThisAppCurrent && currentApp.state ? currentApp.state : null;
@@ -522,16 +536,13 @@ export default function InstalledAppsSection({
               const hasAppError = isThisAppCurrent && (currentApp.error || isAppError);
 
               const isStarting = startingApp === app.name || isAppStarting;
-
-              // Check if app is starting or running (for Open button visibility)
               const isStartingOrRunning = isStarting || isCurrentlyRunning;
 
-              // Get author from app data
               const author = app.extra?.id?.split('/')?.[0] || app.extra?.author || null;
-
-              // Get HuggingFace URL
               const hfUrl =
                 app.url || (app.extra?.id ? `https://huggingface.co/spaces/${app.extra.id}` : null);
+
+              const isMenuOpen = menuAppName === app.name;
 
               return (
                 <Box
@@ -544,11 +555,9 @@ export default function InstalledAppsSection({
                         ? '#ef4444'
                         : isCurrentlyRunning
                           ? '#22c55e'
-                          : isExpanded
-                            ? '#FF9500'
-                            : darkMode
-                              ? 'rgba(255, 255, 255, 0.08)'
-                              : 'rgba(0, 0, 0, 0.08)'
+                          : darkMode
+                            ? 'rgba(255, 255, 255, 0.08)'
+                            : 'rgba(0, 0, 0, 0.08)'
                     }`,
                     transition: 'opacity 0.25s ease, filter 0.25s ease, border-color 0.2s ease',
                     overflow: 'hidden',
@@ -559,9 +568,11 @@ export default function InstalledAppsSection({
                         : 'none',
                     opacity: isRemoving ? 0.5 : isBusy && !isCurrentlyRunning ? 0.4 : 1,
                     filter: isBusy && !isCurrentlyRunning ? 'grayscale(50%)' : 'none',
+                    '&:hover .more-menu-btn': {
+                      display: 'inline-flex',
+                    },
                   }}
                 >
-                  {/* ✅ Timeout watcher for "starting" state - stops app if stuck */}
                   <AppStartingTimeoutWatcher
                     isStarting={isAppStarting}
                     isRunning={isCurrentlyRunning}
@@ -574,13 +585,13 @@ export default function InstalledAppsSection({
                     }}
                   />
 
-                  {/* Header - Always visible */}
                   <Box
                     sx={{
                       p: 2,
                       display: 'flex',
                       alignItems: 'center',
                       justifyContent: 'space-between',
+                      gap: 1,
                       bgcolor: hasAppError
                         ? darkMode
                           ? 'rgba(239, 68, 68, 0.06)'
@@ -601,10 +612,8 @@ export default function InstalledAppsSection({
                         flex: 1,
                         minWidth: 0,
                         overflow: 'hidden',
-                        pr: 1,
                       }}
                     >
-                      {/* Emoji */}
                       <Box sx={{ flexShrink: 0 }}>
                         <Box
                           sx={{
@@ -635,7 +644,6 @@ export default function InstalledAppsSection({
                         </Box>
                       </Box>
 
-                      {/* App name and metadata */}
                       <Box sx={{ flex: 1, minWidth: 0, overflow: 'hidden' }}>
                         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.3 }}>
                           <Typography
@@ -654,7 +662,6 @@ export default function InstalledAppsSection({
                             {app.name}
                           </Typography>
 
-                          {/* Error / Crashed indicator */}
                           {hasAppError && (
                             <Chip
                               label={currentApp?.error ? 'Crashed' : 'Error'}
@@ -735,13 +742,32 @@ export default function InstalledAppsSection({
                     </Box>
 
                     {/* Right: Action buttons */}
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, flexShrink: 0 }}>
+                      {/* Three-dot menu - visible on hover */}
+                      <IconButton
+                        className="more-menu-btn"
+                        size="small"
+                        onClick={e => handleMenuOpen(e, app.name)}
+                        sx={{
+                          width: 28,
+                          height: 28,
+                          display: isMenuOpen ? 'inline-flex' : 'none',
+                          color: darkMode ? '#888' : '#999',
+                          transition: 'color 0.15s ease, background-color 0.15s ease',
+                          '&:hover': {
+                            color: darkMode ? '#ccc' : '#666',
+                            bgcolor: darkMode ? 'rgba(255, 255, 255, 0.08)' : 'rgba(0, 0, 0, 0.06)',
+                          },
+                        }}
+                      >
+                        <MoreVertIcon sx={{ fontSize: 16 }} />
+                      </IconButton>
+
                       {/* Update badge */}
                       {(() => {
                         const isUpdating = isJobRunning(app.name, 'update');
 
                         if (isUpdating) {
-                          // Updating: orange spinner
                           return (
                             <Tooltip title="Updating..." arrow placement="top">
                               <CircularProgress
@@ -754,23 +780,22 @@ export default function InstalledAppsSection({
                         }
 
                         if (hasUpdate && hasUpdate(app.name)) {
-                          // Update available: orange arrow button
                           return (
                             <Tooltip title="Update available" arrow placement="top">
                               <span>
                                 <IconButton
                                   size="small"
-                                  disabled={isCurrentlyRunning || isSleeping}
+                                  disabled={isCurrentlyRunning || isBusy || isSleeping}
                                   onClick={e => {
                                     e.stopPropagation();
                                     if (handleUpdate) handleUpdate(app.name);
                                   }}
                                   sx={{
-                                    width: 24,
-                                    height: 24,
+                                    width: 32,
+                                    height: 32,
                                     color: '#FF9500',
                                     border: '1px solid #FF9500',
-                                    borderRadius: '6px',
+                                    borderRadius: '8px',
                                     transition: 'all 0.2s ease',
                                     '&:hover': {
                                       bgcolor: 'rgba(255, 149, 0, 0.1)',
@@ -790,77 +815,10 @@ export default function InstalledAppsSection({
                           );
                         }
 
-                        // Up to date: subtle green check (only after first check completes)
-                        if (hasUpdate && hasCheckedOnce && !isCheckingUpdates) {
-                          return (
-                            <Tooltip title="Up to date" arrow placement="top">
-                              <CheckCircleOutlinedIcon
-                                sx={{
-                                  fontSize: 16,
-                                  color: '#22c55e',
-                                  opacity: 0.7,
-                                  flexShrink: 0,
-                                }}
-                              />
-                            </Tooltip>
-                          );
-                        }
-
                         return null;
                       })()}
 
-                      {/* Settings button - toggles accordion (disabled when sleeping) */}
-                      <Tooltip
-                        title={isSleeping ? 'Wake robot first' : 'Settings'}
-                        arrow
-                        placement="top"
-                      >
-                        <IconButton
-                          size="small"
-                          disabled={isSleeping}
-                          onClick={e => {
-                            e.stopPropagation();
-                            if (!isSleeping) {
-                              setExpandedApp(isExpanded ? null : app.name);
-                            }
-                          }}
-                          sx={{
-                            width: 32,
-                            height: 32,
-                            color: isExpanded ? '#FF9500' : darkMode ? '#888' : '#999',
-                            bgcolor: isExpanded
-                              ? darkMode
-                                ? 'rgba(255, 149, 0, 0.1)'
-                                : 'rgba(255, 149, 0, 0.08)'
-                              : 'transparent',
-                            border: `1px solid ${
-                              isExpanded
-                                ? '#FF9500'
-                                : darkMode
-                                  ? 'rgba(255, 255, 255, 0.1)'
-                                  : 'rgba(0, 0, 0, 0.1)'
-                            }`,
-                            transition: 'all 0.2s ease',
-                            '&:hover': {
-                              color: '#FF9500',
-                              bgcolor: darkMode
-                                ? 'rgba(255, 149, 0, 0.1)'
-                                : 'rgba(255, 149, 0, 0.08)',
-                              borderColor: '#FF9500',
-                            },
-                          }}
-                        >
-                          <SettingsOutlinedIcon
-                            sx={{
-                              fontSize: 16,
-                              transform: isExpanded ? 'rotate(90deg)' : 'rotate(0deg)',
-                              transition: 'transform 0.3s ease',
-                            }}
-                          />
-                        </IconButton>
-                      </Tooltip>
-
-                      {/* Open button - shows when starting (ghost mode) or running (active) */}
+                      {/* Open button */}
                       <OpenAppButton
                         appName={app.name}
                         customAppUrl={app.extra?.custom_app_url}
@@ -868,7 +826,6 @@ export default function InstalledAppsSection({
                         isRunning={isCurrentlyRunning}
                         darkMode={darkMode}
                         onTimeout={() => {
-                          // App web interface failed to start within 30s - stop the app
                           console.error(`[${app.name}] Web interface timeout - stopping app`);
                           if (isThisAppCurrent) {
                             stopCurrentApp();
@@ -876,13 +833,10 @@ export default function InstalledAppsSection({
                         }}
                       />
 
-                      {/* Start/Stop button - 4 states: Stopping (spinner), Running (Stop), Starting (spinner), Idle (Start) */}
+                      {/* Start/Stop button */}
                       {isStoppingApp && isThisAppCurrent ? (
-                        // ✅ This app is stopping: Show disabled button with red spinner
                         <Tooltip title="Stopping app..." arrow placement="top">
                           <span>
-                            {' '}
-                            {/* Wrapper needed for disabled button tooltip */}
                             <IconButton
                               size="small"
                               disabled
@@ -907,7 +861,6 @@ export default function InstalledAppsSection({
                           </span>
                         </Tooltip>
                       ) : isCurrentlyRunning ? (
-                        // ✅ App is running: Show active Stop button
                         <Tooltip title="Stop app" arrow placement="top">
                           <IconButton
                             size="small"
@@ -938,11 +891,8 @@ export default function InstalledAppsSection({
                           </IconButton>
                         </Tooltip>
                       ) : isStarting ? (
-                        // ✅ App is starting: Show disabled button with spinner (Stop-like style)
                         <Tooltip title="App is starting..." arrow placement="top">
                           <span>
-                            {' '}
-                            {/* Wrapper needed for disabled button tooltip */}
                             <IconButton
                               size="small"
                               disabled
@@ -967,7 +917,6 @@ export default function InstalledAppsSection({
                           </span>
                         </Tooltip>
                       ) : (
-                        // ✅ App is idle: Show Start button
                         <Button
                           size="small"
                           disabled={isBusy || isRemoving}
@@ -1009,112 +958,105 @@ export default function InstalledAppsSection({
                       )}
                     </Box>
                   </Box>
-
-                  {/* Expanded Content - Settings panel */}
-                  <Collapse in={isExpanded}>
-                    <Box
-                      sx={{
-                        px: 2,
-                        pb: 2,
-                        pt: 1.5,
-                        borderTop: `1px solid ${darkMode ? 'rgba(255, 255, 255, 0.05)' : 'rgba(0, 0, 0, 0.05)'}`,
-                        display: 'flex',
-                        flexDirection: 'column',
-                        gap: 1.5,
-                      }}
-                    >
-                      {/* Description */}
-                      <Typography
-                        sx={{
-                          fontSize: 11,
-                          color: darkMode ? '#aaa' : '#666',
-                          lineHeight: 1.5,
-                        }}
-                      >
-                        {app.description || 'No description available'}
-                      </Typography>
-
-                      {/* Actions row */}
-                      <Box
-                        sx={{
-                          display: 'flex',
-                          alignItems: 'center',
-                          justifyContent: 'space-between',
-                          gap: 1,
-                          pt: 1,
-                          borderTop: `1px solid ${darkMode ? 'rgba(255, 255, 255, 0.05)' : 'rgba(0, 0, 0, 0.05)'}`,
-                        }}
-                      >
-                        {/* View on HuggingFace link */}
-                        {hfUrl && (
-                          <Button
-                            size="small"
-                            onClick={async e => {
-                              e.stopPropagation();
-                              await openExternalUrl(hfUrl);
-                            }}
-                            startIcon={<LaunchIcon sx={{ fontSize: 12 }} />}
-                            sx={{
-                              fontSize: 10,
-                              fontWeight: 500,
-                              textTransform: 'none',
-                              color: darkMode ? '#888' : '#999',
-                              px: 1,
-                              py: 0.5,
-                              '&:hover': {
-                                bgcolor: darkMode
-                                  ? 'rgba(255, 255, 255, 0.05)'
-                                  : 'rgba(0, 0, 0, 0.05)',
-                                color: darkMode ? '#aaa' : '#666',
-                              },
-                            }}
-                          >
-                            View on HuggingFace
-                          </Button>
-                        )}
-
-                        {/* Spacer */}
-                        <Box sx={{ flex: 1 }} />
-
-                        {/* Uninstall button */}
-                        <Button
-                          size="small"
-                          disabled={isRemoving || isCurrentlyRunning}
-                          startIcon={
-                            isRemoving ? (
-                              <CircularProgress size={12} />
-                            ) : (
-                              <DeleteOutlineIcon sx={{ fontSize: 14 }} />
-                            )
-                          }
-                          onClick={e => {
-                            e.stopPropagation();
-                            handleUninstall(app.name);
-                          }}
-                          sx={{
-                            px: 1.5,
-                            py: 0.5,
-                            fontSize: 11,
-                            fontWeight: 600,
-                            textTransform: 'none',
-                            color: '#ef4444',
-                            borderRadius: '6px',
-                            '&:hover': {
-                              bgcolor: 'rgba(239, 68, 68, 0.08)',
-                            },
-                            '&:disabled': {
-                              color: darkMode ? '#555' : '#999',
-                            },
-                          }}
-                        >
-                          {isRemoving ? 'Uninstalling...' : 'Uninstall'}
-                        </Button>
-                      </Box>
-                    </Box>
-                  </Collapse>
                 </Box>
               );
             })}
+
+            {/* Context menu for app actions */}
+            <Menu
+              anchorEl={menuAnchorEl}
+              open={Boolean(menuAnchorEl)}
+              onClose={handleMenuClose}
+              anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+              transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+              slotProps={{
+                paper: {
+                  sx: {
+                    bgcolor: darkMode ? '#1a1a1a' : '#fff',
+                    border: `1px solid ${darkMode ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.1)'}`,
+                    borderRadius: '10px',
+                    boxShadow: darkMode
+                      ? '0 8px 24px rgba(0, 0, 0, 0.5)'
+                      : '0 8px 24px rgba(0, 0, 0, 0.12)',
+                    minWidth: 180,
+                    py: 0.5,
+                  },
+                },
+              }}
+            >
+              {(() => {
+                const menuApp = installedApps.find(a => a.name === menuAppName);
+                if (!menuApp) return null;
+
+                const hfUrl =
+                  menuApp.url ||
+                  (menuApp.extra?.id ? `https://huggingface.co/spaces/${menuApp.extra.id}` : null);
+                const isRemoving = isJobRunning(menuAppName, 'remove');
+                const isThisAppCurrent =
+                  currentApp && currentApp.info && currentApp.info.name === menuAppName;
+                const appState = isThisAppCurrent && currentApp.state ? currentApp.state : null;
+                const isCurrentlyRunning = appState === 'running';
+
+                return [
+                  hfUrl && (
+                    <MenuItem
+                      key="hf-link"
+                      onClick={async () => {
+                        await openExternalUrl(hfUrl);
+                        handleMenuClose();
+                      }}
+                      sx={{
+                        fontSize: 12,
+                        py: 1,
+                        color: darkMode ? '#ccc' : '#444',
+                        '&:hover': {
+                          bgcolor: darkMode ? 'rgba(255, 255, 255, 0.06)' : 'rgba(0, 0, 0, 0.04)',
+                        },
+                      }}
+                    >
+                      <ListItemIcon>
+                        <LaunchIcon sx={{ fontSize: 15, color: darkMode ? '#888' : '#999' }} />
+                      </ListItemIcon>
+                      <ListItemText
+                        primary="View on HuggingFace"
+                        primaryTypographyProps={{ fontSize: 12 }}
+                      />
+                    </MenuItem>
+                  ),
+                  <MenuItem
+                    key="uninstall"
+                    disabled={isRemoving || isCurrentlyRunning}
+                    onClick={() => {
+                      handleUninstall(menuAppName);
+                      handleMenuClose();
+                    }}
+                    sx={{
+                      fontSize: 12,
+                      py: 1,
+                      color: '#ef4444',
+                      '&:hover': {
+                        bgcolor: 'rgba(239, 68, 68, 0.06)',
+                      },
+                      '&.Mui-disabled': {
+                        color: darkMode ? '#555' : '#bbb',
+                      },
+                    }}
+                  >
+                    <ListItemIcon>
+                      {isRemoving ? (
+                        <CircularProgress size={15} sx={{ color: '#ef4444' }} />
+                      ) : (
+                        <DeleteOutlineIcon sx={{ fontSize: 15, color: '#ef4444' }} />
+                      )}
+                    </ListItemIcon>
+                    <ListItemText
+                      primary={isRemoving ? 'Uninstalling...' : 'Uninstall'}
+                      primaryTypographyProps={{ fontSize: 12 }}
+                    />
+                  </MenuItem>,
+                ];
+              })()}
+            </Menu>
 
             {/* Compact version: Discover apps / Build your own */}
             <Box


### PR DESCRIPTION
## Summary

**Discover modal:**
- Virtualize the app grid with `@tanstack/react-virtual` (2-column layout) — better performance with large app catalogs
- `FullscreenOverlay`: add `scrollRef` prop forwarded to the scroll container, used by the virtualizer to detect scroll position
- `AppCard`: minor layout adjustments for virtualized rows

**Installed apps:**
- Replace the gear icon + settings accordion with a three-dot context menu (visible on hover) for secondary actions (open on HF, Uninstall)
- App description is now always visible under the name/author
- Refactor `useAppHandlers` with `useCallback` for stable handler references

## Test plan

- [ ] Discover modal: scroll through a large list of apps, verify smooth rendering
- [ ] Discover modal: search/filter still works correctly
- [ ] Installed apps: hover over a card to reveal the three-dot menu
- [ ] Installed apps: Start, Stop, Open URL actions still work
- [ ] Installed apps: Uninstall from the context menu works

Made with [Cursor](https://cursor.com)