### PR TITLE
fix(log-console): wrap long log messages instead of truncating

### DIFF
--- a/src/components/LogConsole/LogItem.jsx
+++ b/src/components/LogConsole/LogItem.jsx
@@ -1,6 +1,12 @@
 import React, { useMemo } from 'react';
 import { Box, Typography } from '@mui/material';
-import { TEXT_SELECT_STYLES, ELLIPSIS_STYLES } from './constants';
+import { TEXT_SELECT_STYLES } from './constants';
+
+const WRAP_STYLES = {
+  whiteSpace: 'pre-wrap',
+  wordBreak: 'break-word',
+  minWidth: 0,
+};
 
 /**
  * Render a single log item
@@ -85,7 +91,7 @@ export const LogItem = React.memo(
               color: darkMode ? '#d1d5db' : '#666',
               lineHeight: 1.6,
               flex: 1,
-              ...ELLIPSIS_STYLES,
+              ...WRAP_STYLES,
               ...TEXT_SELECT_STYLES,
             }}
           >
@@ -147,7 +153,7 @@ export const LogItem = React.memo(
             fontWeight: isFrontend ? 500 : 400,
             opacity: 1,
             flex: 1,
-            ...ELLIPSIS_STYLES,
+            ...WRAP_STYLES,
             ...TEXT_SELECT_STYLES,
           }}
         >


### PR DESCRIPTION
## Summary

- Replace `ELLIPSIS_STYLES` (`white-space: nowrap` + `overflow: hidden` + `text-overflow: ellipsis`) with `WRAP_STYLES` (`white-space: pre-wrap` + `word-break: break-word`) on log message text
- Long messages now wrap to multiple lines instead of being cut off with `...`
- `pre-wrap` also preserves any newlines already present in log messages
- The virtualizer uses `measureElement` for dynamic height measurement, so multi-line items are correctly sized

## Test plan

- [ ] Trigger a long log message (e.g. a stack trace or a long URL) — verify it wraps instead of being truncated
- [ ] Verify auto-scroll still works correctly with variable-height items

Made with [Cursor](https://cursor.com)