### PR TITLE
Support private Hugging Face Spaces in the desktop app store

### DIFF
--- a/src/config/daemon.js
+++ b/src/config/daemon.js
@@ -227,6 +227,7 @@ function isLikelySystemPopupTimeout(error, duration, timeoutMs) {
 
 export async function fetchWithTimeout(url, options = {}, timeoutMs, logOptions = {}) {
   const { silent = false, label = null, fireAndForget = false } = logOptions;
+  const { signal: externalSignal, ...forwardedOptions } = options;
 
   // Extract endpoint from URL (handle both local and remote URLs)
   const currentBaseUrl = getBaseUrl();
@@ -257,8 +258,7 @@ export async function fetchWithTimeout(url, options = {}, timeoutMs, logOptions 
     timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
     // Combine external signal with timeout signal if provided
-    if (options.signal) {
-      const externalSignal = options.signal;
+    if (externalSignal) {
       if (externalSignal.aborted) {
         controller.abort();
       } else {
@@ -269,15 +269,14 @@ export async function fetchWithTimeout(url, options = {}, timeoutMs, logOptions 
 
   try {
     const response = await fetch(url, {
+      ...forwardedOptions,
       method: options.method || 'GET',
       headers: options.headers,
       body: options.body,
-      signal: controller?.signal,
+      signal: controller?.signal || externalSignal,
     });
 
     if (timeoutId) clearTimeout(timeoutId);
-    const duration = Date.now() - startTime;
-
     // Log result if not silent
     if (!shouldBeSilent) {
       if (label) {
@@ -349,7 +348,6 @@ export async function fetchWithTimeout(url, options = {}, timeoutMs, logOptions 
 
     // Log standard error if not silent
     if (!shouldBeSilent) {
-      const logLabel = label || `${method} ${baseEndpoint}`;
       const errorMsg =
         error.name === 'AbortError' || error.name === 'TimeoutError' ? 'timeout' : error.message;
       logApiCall(method, baseEndpoint, false, errorMsg);

--- a/src/views/active-robot/application-store/hooks/useAppFetching.js
+++ b/src/views/active-robot/application-store/hooks/useAppFetching.js
@@ -3,6 +3,143 @@ import { DAEMON_CONFIG, fetchWithTimeout, buildApiUrl, fetchExternal } from '@co
 
 // Website API URL - centralized app store with 24h cache
 const WEBSITE_API_URL = 'https://pollen-robotics-reachy-mini.hf.space/api/apps';
+const DAEMON_APPS_CATALOG_ENDPOINT = '/api/apps/list-available';
+
+const HF_PYTHON_APP_TAG = 'reachy_mini_python_app';
+
+function getCatalogAuthor(app, spaceId = null) {
+  return (
+    app?.extra?.author ||
+    app?.author ||
+    app?.owner ||
+    app?.organization ||
+    app?.org ||
+    spaceId?.split('/')?.[0] ||
+    null
+  );
+}
+
+function getCatalogAppId(app) {
+  const idCandidates = [
+    app?.extra?.id,
+    app?.extra?.repo_id,
+    app?.extra?.repoId,
+    app?.extra?.space_id,
+    app?.extra?.spaceId,
+    app?.extra?.app_id,
+    app?.extra?.appId,
+    app?.id,
+    app?.repo_id,
+    app?.repoId,
+    app?.space_id,
+    app?.spaceId,
+    app?.app_id,
+    app?.appId,
+    app?.space,
+    app?.repo,
+  ].filter(value => typeof value === 'string' && value.trim());
+
+  const namespacedId = idCandidates.find(value => value.includes('/'));
+  if (namespacedId) {
+    return namespacedId;
+  }
+
+  const rawId = idCandidates[0];
+  if (!rawId) {
+    return null;
+  }
+
+  const author = getCatalogAuthor(app);
+  return author ? `${author}/${rawId}` : rawId;
+}
+
+function getCatalogAppKey(app) {
+  return getCatalogAppId(app) || app?.name?.toLowerCase() || null;
+}
+
+function getCatalogRepoName(app) {
+  return getCatalogAppId(app)?.split('/').pop() || null;
+}
+
+function mergeAppExtra(baseExtra = {}, nextExtra = {}) {
+  return {
+    ...baseExtra,
+    ...nextExtra,
+    cardData: {
+      ...baseExtra?.cardData,
+      ...nextExtra?.cardData,
+    },
+  };
+}
+
+function normalizeCatalogApp(app) {
+  const spaceId = getCatalogAppId(app);
+  const author = getCatalogAuthor(app, spaceId);
+  const repoName = getCatalogRepoName(app);
+  const existingCardData = app?.extra?.cardData || app?.cardData || {};
+  const rootTags = app?.extra?.tags || app?.tags || [];
+  const cardTags = existingCardData.tags || [];
+  const isPrivate = app?.extra?.private ?? app?.private ?? false;
+  const isPythonApp =
+    app?.extra?.isPythonApp ??
+    app?.isPythonApp ??
+    [...rootTags, ...cardTags].includes(HF_PYTHON_APP_TAG);
+  const shouldUseRepoName = Boolean(repoName) && (isPrivate || (!app?.source_kind && !app?.url));
+  const normalizedName = shouldUseRepoName ? repoName : app?.name || repoName || '';
+
+  return {
+    ...app,
+    id: spaceId || app?.id || normalizedName,
+    name: normalizedName,
+    description: app?.description || existingCardData.short_description || '',
+    url: app?.url || (spaceId ? `https://huggingface.co/spaces/${spaceId}` : null),
+    source_kind: app?.source_kind || 'hf_space',
+    isOfficial: app?.isOfficial ?? author === 'pollen-robotics',
+    extra: {
+      ...app?.extra,
+      id: spaceId,
+      author,
+      likes: app?.extra?.likes ?? app?.likes ?? 0,
+      downloads: app?.extra?.downloads ?? app?.downloads ?? 0,
+      createdAt: app?.extra?.createdAt ?? app?.createdAt ?? null,
+      lastModified: app?.extra?.lastModified ?? app?.lastModified ?? null,
+      runtime: app?.extra?.runtime ?? app?.runtime ?? null,
+      tags: rootTags,
+      sdk: app?.extra?.sdk ?? app?.sdk ?? existingCardData.sdk,
+      private: isPrivate,
+      isPythonApp,
+      cardData: existingCardData,
+    },
+  };
+}
+
+function normalizeCatalogApps(payload) {
+  const rawApps = Array.isArray(payload) ? payload : payload?.apps || [];
+  return rawApps.map(normalizeCatalogApp);
+}
+
+function mergeCatalogApps(websiteApps, daemonApps) {
+  const mergedApps = new Map(websiteApps.map(app => [getCatalogAppKey(app), app]));
+
+  daemonApps.forEach(app => {
+    const key = getCatalogAppKey(app);
+    if (!key) return;
+
+    const existingApp = mergedApps.get(key);
+    if (!existingApp) {
+      mergedApps.set(key, app);
+      return;
+    }
+
+    mergedApps.set(key, {
+      ...existingApp,
+      ...app,
+      extra: mergeAppExtra(existingApp.extra, app.extra),
+    });
+  });
+
+  return Array.from(mergedApps.values());
+}
 
 /**
  * Merge website catalog apps with daemon-installed apps into a unified list.
@@ -13,13 +150,17 @@ const WEBSITE_API_URL = 'https://pollen-robotics-reachy-mini.hf.space/api/apps';
  * @returns {{ enrichedApps: Array, installedApps: Array }}
  */
 export function mergeAppsData(websiteApps, daemonApps) {
-  const installedAppNames = new Set(daemonApps.map(app => app.name?.toLowerCase()).filter(Boolean));
-  const installedAppsMap = new Map(daemonApps.map(app => [app.name?.toLowerCase(), app]));
+  const websiteAppsMap = new Map(
+    websiteApps.map(app => [getCatalogAppKey(app), app]).filter(([key]) => Boolean(key))
+  );
+  const installedAppsMap = new Map(
+    daemonApps.map(app => [getCatalogAppKey(app), app]).filter(([key]) => Boolean(key))
+  );
+  const installedAppKeys = new Set(installedAppsMap.keys());
 
   // Apps installed locally but not in the website catalog
-  const availableAppNames = new Set(websiteApps.map(app => app.name?.toLowerCase()));
   const localOnlyApps = daemonApps
-    .filter(app => !availableAppNames.has(app.name?.toLowerCase()))
+    .filter(app => !websiteAppsMap.has(getCatalogAppKey(app)))
     .map(app => ({
       ...app,
       source_kind: app.source_kind || 'local',
@@ -29,38 +170,81 @@ export function mergeAppsData(websiteApps, daemonApps) {
   const allApps = [...websiteApps, ...localOnlyApps];
 
   const enrichedApps = allApps.map(app => {
-    const appNameLower = app.name?.toLowerCase();
-    const isInstalled = installedAppNames.has(appNameLower);
-    const installedAppData = installedAppsMap.get(appNameLower);
+    const appKey = getCatalogAppKey(app);
+    const isInstalled = appKey ? installedAppKeys.has(appKey) : false;
+    const installedAppData = appKey ? installedAppsMap.get(appKey) : null;
 
     return {
       ...app,
       isInstalled,
       // custom_app_url is only known by the daemon (local runtime info)
-      ...(isInstalled &&
-        installedAppData?.extra?.custom_app_url && {
-          extra: {
-            ...app.extra,
-            custom_app_url: installedAppData.extra.custom_app_url,
-          },
-        }),
+      ...(isInstalled && {
+        extra: mergeAppExtra(app.extra, installedAppData?.extra),
+      }),
     };
   });
 
-  const installedApps = enrichedApps.filter(app => app.isInstalled);
+  const installedApps = daemonApps.map(app => {
+    const appKey = getCatalogAppKey(app);
+    const catalogApp = appKey ? websiteAppsMap.get(appKey) : null;
+    const mergedExtra = mergeAppExtra(catalogApp?.extra, app.extra);
+    const catalogRepoName = getCatalogRepoName(catalogApp);
+    const daemonRepoName = getCatalogRepoName(app);
+
+    return {
+      ...(catalogApp || {}),
+      ...app,
+      id: catalogApp?.id || app?.id || mergedExtra.id || app.name,
+      displayName: catalogApp?.name || catalogRepoName || daemonRepoName || app.name,
+      description: catalogApp?.description || app.description || '',
+      url:
+        catalogApp?.url ||
+        app.url ||
+        (mergedExtra.id ? `https://huggingface.co/spaces/${mergedExtra.id}` : null),
+      source_kind: app.source_kind || catalogApp?.source_kind || 'local',
+      isOfficial: catalogApp?.isOfficial ?? app.isOfficial ?? false,
+      isInstalled: true,
+      extra: mergedExtra,
+    };
+  });
 
   return { enrichedApps, installedApps };
 }
 
 /**
  * Hook for fetching apps from different sources
- * Uses the website API as primary source (cached, pre-enriched data)
+ * Uses the daemon catalog first when available (supports private spaces),
+ * and merges it with the public website API catalog.
  * Falls back to daemon for installed apps only
  */
 export function useAppFetching() {
+  const fetchAppsFromDaemonCatalog = useCallback(async () => {
+    try {
+      const response = await fetchWithTimeout(
+        buildApiUrl(DAEMON_APPS_CATALOG_ENDPOINT),
+        {},
+        DAEMON_CONFIG.TIMEOUTS.APPS_LIST,
+        { silent: true }
+      );
+
+      if (!response.ok) {
+        return { apps: [], error: `HTTP ${response.status}` };
+      }
+
+      const data = await response.json();
+      return { apps: normalizeCatalogApps(data), error: null };
+    } catch (error) {
+      return { apps: [], error: error.message };
+    }
+  }, []);
+
   /**
-   * Fetch all available apps from the website API
-   * This is the primary source - returns pre-enriched data with:
+   * Fetch all available apps from the catalog sources
+   * The daemon catalog is preferred when available because it can include
+   * private spaces accessible through the user's HF login on the daemon.
+   * The public website API remains the fallback/public source and is merged in.
+   *
+   * Returns desktop-compatible apps with:
    * - Official/community flags
    * - Likes, downloads, runtime
    * - Full cardData (emoji, description, sdk, tags)
@@ -68,26 +252,45 @@ export function useAppFetching() {
    * @returns {Promise<Array>} Array of apps in desktop-compatible format
    */
   const fetchAppsFromWebsite = useCallback(async () => {
-    try {
-      const response = await fetchExternal(WEBSITE_API_URL, {}, DAEMON_CONFIG.TIMEOUTS.APPS_LIST, {
-        silent: true,
-      });
+    const daemonCatalogResult = await fetchAppsFromDaemonCatalog();
 
-      if (!response.ok) {
-        const error = new Error(`Website API returned ${response.status}`);
+    try {
+      const websiteResponse = await fetchExternal(
+        WEBSITE_API_URL,
+        {
+          // Include browser credentials when available for environments where the
+          // website catalog can rely on a direct HF session.
+          credentials: 'include',
+        },
+        DAEMON_CONFIG.TIMEOUTS.APPS_LIST,
+        {
+          silent: true,
+        }
+      );
+
+      if (!websiteResponse.ok) {
+        const error = new Error(`Website API returned ${websiteResponse.status}`);
         error.name = 'NetworkError';
         throw error;
       }
 
-      const data = await response.json();
-      const apps = data.apps || [];
+      const websiteData = await websiteResponse.json();
+      const websiteApps = normalizeCatalogApps(websiteData);
+      const mergedApps = mergeCatalogApps(websiteApps, daemonCatalogResult.apps);
 
       console.log(
-        `[Apps] Fetched ${apps.length} apps from website API (cache age: ${data.cacheAge}s)`
+        `[Apps] Fetched ${mergedApps.length} apps from catalog (website=${websiteApps.length}, daemon=${daemonCatalogResult.apps.length}, cache age: ${websiteData.cacheAge}s)`
       );
 
-      return apps;
+      return mergedApps;
     } catch (error) {
+      if (daemonCatalogResult.apps.length > 0) {
+        console.log(
+          `[Apps] Falling back to daemon catalog only (${daemonCatalogResult.apps.length} apps)`
+        );
+        return daemonCatalogResult.apps;
+      }
+
       const isNetworkError =
         error.name === 'NetworkError' ||
         error.name === 'AbortError' ||
@@ -108,7 +311,7 @@ export function useAppFetching() {
       console.error('[Apps] Failed to fetch apps from website:', error.message);
       throw error;
     }
-  }, []);
+  }, [fetchAppsFromDaemonCatalog]);
 
   /**
    * Fetch installed apps from daemon

--- a/src/views/active-robot/application-store/installed/InstalledAppsSection.jsx
+++ b/src/views/active-robot/application-store/installed/InstalledAppsSection.jsx
@@ -526,6 +526,7 @@ export default function InstalledAppsSection({
           >
             {installedApps.map(app => {
               const isRemoving = isJobRunning(app.name, 'remove');
+              const displayName = app.displayName || app.name;
 
               const isThisAppCurrent =
                 currentApp && currentApp.info && currentApp.info.name === app.name;
@@ -539,8 +540,6 @@ export default function InstalledAppsSection({
               const isStartingOrRunning = isStarting || isCurrentlyRunning;
 
               const author = app.extra?.id?.split('/')?.[0] || app.extra?.author || null;
-              const hfUrl =
-                app.url || (app.extra?.id ? `https://huggingface.co/spaces/${app.extra.id}` : null);
 
               const isMenuOpen = menuAppName === app.name;
 
@@ -659,7 +658,7 @@ export default function InstalledAppsSection({
                               minWidth: 0,
                             }}
                           >
-                            {app.name}
+                            {displayName}
                           </Typography>
 
                           {hasAppError && (

--- a/src/views/active-robot/right-panel/EmbeddedAppView.jsx
+++ b/src/views/active-robot/right-panel/EmbeddedAppView.jsx
@@ -154,8 +154,24 @@ export default function EmbeddedAppView({ darkMode = false }) {
         flexDirection: 'column',
         height: '100%',
         minHeight: 0,
+        position: 'relative',
       }}
     >
+      {/* Left-edge gradient for depth, matching left column shadow */}
+      <Box
+        sx={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          bottom: 0,
+          width: '12px',
+          background: darkMode
+            ? 'linear-gradient(to right, rgba(0, 0, 0, 0.25) 0%, rgba(0, 0, 0, 0) 100%)'
+            : 'linear-gradient(to right, rgba(0, 0, 0, 0.06) 0%, rgba(0, 0, 0, 0) 100%)',
+          pointerEvents: 'none',
+          zIndex: 2,
+        }}
+      />
       {/* Toolbar */}
       <Box
         sx={{
@@ -243,6 +259,7 @@ export default function EmbeddedAppView({ darkMode = false }) {
         <iframe
           src={iframeSrc}
           title={currentAppName || 'App'}
+          allow="microphone; camera; autoplay"
           style={{
             width: '100%',
             height: '100%',

--- a/src/views/active-robot/right-panel/applications/ApplicationsSection.jsx
+++ b/src/views/active-robot/right-panel/applications/ApplicationsSection.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useEffect, useRef } from 'react';
+import { useState, useMemo, useEffect, useRef } from 'react';
 import { Box, Typography, Tooltip, IconButton, Avatar } from '@mui/material';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import LogoutIcon from '@mui/icons-material/Logout';
@@ -51,6 +51,7 @@ export default function ApplicationsSection({
   const [officialOnly, setOfficialOnly] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState(null);
   const [searchQuery, setSearchQuery] = useState('');
+  const previousHfUsernameRef = useRef(hfUser?.username || null);
 
   // ✅ Modal stack hook - declared BEFORE useAppInstallation to avoid stale closure
   const { openModal, closeModal, discoverModalOpen, createAppTutorialModalOpen } = useModalStack();
@@ -81,6 +82,17 @@ export default function ApplicationsSection({
       onLoadingChange(isLoading);
     }
   }, [isLoading, onLoadingChange]);
+
+  // Refresh the catalog when HF auth state changes so private spaces appear/disappear promptly.
+  useEffect(() => {
+    const currentUsername = hfUser?.username || null;
+    if (previousHfUsernameRef.current === currentUsername) {
+      return;
+    }
+
+    previousHfUsernameRef.current = currentUsername;
+    fetchAvailableApps(true);
+  }, [hfUser?.username, fetchAvailableApps]);
 
   // Reset category when switching between official/non-official
   useEffect(() => {
@@ -303,7 +315,7 @@ export default function ApplicationsSection({
                 fontWeight: 500,
               }}
             >
-              Extend Reachy's capabilities
+              Extend Reachy&apos;s capabilities
             </Typography>
           </Box>
         </Box>


### PR DESCRIPTION
Solves https://github.com/pollen-robotics/reachy-mini-desktop-app/issues/201. This updates the desktop app store to support private Hugging Face Spaces exposed by the authenticated local daemon. The app now merges the daemon catalog with the website catalog, matches apps by stable repo identity instead of display name, keeps preview apps like `reachy_mini_conversation_app_PRxxx` distinct from the production app, and makes installed cards and "View on HuggingFace" point to the exact installed Space. It also refreshes the catalog when HF auth changes and includes a small Tauri-side cleanup in the patched btleplug dependency to remove the current compiler warning.
