### PR TITLE
fix: return refresh promise so job overlay waits for app list update

### DIFF
--- a/src/views/active-robot/application-store/hooks/useAppsStore.js
+++ b/src/views/active-robot/application-store/hooks/useAppsStore.js
@@ -240,7 +240,7 @@ export function useAppsStore(isActive) {
     cleanup: cleanupJobs,
   } = useAppJobs(setActiveJobs, () => {
     if (fetchAvailableAppsRef.current) {
-      fetchAvailableAppsRef.current(true); // Force refresh after job completion
+      return fetchAvailableAppsRef.current(true); // Force refresh after job completion
     }
   });
 


### PR DESCRIPTION
## Summary
- The callback passed to `useAppJobs` did not `return` the Promise from `fetchAvailableApps`, causing the job overlay to close before the app list actually refreshed
- Uninstalled apps would still appear in the UI until the next manual refresh

## Changes
- Added `return` to propagate the Promise in `useAppsStore.js`

## Test plan
- [ ] Uninstall an app and verify it disappears from the list immediately (no ghost entry)
- [ ] Install an app and verify the list updates once the overlay closes

Made with [Cursor](https://cursor.com)