### PR TITLE
fix: surface relaunch failure to user after consecutive updates

### DIFF
--- a/src/hooks/system/useUpdater.js
+++ b/src/hooks/system/useUpdater.js
@@ -315,21 +315,17 @@ export const useUpdater = ({
           }
         });
 
-        // downloadAndInstall should handle restart automatically,
-        // but we call relaunch() explicitly to ensure restart happens
-        // Note: In dev mode, relaunch might not work correctly
+        // Explicitly relaunch after install; Tauri's updater doesn't always
+        // auto-restart (especially on consecutive updates in the same session).
         try {
-          // Small delay to ensure installation is complete before restarting
           await new Promise(resolve => setTimeout(resolve, DAEMON_CONFIG.UPDATE_CHECK.RETRY_DELAY));
-
-          // Attempt to relaunch
           await relaunch();
-
-          // If we reach here, relaunch didn't work (shouldn't happen)
-        } catch (relaunchError) {
-          // In dev mode, relaunch might fail - this is expected
-          // The app should still restart automatically via Tauri's updater mechanism
-          // Don't throw here, as the update was successful
+        } catch {
+          // relaunch() can fail on the second consecutive update (stale process
+          // handle after the first in-place binary swap). Surface it to the user.
+          setIsDownloading(false);
+          setDownloadProgress(100);
+          setError('Update installed successfully. Please restart the app manually to apply it.');
         }
       } catch (err) {
         // Extract and format error message using centralized utilities (DRY)


### PR DESCRIPTION
## Summary
- On the second consecutive update in the same session, `relaunch()` can fail due to a stale process handle after the first in-place binary swap
- Previously, this error was silently swallowed; now we display a user-friendly message asking to restart manually

## Changes
- Updated error handling in `useUpdater.js` to surface relaunch failures with a clear message
- Cleaned up dead comments and unused variable

## Test plan
- [ ] Trigger two consecutive updates and verify user sees "restart manually" message if relaunch fails
- [ ] Verify single update still relaunches correctly

Made with [Cursor](https://cursor.com)