### PR TITLE
fix: disable three-dot menu while an app is stopping

### DIFF
--- a/src/views/active-robot/application-store/installed/InstalledAppsSection.jsx
+++ b/src/views/active-robot/application-store/installed/InstalledAppsSection.jsx
@@ -743,10 +743,11 @@ export default function InstalledAppsSection({
 
                     {/* Right: Action buttons */}
                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, flexShrink: 0 }}>
-                      {/* Three-dot menu - visible on hover */}
+                      {/* Three-dot menu - visible on hover, disabled while stopping */}
                       <IconButton
                         className="more-menu-btn"
                         size="small"
+                        disabled={isStoppingApp && isThisAppCurrent}
                         onClick={e => handleMenuOpen(e, app.name)}
                         sx={{
                           width: 28,


### PR DESCRIPTION
## Summary
- Prevents the user from triggering actions (uninstall, update, etc.) on an app that is currently stopping
- The three-dot menu `IconButton` is now disabled when the current app is in a stopping state

## Changes
- Added `disabled={isStoppingApp && isThisAppCurrent}` to the menu button in `InstalledAppsSection.jsx`

## Test plan
- [ ] Start an app, click stop, verify three-dot menu is disabled during stop
- [ ] Verify menu works normally when no app is stopping

Made with [Cursor](https://cursor.com)