### PR TITLE
fix: improve WebRTC stream reliability and enable simulation mode

### DIFF
--- a/src/contexts/WebRTCStreamContext.jsx
+++ b/src/contexts/WebRTCStreamContext.jsx
@@ -47,7 +47,7 @@ export function WebRTCStreamProvider({ children }) {
   // WebRTC availability: true if the daemon exposes a WebRTC signaling server
   // - WiFi + wireless_version: true (Wireless robot over WiFi)
   // - USB (Lite): true (Lite daemon now supports WebRTC locally)
-  // - Simulation: depends on daemon capabilities
+  // - Simulation: true (mockup-sim daemon runs locally with WebRTC signaling)
   const [isWebRTCAvailable, setIsWebRTCAvailable] = useState(null);
   const [checkFailed, setCheckFailed] = useState(false);
 
@@ -70,7 +70,11 @@ export function WebRTCStreamProvider({ children }) {
       return;
     }
 
-    if (connectionMode === 'usb' || connectionMode === 'external') {
+    if (
+      connectionMode === 'usb' ||
+      connectionMode === 'external' ||
+      connectionMode === 'simulation'
+    ) {
       // Local daemon always exposes WebRTC signaling server on localhost
       setIsWebRTCAvailable(true);
       return;
@@ -131,6 +135,11 @@ export function WebRTCStreamProvider({ children }) {
           apiRef.current.unregisterConnectionListener(connectionListenerRef.current);
           connectionListenerRef.current = null;
         }
+        // GstWebRTCAPI has no public close() - close the underlying signaling channel
+        // directly to prevent orphaned WebSocket connections
+        if (apiRef.current._channel) {
+          apiRef.current._channel.close();
+        }
       } catch (e) {
         // Ignore cleanup errors
       }
@@ -185,7 +194,9 @@ export function WebRTCStreamProvider({ children }) {
         },
         disconnected: () => {
           if (!mountedRef.current) return;
+          setState(StreamState.DISCONNECTED);
           setStream(null);
+          setAudioTrack(null);
 
           // Schedule reconnect if still should connect
           if (mountedRef.current && !reconnectTimeoutRef.current) {
@@ -252,6 +263,7 @@ export function WebRTCStreamProvider({ children }) {
             if (!mountedRef.current) return;
             sessionRef.current = null;
             setStream(null);
+            setAudioTrack(null);
             setState(prev => (prev === StreamState.CONNECTED ? StreamState.DISCONNECTED : prev));
           });
 
@@ -284,6 +296,7 @@ export function WebRTCStreamProvider({ children }) {
             sessionRef.current.close();
             sessionRef.current = null;
             setStream(null);
+            setAudioTrack(null);
             setState(StreamState.DISCONNECTED);
           }
         },

--- a/src/views/active-robot/camera/CameraFeed.jsx
+++ b/src/views/active-robot/camera/CameraFeed.jsx
@@ -23,15 +23,34 @@ export default function CameraFeed({ isLarge = false }) {
     connect,
   } = useWebRTCStreamContext();
 
-  // Attach stream to video element
+  // Attach/detach stream to video element
   useEffect(() => {
-    if (videoRef.current && stream) {
-      videoRef.current.srcObject = stream;
-      videoRef.current.play().catch(e => {
+    const video = videoRef.current;
+    if (!video) return;
+
+    if (stream) {
+      video.srcObject = stream;
+      video.play().catch(e => {
         console.warn('[CameraFeed] Autoplay failed:', e);
       });
+    } else {
+      video.srcObject = null;
     }
+
+    return () => {
+      video.srcObject = null;
+    };
   }, [stream]);
+
+  // Re-trigger play() when the video becomes visible after connection
+  useEffect(() => {
+    const video = videoRef.current;
+    if (video && isConnected && video.srcObject && video.paused) {
+      video.play().catch(e => {
+        console.warn('[CameraFeed] Resume play failed:', e);
+      });
+    }
+  }, [isConnected]);
 
   // Common placeholder box style
   const placeholderStyle = {
@@ -174,7 +193,7 @@ export default function CameraFeed({ isLarge = false }) {
           width: '100%',
           height: '100%',
           objectFit: 'cover',
-          display: isConnected ? 'block' : 'none',
+          visibility: isConnected ? 'visible' : 'hidden',
         }}
       />
 

--- a/src/views/active-robot/right-panel/applications/ApplicationsSection.jsx
+++ b/src/views/active-robot/right-panel/applications/ApplicationsSection.jsx
@@ -14,8 +14,6 @@ import { InstalledAppsSection } from '../../application-store/installed';
 import { Modal as DiscoverModal } from '../../application-store/discover';
 import { CreateAppTutorial as CreateAppTutorialModal } from '../../application-store/modals';
 import { Overlay as InstallOverlay } from '../../application-store/installation';
-import SimulationDisclaimer from './SimulationDisclaimer';
-import { isSimulationMode } from '../../../../utils/simulationMode';
 
 /**
  * Applications Section - Displays installed and available apps from Hugging Face
@@ -171,9 +169,6 @@ export default function ApplicationsSection({
     officialOnly
   );
 
-  // Check if we're in simulation mode
-  const inSimulationMode = isSimulationMode();
-
   return (
     <>
       <Box>
@@ -307,11 +302,7 @@ export default function ApplicationsSection({
             </Typography>
           </Box>
         </Box>
-        {/* Apps list container with simulation disclaimer overlay */}
         <Box sx={{ px: 0, mb: 0, bgcolor: 'transparent', position: 'relative' }}>
-          {/* Simulation mode disclaimer - only covers the apps list box */}
-          {inSimulationMode && <SimulationDisclaimer darkMode={effectiveDarkMode} />}
-
           <InstalledAppsSection
             installedApps={installedApps}
             darkMode={effectiveDarkMode}


### PR DESCRIPTION
## Summary
- WebRTC streaming now works in simulation mode (mockup-sim daemon runs locally with signaling)
- Camera feed is more reliable: explicit srcObject cleanup, play() re-trigger on reconnection, visibility:hidden instead of display:none
- WebRTC context properly closes the signaling WebSocket and clears audioTrack in all disconnect paths
- Removes the simulation mode disclaimer overlay from the applications section

## Changes
- `WebRTCStreamContext.jsx`: add `simulation` to connectionMode check, close `_channel` on cleanup, add `setAudioTrack(null)` in disconnect/session.closed/producerRemoved handlers
- `CameraFeed.jsx`: explicit srcObject null on detach, play() on visibility change, visibility instead of display
- `ApplicationsSection.jsx`: remove SimulationDisclaimer import and rendering

## Test plan
- [ ] Launch in simulation mode, verify camera feed shows the simulated stream
- [ ] Disconnect/reconnect and verify the feed recovers without stale frames
- [ ] Verify no orphaned WebSocket connections after navigating away
- [ ] Confirm audio track is properly null'd after disconnection
- [ ] Verify applications section no longer shows simulation disclaimer

Made with [Cursor](https://cursor.com)