### PR TITLE
feat: add private apps filter in app store

### DIFF
--- a/src/views/active-robot/application-store/discover/Modal.jsx
+++ b/src/views/active-robot/application-store/discover/Modal.jsx
@@ -34,6 +34,8 @@ export default function DiscoverModal({
   setSearchQuery,
   officialOnly,
   setOfficialOnly,
+  privateOnly,
+  setPrivateOnly,
   categories,
   selectedCategory,
   setSelectedCategory,
@@ -101,6 +103,8 @@ export default function DiscoverModal({
           setSearchQuery={setSearchQuery}
           officialOnly={officialOnly}
           setOfficialOnly={setOfficialOnly}
+          privateOnly={privateOnly}
+          setPrivateOnly={setPrivateOnly}
           isLoading={isLoading}
           filteredApps={filteredApps}
           totalAppsCount={totalAppsCount}

--- a/src/views/active-robot/application-store/discover/components/AppCard.jsx
+++ b/src/views/active-robot/application-store/discover/components/AppCard.jsx
@@ -4,6 +4,7 @@ import DownloadOutlinedIcon from '@mui/icons-material/DownloadOutlined';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import VerifiedIcon from '@mui/icons-material/Verified';
+import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import { useActiveRobotContext } from '../../../context';
@@ -33,6 +34,7 @@ function AppCard({
   const lastModified = app.extra?.lastModified || app.extra?.createdAt || null;
   const isPythonApp = app.extra?.isPythonApp !== false;
   const isOfficial = app.isOfficial === true;
+  const isPrivate = app.extra?.private === true;
   const emoji = [...(cardData.emoji || (isPythonApp ? '📦' : '🌐'))][0];
   const spaceUrl = app.url || `https://huggingface.co/spaces/${app.extra?.id || app.name}`;
 
@@ -151,6 +153,23 @@ function AppCard({
                   height: 18,
                   flexShrink: 0,
                   '& .MuiChip-icon': { color: '#FF9500', ml: 0.5 },
+                  '& .MuiChip-label': { px: 0.5 },
+                }}
+              />
+            )}
+            {isPrivate && (
+              <Chip
+                icon={<LockOutlinedIcon sx={{ fontSize: 11 }} />}
+                label="Private"
+                size="small"
+                sx={{
+                  bgcolor: darkMode ? 'rgba(139, 92, 246, 0.15)' : 'rgba(139, 92, 246, 0.1)',
+                  color: '#8b5cf6',
+                  fontWeight: 600,
+                  fontSize: 9,
+                  height: 18,
+                  flexShrink: 0,
+                  '& .MuiChip-icon': { color: '#8b5cf6', ml: 0.5 },
                   '& .MuiChip-label': { px: 0.5 },
                 }}
               />

--- a/src/views/active-robot/application-store/discover/components/SearchBar.jsx
+++ b/src/views/active-robot/application-store/discover/components/SearchBar.jsx
@@ -21,6 +21,8 @@ export default function SearchBar({
   setSearchQuery,
   officialOnly,
   setOfficialOnly,
+  privateOnly,
+  setPrivateOnly,
   isLoading,
   filteredApps,
   totalAppsCount,
@@ -262,7 +264,58 @@ export default function SearchBar({
             </>
           )}
 
-          {/* Official/Non-official toggle */}
+          {/* Private only toggle */}
+          <Box
+            sx={{
+              width: '1px',
+              height: '18px',
+              bgcolor: darkMode ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.1)',
+            }}
+          />
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={privateOnly}
+                onChange={e => setPrivateOnly(e.target.checked)}
+                disabled={isLoading}
+                size="small"
+                sx={{
+                  color: darkMode ? '#888' : '#999',
+                  '&.Mui-checked': {
+                    color: '#8b5cf6',
+                  },
+                  '&.Mui-disabled': {
+                    color: darkMode ? '#444' : '#ccc',
+                    opacity: 0.5,
+                  },
+                  '& .MuiSvgIcon-root': {
+                    fontSize: 18,
+                  },
+                }}
+              />
+            }
+            label={
+              <Typography
+                sx={{
+                  fontSize: 12,
+                  fontWeight: 600,
+                  color: darkMode ? '#888' : '#999',
+                  userSelect: 'none',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                Private
+              </Typography>
+            }
+            sx={{
+              m: 0,
+              '& .MuiFormControlLabel-label': {
+                ml: 0.5,
+              },
+            }}
+          />
+
+          {/* Official only toggle */}
           <Box
             sx={{
               width: '1px',
@@ -299,10 +352,10 @@ export default function SearchBar({
                   fontWeight: 600,
                   color: darkMode ? '#888' : '#999',
                   userSelect: 'none',
-                  pr: 1.5, // Padding right after text
+                  pr: 1.5,
                 }}
               >
-                Official only
+                Official
               </Typography>
             }
             sx={{

--- a/src/views/active-robot/application-store/hooks/useAppFiltering.js
+++ b/src/views/active-robot/application-store/hooks/useAppFiltering.js
@@ -33,23 +33,31 @@ const FUSE_OPTIONS = {
  * @param {string} searchQuery - Search query string
  * @param {string|null} selectedCategory - Selected category filter
  * @param {boolean} officialOnly - If true, show only official apps; if false, show all apps
+ * @param {boolean} privateOnly - If true, show only private apps; if false, show all apps
  */
 export function useAppFiltering(
   availableApps,
   searchQuery,
   selectedCategory,
-  officialOnly = false
+  officialOnly = false,
+  privateOnly = false
 ) {
   const fuseRef = useRef(null);
   const fuseInputRef = useRef(null);
 
   const appsForMode = useMemo(() => {
-    if (!officialOnly) return availableApps;
-    return availableApps.filter(app => {
-      if (app.isOfficial !== undefined) return app.isOfficial;
-      return app.source_kind === 'hf_space';
-    });
-  }, [availableApps, officialOnly]);
+    let apps = availableApps;
+    if (officialOnly) {
+      apps = apps.filter(app => {
+        if (app.isOfficial !== undefined) return app.isOfficial;
+        return app.source_kind === 'hf_space';
+      });
+    }
+    if (privateOnly) {
+      apps = apps.filter(app => app.extra?.private === true);
+    }
+    return apps;
+  }, [availableApps, officialOnly, privateOnly]);
 
   // Build / rebuild Fuse index when the filtered app set changes
   const fuse = useMemo(() => {

--- a/src/views/active-robot/right-panel/applications/ApplicationsSection.jsx
+++ b/src/views/active-robot/right-panel/applications/ApplicationsSection.jsx
@@ -47,6 +47,7 @@ export default function ApplicationsSection({
 
   // State
   const [officialOnly, setOfficialOnly] = useState(false);
+  const [privateOnly, setPrivateOnly] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState(null);
   const [searchQuery, setSearchQuery] = useState('');
 
@@ -166,7 +167,8 @@ export default function ApplicationsSection({
     availableApps,
     searchQuery,
     selectedCategory,
-    officialOnly
+    officialOnly,
+    privateOnly
   );
 
   return (
@@ -344,6 +346,8 @@ export default function ApplicationsSection({
         setSearchQuery={setSearchQuery}
         officialOnly={officialOnly}
         setOfficialOnly={setOfficialOnly}
+        privateOnly={privateOnly}
+        setPrivateOnly={setPrivateOnly}
         categories={categories}
         selectedCategory={selectedCategory}
         setSelectedCategory={setSelectedCategory}


### PR DESCRIPTION
## Summary
- Add a "Private" checkbox filter in the discover modal to show only private HF Spaces
- Display a purple "Private" chip with lock icon on private app cards
- Rename "Official only" label to "Official" for consistency

## Changes
- `useAppFiltering.js`: accept and apply `privateOnly` parameter
- `SearchBar.jsx`: add Private checkbox with purple accent color
- `AppCard.jsx`: show Private chip when `app.extra.private === true`
- `Modal.jsx` + `ApplicationsSection.jsx`: thread `privateOnly` state through

## Test plan
- [ ] Open discover modal, toggle Private filter, verify only private apps appear
- [ ] Verify private app cards show the purple "Private" chip
- [ ] Verify Official filter still works independently
- [ ] Verify combined Private + Official filters work correctly

Made with [Cursor](https://cursor.com)