### PR TITLE
fix: make maintenance and motor settings available in all connection modes

### DIFF
--- a/src/components/viewer3d/SettingsOverlay.jsx
+++ b/src/components/viewer3d/SettingsOverlay.jsx
@@ -18,7 +18,6 @@ import {
   SettingsPreferencesCard,
   SettingsCacheCard,
   SettingsDaemonCard,
-  SettingsResetCard,
   ChangeWifiOverlay,
 } from './settings';
 
@@ -686,7 +685,7 @@ export default function SettingsOverlay({ open, onClose, darkMode }) {
         <Box
           sx={{
             width: '90%',
-            maxWidth: isWifiMode ? '680px' : '360px',
+            maxWidth: '680px',
             mx: 'auto',
             display: 'flex',
             flexDirection: 'column',
@@ -750,11 +749,11 @@ export default function SettingsOverlay({ open, onClose, darkMode }) {
           <Box
             sx={{
               display: 'grid',
-              gridTemplateColumns: isWifiMode ? 'repeat(2, 1fr)' : '1fr',
+              gridTemplateColumns: 'repeat(2, 1fr)',
               gap: 2,
             }}
           >
-            {/* Row 1: Update + WiFi (or Update alone) */}
+            {/* Row 1: Update + WiFi (WiFi) or Update + Daemon Control (USB/Sim) */}
             <SettingsUpdateCard
               darkMode={darkMode}
               title={isWifiMode ? 'System Update' : 'Daemon Update'}
@@ -770,7 +769,7 @@ export default function SettingsOverlay({ open, onClose, darkMode }) {
               isOnline={navigator.onLine}
             />
 
-            {isWifiMode && (
+            {isWifiMode ? (
               <SettingsWifiCard
                 darkMode={darkMode}
                 wifiStatus={wifiStatus}
@@ -780,15 +779,16 @@ export default function SettingsOverlay({ open, onClose, darkMode }) {
                 onClearAllNetworks={() => setShowClearNetworksConfirm(true)}
                 cardStyle={cardStyle}
               />
+            ) : (
+              <SettingsDaemonCard darkMode={darkMode} cardStyle={cardStyle} />
             )}
 
-            {/* Row 2: Preferences + Daemon Control (WiFi) or just Preferences */}
+            {/* Row 2: Preferences + Daemon Control (WiFi) or Preferences + Maintenance (USB/Sim) */}
             <SettingsPreferencesCard darkMode={darkMode} cardStyle={cardStyle} />
 
-            {isWifiMode && <SettingsDaemonCard darkMode={darkMode} cardStyle={cardStyle} />}
-
-            {/* Row 3: Cache (WiFi only) / Environment Reset (USB/Sim only) */}
-            {isWifiMode && (
+            {isWifiMode ? (
+              <SettingsDaemonCard darkMode={darkMode} cardStyle={cardStyle} />
+            ) : (
               <SettingsCacheCard
                 darkMode={darkMode}
                 cardStyle={cardStyle}
@@ -797,15 +797,15 @@ export default function SettingsOverlay({ open, onClose, darkMode }) {
                 isResettingApps={isResettingApps}
               />
             )}
-            {!isWifiMode && (
-              <SettingsResetCard
+
+            {/* Row 3: Maintenance (WiFi only) */}
+            {isWifiMode && (
+              <SettingsCacheCard
                 darkMode={darkMode}
                 cardStyle={cardStyle}
                 buttonStyle={buttonStyle}
-                onResetAppsVenv={handleResetAppsVenvClick}
-                isResettingAppsVenv={isResettingAppsVenv}
-                onResetPythonEnv={handleResetPythonEnvClick}
-                isResettingPythonEnv={isResettingPythonEnv}
+                onResetAppsClick={handleResetAppsClick}
+                isResettingApps={isResettingApps}
               />
             )}
           </Box>

--- a/src/components/viewer3d/settings/SettingsCacheCard.jsx
+++ b/src/components/viewer3d/settings/SettingsCacheCard.jsx
@@ -6,8 +6,12 @@ import { buildApiUrl, fetchWithTimeout, DAEMON_CONFIG } from '../../../config/da
 import { useToast } from '../../../hooks/useToast';
 
 /**
- * Cache Card Component
- * Allows clearing HuggingFace cache and resetting apps on the robot
+ * Maintenance Card
+ * Clear HuggingFace cache and reset apps (via daemon API).
+ * Shown in all connection modes.
+ *
+ * Heavier environment resets (apps venv, full Python env) are available
+ * from the robot selection screen (FindingRobotView).
  */
 export default function SettingsCacheCard({
   darkMode,
@@ -46,10 +50,33 @@ export default function SettingsCacheCard({
   };
 
   const textSecondary = darkMode ? '#888' : '#666';
+  const dangerColor = darkMode ? '#f87171' : '#dc2626';
+  const dangerBorder = darkMode ? 'rgba(248, 113, 113, 0.5)' : 'rgba(220, 38, 38, 0.5)';
+  const dangerHoverBg = darkMode ? 'rgba(248, 113, 113, 0.1)' : 'rgba(220, 38, 38, 0.08)';
+  const disabledBorder = darkMode ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)';
+  const disabledColor = darkMode ? '#555' : '#bbb';
+
+  const dangerButtonStyle = {
+    ...buttonStyle,
+    fontSize: 12,
+    py: 0.75,
+    px: 2,
+    borderRadius: '8px',
+    color: dangerColor,
+    borderColor: dangerBorder,
+    '&:hover': {
+      borderColor: dangerColor,
+      bgcolor: dangerHoverBg,
+    },
+    '&:disabled': {
+      borderColor: disabledBorder,
+      color: disabledColor,
+    },
+  };
 
   return (
     <Box sx={cardStyle}>
-      <SectionHeader title="Cache Management" icon={DeleteOutlineIcon} darkMode={darkMode} />
+      <SectionHeader title="Maintenance" icon={DeleteOutlineIcon} darkMode={darkMode} />
 
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
         <Typography sx={{ fontSize: 12, color: textSecondary, lineHeight: 1.5 }}>
@@ -63,24 +90,7 @@ export default function SettingsCacheCard({
           startIcon={
             isClearing ? <CircularProgress size={16} color="inherit" /> : <DeleteOutlineIcon />
           }
-          sx={{
-            ...buttonStyle,
-            fontSize: 12,
-            py: 0.75,
-            px: 2,
-            borderRadius: '8px',
-            // Use warning color for destructive action
-            color: darkMode ? '#f87171' : '#dc2626',
-            borderColor: darkMode ? 'rgba(248, 113, 113, 0.5)' : 'rgba(220, 38, 38, 0.5)',
-            '&:hover': {
-              borderColor: darkMode ? '#f87171' : '#dc2626',
-              bgcolor: darkMode ? 'rgba(248, 113, 113, 0.1)' : 'rgba(220, 38, 38, 0.08)',
-            },
-            '&:disabled': {
-              borderColor: darkMode ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)',
-              color: darkMode ? '#555' : '#bbb',
-            },
-          }}
+          sx={dangerButtonStyle}
         >
           {isClearing ? 'Clearing...' : 'Clear HuggingFace Cache'}
         </Button>
@@ -96,23 +106,7 @@ export default function SettingsCacheCard({
           startIcon={
             isResettingApps ? <CircularProgress size={16} color="inherit" /> : <DeleteOutlineIcon />
           }
-          sx={{
-            ...buttonStyle,
-            fontSize: 12,
-            py: 0.75,
-            px: 2,
-            borderRadius: '8px',
-            color: darkMode ? '#f87171' : '#dc2626',
-            borderColor: darkMode ? 'rgba(248, 113, 113, 0.5)' : 'rgba(220, 38, 38, 0.5)',
-            '&:hover': {
-              borderColor: darkMode ? '#f87171' : '#dc2626',
-              bgcolor: darkMode ? 'rgba(248, 113, 113, 0.1)' : 'rgba(220, 38, 38, 0.08)',
-            },
-            '&:disabled': {
-              borderColor: darkMode ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)',
-              color: darkMode ? '#555' : '#bbb',
-            },
-          }}
+          sx={dangerButtonStyle}
         >
           {isResettingApps ? 'Resetting...' : 'Reset Apps Cache'}
         </Button>


### PR DESCRIPTION
## Summary
- Show motor backend settings (SettingsDaemonCard) and maintenance settings (SettingsCacheCard) in all connection modes (WiFi, USB, Simulation), not just WiFi
- Remove heavy environment resets from settings overlay (already available on robot selection screen)
- Use consistent 2-column grid layout across all modes

## Test plan
- [ ] Open settings in WiFi mode: verify motor backend + maintenance cards visible
- [ ] Open settings in USB mode: verify same cards visible
- [ ] Open settings in Simulation mode: verify same cards visible
- [ ] Verify "Clear HuggingFace Cache" and "Reset Apps Cache" buttons work
- [ ] Verify grid layout is consistent across modes

Made with [Cursor](https://cursor.com)