### PR TITLE
feat: improve daemon log buffer and expose sidecar branch info

### DIFF
--- a/src-tauri/src/daemon/mod.rs
+++ b/src-tauri/src/daemon/mod.rs
@@ -113,13 +113,14 @@ pub struct DaemonState {
     pub connection_mode: Mutex<Option<String>>,
 }
 
-pub const MAX_LOGS: usize = 50;
+pub const MAX_LOGS: usize = 2000;
 
 // ============================================================================
 // LOG MANAGEMENT
 // ============================================================================
 
-pub fn add_log(state: &State<DaemonState>, message: String) {
+/// Store a log line in the ring buffer (callable from any context).
+pub fn buffer_log(state: &DaemonState, message: String) {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     let timestamp = SystemTime::now()
@@ -144,6 +145,11 @@ pub fn add_log(state: &State<DaemonState>, message: String) {
             );
         }
     }
+}
+
+/// Convenience wrapper for Tauri command handlers (State<T> derefs to T).
+pub fn add_log(state: &State<DaemonState>, message: String) {
+    buffer_log(state, message);
 }
 
 // ============================================================================
@@ -422,6 +428,8 @@ macro_rules! spawn_sidecar_monitor {
                             .unwrap_or_else(|| line.to_string());
                         log::info!("Sidecar stdout: {}", prefixed_line);
                         let _ = app_handle_clone.emit("sidecar-stdout", prefixed_line.clone());
+                        let ds = app_handle_clone.state::<$crate::daemon::DaemonState>();
+                        $crate::daemon::buffer_log(&ds, prefixed_line);
                     }
                     CommandEvent::Stderr(line_bytes) => {
                         let line = String::from_utf8_lossy(&line_bytes);
@@ -431,6 +439,8 @@ macro_rules! spawn_sidecar_monitor {
                             .unwrap_or_else(|| line.to_string());
                         log::warn!("Sidecar stderr: {}", prefixed_line);
                         let _ = app_handle_clone.emit("sidecar-stderr", prefixed_line.clone());
+                        let ds = app_handle_clone.state::<$crate::daemon::DaemonState>();
+                        $crate::daemon::buffer_log(&ds, prefixed_line);
                     }
                     CommandEvent::Terminated(status) => {
                         if let Some(ref p) = prefix {
@@ -549,12 +559,18 @@ pub fn spawn_and_monitor_sidecar(
                 CommandEvent::Stdout(line_bytes) => {
                     let line = String::from_utf8_lossy(&line_bytes);
                     log::info!("Sidecar stdout: {}", line);
-                    let _ = app_handle_clone.emit("sidecar-stdout", line.to_string());
+                    let line_str = line.to_string();
+                    let _ = app_handle_clone.emit("sidecar-stdout", line_str.clone());
+                    let ds = app_handle_clone.state::<crate::daemon::DaemonState>();
+                    crate::daemon::buffer_log(&ds, line_str);
                 }
                 CommandEvent::Stderr(line_bytes) => {
                     let line = String::from_utf8_lossy(&line_bytes);
                     log::warn!("Sidecar stderr: {}", line);
-                    let _ = app_handle_clone.emit("sidecar-stderr", line.to_string());
+                    let line_str = line.to_string();
+                    let _ = app_handle_clone.emit("sidecar-stderr", line_str.clone());
+                    let ds = app_handle_clone.state::<crate::daemon::DaemonState>();
+                    crate::daemon::buffer_log(&ds, line_str);
 
                     let line_lower = line.to_lowercase();
                     if line_lower.contains("unrecognised argument")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -90,12 +90,6 @@ fn start_daemon(
         );
     }
 
-    let success_msg = if sim_mode {
-        "Daemon started in simulation mode (mockup-sim)"
-    } else {
-        "Daemon started via embedded sidecar"
-    };
-    add_log(&state, success_msg.to_string());
     Ok("Daemon started successfully".to_string())
 }
 
@@ -229,6 +223,50 @@ async fn set_local_proxy_target(
 async fn clear_local_proxy_target(state: State<'_, Arc<LocalProxyState>>) -> Result<(), String> {
     local_proxy::clear_target_host(&state).await;
     Ok(())
+}
+
+// ============================================================================
+// SIDECAR BUILD INFO
+// ============================================================================
+
+#[tauri::command]
+fn get_sidecar_source() -> serde_json::Value {
+    let marker_path = {
+        #[cfg(target_os = "macos")]
+        {
+            std::env::var("HOME").ok().map(|h| {
+                std::path::PathBuf::from(h).join(
+                    "Library/Application Support/com.pollen-robotics.reachy-mini/.reachy_mini_spec",
+                )
+            })
+        }
+        #[cfg(target_os = "windows")]
+        {
+            std::env::var("LOCALAPPDATA")
+                .ok()
+                .map(|d| std::path::PathBuf::from(d).join("Reachy Mini Control\\.reachy_mini_spec"))
+        }
+        #[cfg(target_os = "linux")]
+        {
+            std::env::var("HOME").ok().map(|h| {
+                std::path::PathBuf::from(h)
+                    .join(".local/share/reachy-mini-control/.reachy_mini_spec")
+            })
+        }
+    };
+
+    let spec = marker_path
+        .and_then(|p| std::fs::read_to_string(p).ok())
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+
+    let branch = spec.split('@').nth(1).map(String::from);
+
+    serde_json::json!({
+        "source": branch.as_deref().unwrap_or("pypi"),
+        "spec": spec,
+    })
 }
 
 // ============================================================================
@@ -412,6 +450,7 @@ pub fn run() {
             update::update_daemon,
             reset::reset_apps_venv,
             reset::reset_python_env,
+            get_sidecar_source,
             set_local_proxy_target,
             clear_local_proxy_target,
             // Robot discovery (mDNS + manual IP)

--- a/src/views/active-robot/RobotHeader.jsx
+++ b/src/views/active-robot/RobotHeader.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Box, Typography } from '@mui/material';
 import { getVersion } from '@utils/tauriCompat';
+import { invoke } from '@tauri-apps/api/core';
 import useAppStore from '../../store/useAppStore';
 
 /**
@@ -10,11 +11,19 @@ import useAppStore from '../../store/useAppStore';
 export default function RobotHeader({ daemonVersion, darkMode = false }) {
   const { connectionMode } = useAppStore();
   const [appVersion, setAppVersion] = useState('');
+  const [sidecarBranch, setSidecarBranch] = useState(null);
 
   useEffect(() => {
     getVersion()
       .then(setAppVersion)
       .catch(() => setAppVersion(null));
+    invoke('get_sidecar_source')
+      .then(info => {
+        if (info?.source && info.source !== 'pypi') {
+          setSidecarBranch(info.source);
+        }
+      })
+      .catch(() => {});
   }, []);
 
   // Get connection type label
@@ -89,7 +98,11 @@ export default function RobotHeader({ daemonVersion, darkMode = false }) {
             verticalAlign: 'middle',
           }}
         />
-        {daemonVersion ? `Daemon v${daemonVersion}` : 'Daemon ?'}
+        {sidecarBranch
+          ? `Daemon @${sidecarBranch}`
+          : daemonVersion
+            ? `Daemon v${daemonVersion}`
+            : 'Daemon ?'}
       </Typography>
     </Box>
   );


### PR DESCRIPTION
## Summary

- **Increase `MAX_LOGS` from 50 to 2000** so the Rust ring buffer retains a much deeper history of daemon logs, fixing the issue where dev mode appeared to lose older entries.
- **Refactor `add_log` into `buffer_log`** and call it from sidecar stdout/stderr event handlers so every daemon process output line is stored in the `VecDeque` (previously they were only emitted as Tauri events but never stored).
- **Remove the duplicate "Daemon started" manual log** in `lib.rs` - the message is already captured from the Python daemon's stdout.
- **Add `get_sidecar_source` Tauri command** that reads the `.reachy_mini_spec` marker file to expose which branch the sidecar was compiled from (cross-platform: macOS, Windows, Linux).
- **Show branch name in `RobotHeader`**: displays "Daemon @main" (or @develop, etc.) when running from a git branch build, falls back to "Daemon v1.6.3" for PyPI releases.

## Test plan

- [ ] Launch app in simulation mode - verify logs appear in dev mode without gaps
- [ ] Check RobotHeader shows "Daemon @main" when sidecar was compiled from main branch
- [ ] Check RobotHeader shows "Daemon v<version>" when sidecar installed from PyPI
- [ ] Verify no duplicate "Daemon started" log on startup

Made with [Cursor](https://cursor.com)