### PR TITLE
feat: refactor logging system with simple/dev modes, perf & UX improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,11 +46,13 @@
         user-select: text !important;
       }
       
-      /* Re-enable selection for log boxes */
+      /* Re-enable selection for log boxes and error boundary */
       .log-console,
       .log-console *,
       .log-console *::before,
-      .log-console *::after {
+      .log-console *::after,
+      .selectable-text,
+      .selectable-text * {
         -webkit-user-select: text !important;
         -moz-user-select: text !important;
         -ms-user-select: text !important;

--- a/src-tauri/src/daemon/mod.rs
+++ b/src-tauri/src/daemon/mod.rs
@@ -113,13 +113,14 @@ pub struct DaemonState {
     pub connection_mode: Mutex<Option<String>>,
 }
 
-pub const MAX_LOGS: usize = 50;
+pub const MAX_LOGS: usize = 2000;
 
 // ============================================================================
 // LOG MANAGEMENT
 // ============================================================================
 
-pub fn add_log(state: &State<DaemonState>, message: String) {
+/// Store a log line in the ring buffer (callable from any context).
+pub fn buffer_log(state: &DaemonState, message: String) {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     let timestamp = SystemTime::now()
@@ -144,6 +145,11 @@ pub fn add_log(state: &State<DaemonState>, message: String) {
             );
         }
     }
+}
+
+/// Convenience wrapper for Tauri command handlers (State<T> derefs to T).
+pub fn add_log(state: &State<DaemonState>, message: String) {
+    buffer_log(state, message);
 }
 
 // ============================================================================
@@ -422,6 +428,8 @@ macro_rules! spawn_sidecar_monitor {
                             .unwrap_or_else(|| line.to_string());
                         log::info!("Sidecar stdout: {}", prefixed_line);
                         let _ = app_handle_clone.emit("sidecar-stdout", prefixed_line.clone());
+                        let ds = app_handle_clone.state::<$crate::daemon::DaemonState>();
+                        $crate::daemon::buffer_log(&ds, prefixed_line);
                     }
                     CommandEvent::Stderr(line_bytes) => {
                         let line = String::from_utf8_lossy(&line_bytes);
@@ -431,6 +439,8 @@ macro_rules! spawn_sidecar_monitor {
                             .unwrap_or_else(|| line.to_string());
                         log::warn!("Sidecar stderr: {}", prefixed_line);
                         let _ = app_handle_clone.emit("sidecar-stderr", prefixed_line.clone());
+                        let ds = app_handle_clone.state::<$crate::daemon::DaemonState>();
+                        $crate::daemon::buffer_log(&ds, prefixed_line);
                     }
                     CommandEvent::Terminated(status) => {
                         if let Some(ref p) = prefix {
@@ -549,12 +559,18 @@ pub fn spawn_and_monitor_sidecar(
                 CommandEvent::Stdout(line_bytes) => {
                     let line = String::from_utf8_lossy(&line_bytes);
                     log::info!("Sidecar stdout: {}", line);
-                    let _ = app_handle_clone.emit("sidecar-stdout", line.to_string());
+                    let line_str = line.to_string();
+                    let _ = app_handle_clone.emit("sidecar-stdout", line_str.clone());
+                    let ds = app_handle_clone.state::<crate::daemon::DaemonState>();
+                    crate::daemon::buffer_log(&ds, line_str);
                 }
                 CommandEvent::Stderr(line_bytes) => {
                     let line = String::from_utf8_lossy(&line_bytes);
                     log::warn!("Sidecar stderr: {}", line);
-                    let _ = app_handle_clone.emit("sidecar-stderr", line.to_string());
+                    let line_str = line.to_string();
+                    let _ = app_handle_clone.emit("sidecar-stderr", line_str.clone());
+                    let ds = app_handle_clone.state::<crate::daemon::DaemonState>();
+                    crate::daemon::buffer_log(&ds, line_str);
 
                     let line_lower = line.to_lowercase();
                     if line_lower.contains("unrecognised argument")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -90,12 +90,6 @@ fn start_daemon(
         );
     }
 
-    let success_msg = if sim_mode {
-        "Daemon started in simulation mode (mockup-sim)"
-    } else {
-        "Daemon started via embedded sidecar"
-    };
-    add_log(&state, success_msg.to_string());
     Ok("Daemon started successfully".to_string())
 }
 
@@ -229,6 +223,50 @@ async fn set_local_proxy_target(
 async fn clear_local_proxy_target(state: State<'_, Arc<LocalProxyState>>) -> Result<(), String> {
     local_proxy::clear_target_host(&state).await;
     Ok(())
+}
+
+// ============================================================================
+// SIDECAR BUILD INFO
+// ============================================================================
+
+#[tauri::command]
+fn get_sidecar_source() -> serde_json::Value {
+    let marker_path = {
+        #[cfg(target_os = "macos")]
+        {
+            std::env::var("HOME").ok().map(|h| {
+                std::path::PathBuf::from(h).join(
+                    "Library/Application Support/com.pollen-robotics.reachy-mini/.reachy_mini_spec",
+                )
+            })
+        }
+        #[cfg(target_os = "windows")]
+        {
+            std::env::var("LOCALAPPDATA")
+                .ok()
+                .map(|d| std::path::PathBuf::from(d).join("Reachy Mini Control\\.reachy_mini_spec"))
+        }
+        #[cfg(target_os = "linux")]
+        {
+            std::env::var("HOME").ok().map(|h| {
+                std::path::PathBuf::from(h)
+                    .join(".local/share/reachy-mini-control/.reachy_mini_spec")
+            })
+        }
+    };
+
+    let spec = marker_path
+        .and_then(|p| std::fs::read_to_string(p).ok())
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+
+    let branch = spec.split('@').nth(1).map(String::from);
+
+    serde_json::json!({
+        "source": branch.as_deref().unwrap_or("pypi"),
+        "spec": spec,
+    })
 }
 
 // ============================================================================
@@ -412,6 +450,7 @@ pub fn run() {
             update::update_daemon,
             reset::reset_apps_venv,
             reset::reset_python_env,
+            get_sidecar_source,
             set_local_proxy_target,
             clear_local_proxy_target,
             // Robot discovery (mDNS + manual IP)

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -85,6 +85,7 @@ class ErrorBoundary extends React.Component {
 
         {this.state.error && (
           <Box
+            className="selectable-text"
             sx={{
               mt: 1,
               px: 2,
@@ -101,6 +102,7 @@ class ErrorBoundary extends React.Component {
                 fontSize: 11,
                 color: isDark ? 'rgba(255,255,255,0.4)' : 'rgba(0,0,0,0.35)',
                 wordBreak: 'break-word',
+                cursor: 'text',
               }}
             >
               {this.state.error.message}

--- a/src/components/LogConsole/LogItem.jsx
+++ b/src/components/LogConsole/LogItem.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 import { Box, Typography } from '@mui/material';
 import { TEXT_SELECT_STYLES } from './constants';
+import { CATEGORY_META } from '../../utils/logging/constants';
 
 const WRAP_STYLES = {
   whiteSpace: 'pre-wrap',
@@ -8,66 +9,62 @@ const WRAP_STYLES = {
   minWidth: 0,
 };
 
+const getLogColor = (log, darkMode) => {
+  const { level, category } = log;
+  const msg = log.message || '';
+
+  const isError =
+    level === 'error' ||
+    msg.includes('FAILED') ||
+    msg.includes('ERROR') ||
+    msg.includes('❌') ||
+    msg.includes('[ERROR]');
+  const isWarning = level === 'warning' || msg.includes('WARNING') || msg.includes('[WARNING]');
+  const isSuccess = level === 'success' || msg.includes('✓');
+
+  if (isError) return darkMode ? '#ff5555' : '#cc0000';
+  if (isWarning) return darkMode ? '#fbbf24' : '#d97706';
+  if (isSuccess) return darkMode ? '#55ff55' : '#00aa00';
+
+  const meta = CATEGORY_META[category];
+  if (meta) return meta.color;
+
+  return darkMode ? '#f0f0f0' : '#1a1a1a';
+};
+
 /**
- * Render a single log item
- * Uses marginBottom for spacing between items (better for scrollMax)
- *
- * @param {Object} props
- * @param {Object} props.log - Log object with message, source, timestamp, etc.
- * @param {number} props.index - Index of the log in the list
- * @param {number} props.totalCount - Total number of logs
- * @param {boolean} props.darkMode - Dark mode enabled
- * @param {number} props.fontSize - Font size in pixels
- * @param {boolean} props.compact - Compact mode
- * @param {boolean} props.showTimestamp - Show timestamp
- * @param {boolean} props.simpleStyle - Simple style mode
+ * Render a single log item.
+ * Supports both simple and full (dev) rendering.
  */
 export const LogItem = React.memo(
-  ({ log, index, totalCount, darkMode, fontSize, compact, showTimestamp, simpleStyle }) => {
-    // Calculate spacing between items (marginBottom on all items except last)
-    const itemSpacing = compact ? 1.6 : 2.4; // 0.2 * 8 or 0.3 * 8
+  ({
+    log,
+    index,
+    totalCount,
+    darkMode,
+    fontSize,
+    compact,
+    showTimestamp,
+    simpleStyle,
+    logMode,
+  }) => {
+    const itemSpacing = compact ? 1.6 : 2.4;
 
-    // Memoize calculations - MUST be called before any early returns (Rules of Hooks)
     const memoizedValues = useMemo(() => {
       if (!log) return null;
 
-      const isFrontend = log.source === 'frontend';
       const isApp = log.source === 'app';
-      const isDaemonRemote = log.source === 'daemon';
-      const isApi = log.source === 'api';
-      const message = log.message;
-      const logLevel = log.level || 'info';
+      const displayMessage = isApp && log.appName ? `[app] ${log.message}` : log.message;
+      const color = getLogColor(log, darkMode);
 
-      const isSuccess = message.includes('SUCCESS') || message.includes('✓');
-      const isError =
-        logLevel === 'error' ||
-        message.includes('FAILED') ||
-        message.includes('ERROR') ||
-        message.includes('❌') ||
-        message.includes('[ERROR]');
-      const isWarning =
-        logLevel === 'warning' || message.includes('WARNING') || message.includes('[WARNING]');
-      const isCommand = message.includes('→') || message.includes('📥');
+      return { displayMessage, color };
+    }, [log, darkMode]);
 
-      const displayMessage = isApp && log.appName ? `[app] ${message}` : message;
-
-      return {
-        isFrontend,
-        isApp,
-        isDaemonRemote,
-        isApi,
-        displayMessage,
-        isSuccess,
-        isError,
-        isWarning,
-        isCommand,
-      };
-    }, [log]);
-
-    // Early return for null log
     if (!log || !memoizedValues) return null;
 
-    // Simple style: message with colored dot
+    const { displayMessage, color } = memoizedValues;
+
+    // Simple style (inline in small console, minimal)
     if (simpleStyle) {
       return (
         <Box
@@ -105,74 +102,106 @@ export const LogItem = React.memo(
       );
     }
 
-    // Destructure memoized values for default style
-    const {
-      isFrontend,
-      isApp,
-      isDaemonRemote,
-      isApi,
-      displayMessage,
-      isSuccess,
-      isError,
-      isWarning,
-      isCommand,
-    } = memoizedValues;
+    // Simple log mode - cleaner rendering with colored dot + message
+    if (logMode === 'simple') {
+      return (
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'flex-start',
+            gap: 1,
+            marginBottom: index < totalCount - 1 ? `${itemSpacing}px` : 0,
+          }}
+        >
+          <Box
+            sx={{
+              width: 5,
+              height: 5,
+              borderRadius: '50%',
+              bgcolor: color,
+              mt: '5px',
+              flexShrink: 0,
+            }}
+          />
+          <Typography
+            sx={{
+              fontSize,
+              fontFamily: 'inherit',
+              color: darkMode ? '#d1d5db' : '#555',
+              lineHeight: 1.6,
+              flex: 1,
+              ...WRAP_STYLES,
+              ...TEXT_SELECT_STYLES,
+            }}
+          >
+            {displayMessage}
+          </Typography>
+          {showTimestamp && (
+            <Typography
+              sx={{
+                fontSize: fontSize - 1,
+                color: darkMode ? 'rgba(255, 255, 255, 0.35)' : 'rgba(0, 0, 0, 0.35)',
+                fontFamily: 'inherit',
+                lineHeight: 1.6,
+                flexShrink: 0,
+                whiteSpace: 'nowrap',
+                ...TEXT_SELECT_STYLES,
+              }}
+            >
+              {log.timestamp}
+            </Typography>
+          )}
+        </Box>
+      );
+    }
 
-    // Default style: full formatting with colors and timestamps
+    // Dev mode - full formatting with category badge, colored message, timestamp
+    const catMeta = CATEGORY_META[log.category] || { label: log.category || '?', color: '#888' };
+
     return (
       <Box
         sx={{
           display: 'flex',
-          flexDirection: showTimestamp ? 'row' : 'column',
           alignItems: 'flex-start',
-          gap: 1,
+          gap: 0.75,
           width: '100%',
           minWidth: 0,
           marginBottom: index < totalCount - 1 ? `${itemSpacing}px` : 0,
         }}
       >
+        {/* Category badge */}
+        <Box
+          sx={{
+            fontSize: 8,
+            fontWeight: 700,
+            fontFamily: 'inherit',
+            px: 0.6,
+            py: 0.1,
+            borderRadius: '3px',
+            bgcolor: `${catMeta.color}18`,
+            color: catMeta.color,
+            border: `1px solid ${catMeta.color}30`,
+            whiteSpace: 'nowrap',
+            flexShrink: 0,
+            lineHeight: 1.6,
+            mt: '1px',
+            textTransform: 'uppercase',
+            letterSpacing: '0.3px',
+            minWidth: 40,
+            textAlign: 'center',
+          }}
+        >
+          {catMeta.label}
+        </Box>
+
+        {/* Message */}
         <Typography
           sx={{
             fontSize,
-            color: darkMode
-              ? isError
-                ? '#ff5555'
-                : isWarning
-                  ? '#fbbf24'
-                  : isSuccess
-                    ? '#55ff55'
-                    : isCommand
-                      ? '#ff9500'
-                      : isApi
-                        ? '#34d399'
-                        : isDaemonRemote
-                          ? '#60a5fa'
-                          : isFrontend
-                            ? '#5db3ff'
-                            : isApp
-                              ? '#a78bfa'
-                              : '#f0f0f0'
-              : isError
-                ? '#cc0000'
-                : isWarning
-                  ? '#d97706'
-                  : isSuccess
-                    ? '#00aa00'
-                    : isCommand
-                      ? '#ff6600'
-                      : isApi
-                        ? '#059669'
-                        : isDaemonRemote
-                          ? '#2563eb'
-                          : isFrontend
-                            ? '#0055cc'
-                            : isApp
-                              ? '#7c3aed'
-                              : '#1a1a1a',
+            color,
             fontFamily: 'inherit',
             lineHeight: compact ? 1.4 : 1.6,
-            fontWeight: isFrontend ? 500 : 400,
-            opacity: 1,
+            fontWeight: 400,
             flex: 1,
             ...WRAP_STYLES,
             ...TEXT_SELECT_STYLES,
@@ -180,6 +209,8 @@ export const LogItem = React.memo(
         >
           {displayMessage}
         </Typography>
+
+        {/* Timestamp */}
         {showTimestamp && (
           <Typography
             sx={{
@@ -187,8 +218,6 @@ export const LogItem = React.memo(
               color: darkMode ? 'rgba(255, 255, 255, 0.5)' : 'rgba(0, 0, 0, 0.5)',
               fontFamily: 'inherit',
               lineHeight: compact ? 1.4 : 1.6,
-              fontWeight: 400,
-              opacity: 0.8,
               flexShrink: 0,
               whiteSpace: 'nowrap',
               ...TEXT_SELECT_STYLES,

--- a/src/components/LogConsole/index.jsx
+++ b/src/components/LogConsole/index.jsx
@@ -1,7 +1,9 @@
-import React, { useMemo, useRef } from 'react';
-import { Box, Typography, IconButton, Tooltip } from '@mui/material';
+import React, { useMemo, useRef, useCallback } from 'react';
+import { Box, Typography, IconButton, Tooltip, InputBase } from '@mui/material';
 import OpenInFullIcon from '@mui/icons-material/OpenInFull';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import SearchIcon from '@mui/icons-material/Search';
+import ClearIcon from '@mui/icons-material/Clear';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import useAppStore from '../../store/useAppStore';
 import { FONT_SIZES, PADDING, EMPTY_ARRAY, TEXT_SELECT_STYLES } from './constants';
@@ -9,25 +11,84 @@ import { useLogProcessing } from './useLogProcessing';
 import { LogItem } from './LogItem';
 import { useLogConsoleHeight, useFixedItemHeight } from './useLogConsoleHeight';
 import { useVirtualizerScroll } from './useVirtualizerScroll';
+import { CATEGORY_META } from '../../utils/logging/constants';
+
+function FilterChip({ label, color, active, onClick, darkMode }) {
+  return (
+    <Box
+      onClick={onClick}
+      sx={{
+        fontSize: 9,
+        fontWeight: 600,
+        px: 0.75,
+        py: 0.15,
+        borderRadius: '4px',
+        cursor: 'pointer',
+        transition: 'all 0.15s',
+        userSelect: 'none',
+        color: active ? color : darkMode ? '#555' : '#bbb',
+        bgcolor: active ? `${color}18` : 'transparent',
+        border: `1px solid ${active ? `${color}40` : darkMode ? '#333' : '#ddd'}`,
+        '&:hover': {
+          bgcolor: `${color}15`,
+          borderColor: `${color}30`,
+        },
+      }}
+    >
+      {label}
+    </Box>
+  );
+}
+
+function ModeToggle({ mode, onChange, darkMode }) {
+  return (
+    <Box
+      sx={{
+        display: 'inline-flex',
+        borderRadius: '4px',
+        overflow: 'hidden',
+        border: `1px solid ${darkMode ? '#333' : '#ddd'}`,
+      }}
+    >
+      {[
+        { value: 'simple', label: 'Simple' },
+        { value: 'dev', label: 'Dev' },
+      ].map(opt => (
+        <Box
+          key={opt.value}
+          onClick={() => onChange(opt.value)}
+          sx={{
+            fontSize: 9,
+            fontWeight: 600,
+            px: 0.75,
+            py: 0.15,
+            cursor: 'pointer',
+            userSelect: 'none',
+            transition: 'all 0.15s',
+            color: mode === opt.value ? (darkMode ? '#fff' : '#111') : darkMode ? '#555' : '#bbb',
+            bgcolor:
+              mode === opt.value
+                ? darkMode
+                  ? 'rgba(255,255,255,0.08)'
+                  : 'rgba(0,0,0,0.05)'
+                : 'transparent',
+            '&:hover': { bgcolor: darkMode ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.03)' },
+          }}
+        >
+          {opt.label}
+        </Box>
+      ))}
+    </Box>
+  );
+}
 
 /**
  * LogConsole Component
  *
- * A virtualized log console component that displays logs from multiple sources (daemon, frontend, apps).
- * Supports auto-scrolling, filtering, and multiple display modes.
- *
- * @param {Object} props
- * @param {Array} props.logs - Array of daemon logs
- * @param {boolean} [props.darkMode=false] - Dark mode enabled
- * @param {boolean} [props.includeStoreLogs=true] - Include logs from Zustand store
- * @param {Object} [props.sx={}] - Additional MUI sx styles
- * @param {number|string|null} [props.maxHeight=null] - Maximum height in pixels
- * @param {number|string|null} [props.height=null] - Fixed height in pixels or '100%' or 'auto'
- * @param {number|null} [props.lines=null] - Number of lines to display (calculates height automatically)
- * @param {boolean} [props.showTimestamp=true] - Show timestamp for each log
- * @param {boolean} [props.compact=false] - Compact mode (smaller font and spacing)
- * @param {boolean} [props.simpleStyle=false] - Simple style mode (minimal formatting)
- * @param {string} [props.emptyMessage='No logs'] - Message to display when no logs
+ * Two layouts:
+ *   - Inline (default): compact header with "Logs" + expand/copy
+ *   - Full-size (fullSize=true): toggle Simple/Dev, and in Dev mode
+ *     category filters + search appear on the same line
  */
 function LogConsole({
   logs,
@@ -43,29 +104,45 @@ function LogConsole({
   simpleStyle = false,
   emptyMessage = 'No logs',
   onExpand = null,
+  fullSize = false,
 }) {
-  // Select logs from store - will trigger re-render when logs change
   const frontendLogs = useAppStore(state => (includeStoreLogs ? state.frontendLogs : EMPTY_ARRAY));
   const appLogs = useAppStore(state => (includeStoreLogs ? state.appLogs : EMPTY_ARRAY));
 
-  // Process and normalize all logs (remoteLogs bypass shouldFilterLog via appLogs path)
+  const logMode = useAppStore(s => s.logMode);
+  const setLogMode = useAppStore(s => s.setLogMode);
+  const logSearch = useAppStore(s => s.logSearch);
+  const setLogSearch = useAppStore(s => s.setLogSearch);
+  const categoryFilters = useAppStore(s => s.logCategoryFilters);
+  const toggleCategory = useAppStore(s => s.toggleLogCategory);
+
+  const effectiveMode = simpleStyle ? 'simple' : logMode;
+  const isDevMode = effectiveMode === 'dev';
+
+  const mergedAppLogs = useMemo(
+    () => (remoteLogs.length > 0 ? [...appLogs, ...remoteLogs] : appLogs),
+    [appLogs, remoteLogs]
+  );
+
   const normalizedLogs = useLogProcessing(
     logs,
     frontendLogs,
-    [...appLogs, ...remoteLogs],
+    mergedAppLogs,
     includeStoreLogs,
-    simpleStyle
+    simpleStyle,
+    {
+      mode: effectiveMode,
+      categoryFilters: isDevMode ? categoryFilters : null,
+      search: isDevMode ? logSearch : '',
+    }
   );
 
-  // Calculate heights
   const fontSize = compact ? FONT_SIZES.COMPACT : FONT_SIZES.NORMAL;
   const fixedItemHeight = useFixedItemHeight(compact);
   const containerHeight = useLogConsoleHeight({ lines, height, maxHeight, compact, simpleStyle });
 
-  // Parent ref for virtualizer
   const parentRef = useRef(null);
 
-  // Create virtualizer instance - NO paddingEnd, spacing handled by marginBottom on items
   const virtualizer = useVirtualizer({
     count: normalizedLogs.length,
     getScrollElement: () => parentRef.current,
@@ -73,56 +150,40 @@ function LogConsole({
     overscan: 5,
   });
 
-  // Use auto-scroll hook
   const { handleScroll } = useVirtualizerScroll({
     virtualizer,
     totalCount: normalizedLogs.length,
     enabled: true,
     compact,
     simpleStyle,
-    scrollElementRef: parentRef, // Pass direct ref as fallback
+    scrollElementRef: parentRef,
   });
 
-  // Copy all logs to clipboard
-  const handleCopyLogs = async () => {
+  const handleCopyLogs = useCallback(async () => {
+    const text = normalizedLogs
+      .map(log =>
+        showTimestamp && log.timestamp ? `[${log.timestamp}] ${log.message}` : log.message
+      )
+      .join('\n');
     try {
-      const logsText = normalizedLogs
-        .map(log => {
-          if (showTimestamp && log.timestamp) {
-            return `[${log.timestamp}] ${log.message}`;
-          }
-          return log.message;
-        })
-        .join('\n');
-
-      await navigator.clipboard.writeText(logsText);
+      await navigator.clipboard.writeText(text);
     } catch {
-      // Fallback for older browsers
-      const textArea = document.createElement('textarea');
-      textArea.value = normalizedLogs
-        .map(log => {
-          if (showTimestamp && log.timestamp) {
-            return `[${log.timestamp}] ${log.message}`;
-          }
-          return log.message;
-        })
-        .join('\n');
-      document.body.appendChild(textArea);
-      textArea.select();
+      const ta = document.createElement('textarea');
+      ta.value = text;
+      document.body.appendChild(ta);
+      ta.select();
       try {
         document.execCommand('copy');
       } catch {
-        // Silently fail
+        /* noop */
       }
-      document.body.removeChild(textArea);
+      document.body.removeChild(ta);
     }
-  };
+  }, [normalizedLogs, showTimestamp]);
 
-  // Memoize sx styles to prevent recalculation on every render
   const boxSx = useMemo(
     () => ({
       width: '100%',
-      // If containerHeight is null (height='100%'), use '100%', otherwise use calculated height
       height:
         containerHeight === null ? '100%' : height === 'auto' ? 'auto' : `${containerHeight}px`,
       maxHeight: maxHeight || undefined,
@@ -134,9 +195,9 @@ function LogConsole({
           ? '1px solid rgba(255, 255, 255, 0.15)'
           : '1px solid rgba(0, 0, 0, 0.15)',
       overflow: 'hidden',
-      overflowY: normalizedLogs.length === 0 ? 'hidden' : 'auto', // No scroll when empty
-      overflowX: 'hidden', // No horizontal scroll - use ellipsis instead
-      position: 'relative', // For absolute positioning of empty state
+      overflowY: normalizedLogs.length === 0 ? 'hidden' : 'auto',
+      overflowX: 'hidden',
+      position: 'relative',
       display: 'flex',
       flexDirection: 'column',
       fontFamily: simpleStyle ? 'monospace' : 'SF Mono, Monaco, Menlo, monospace',
@@ -146,11 +207,11 @@ function LogConsole({
       '&::-webkit-scrollbar': { width: 6 },
       '&::-webkit-scrollbar-track': { background: 'transparent' },
       '&::-webkit-scrollbar-thumb': {
-        background: darkMode ? 'rgba(255, 255, 255, 0.15)' : 'rgba(0, 0, 0, 0.15)',
+        background: darkMode ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.15)',
         borderRadius: 3,
       },
       '&:hover::-webkit-scrollbar-thumb': {
-        background: darkMode ? 'rgba(255, 255, 255, 0.25)' : 'rgba(0, 0, 0, 0.25)',
+        background: darkMode ? 'rgba(255,255,255,0.25)' : 'rgba(0,0,0,0.25)',
       },
       ...sx,
     }),
@@ -167,77 +228,193 @@ function LogConsole({
     ]
   );
 
+  // Inline (small) header
+  const renderInlineHeader = () => (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        px: 1,
+        py: 0.25,
+        borderBottom: `1px solid ${darkMode ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)'}`,
+        flexShrink: 0,
+        minHeight: 24,
+      }}
+    >
+      <Typography
+        sx={{
+          fontSize: 9,
+          fontWeight: 600,
+          color: darkMode ? '#666' : '#aaa',
+          textTransform: 'uppercase',
+          letterSpacing: '0.5px',
+        }}
+      >
+        Logs
+      </Typography>
+      <Box
+        className="log-console-actions"
+        sx={{ display: 'flex', gap: 0.25, opacity: 0, transition: 'opacity 0.15s' }}
+      >
+        {onExpand && (
+          <IconButton
+            onClick={onExpand}
+            sx={{
+              width: 20,
+              height: 20,
+              padding: 0.25,
+              '&:hover': { bgcolor: darkMode ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.06)' },
+            }}
+          >
+            <OpenInFullIcon sx={{ fontSize: 10, color: darkMode ? '#666' : '#aaa' }} />
+          </IconButton>
+        )}
+        <IconButton
+          onClick={handleCopyLogs}
+          sx={{
+            width: 20,
+            height: 20,
+            padding: 0.25,
+            '&:hover': { bgcolor: darkMode ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.06)' },
+          }}
+        >
+          <ContentCopyIcon sx={{ fontSize: 10, color: darkMode ? '#666' : '#aaa' }} />
+        </IconButton>
+      </Box>
+    </Box>
+  );
+
+  // Full-size header: [Logs] [Simple|Dev]  ...dev filters...  [Search] [Copy]
+  const renderFullSizeHeader = () => (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 0.75,
+        px: 1.5,
+        py: 0.75,
+        borderBottom: `1px solid ${darkMode ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'}`,
+        flexShrink: 0,
+      }}
+    >
+      <Typography
+        sx={{
+          fontSize: 10,
+          fontWeight: 600,
+          color: darkMode ? '#666' : '#aaa',
+          textTransform: 'uppercase',
+          letterSpacing: '0.5px',
+        }}
+      >
+        Logs
+      </Typography>
+
+      <ModeToggle mode={logMode} onChange={setLogMode} darkMode={darkMode} />
+
+      {/* Dev-only: category filters + search */}
+      {isDevMode && (
+        <>
+          {Object.entries(CATEGORY_META).map(([key, meta]) => (
+            <FilterChip
+              key={key}
+              label={meta.label}
+              color={meta.color}
+              active={categoryFilters.includes(key)}
+              onClick={() => toggleCategory(key)}
+              darkMode={darkMode}
+            />
+          ))}
+
+          {/* Search */}
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 0.5,
+              bgcolor: darkMode ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.03)',
+              borderRadius: '5px',
+              px: 0.75,
+              py: 0.2,
+              border: `1px solid ${darkMode ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'}`,
+              minWidth: 140,
+              maxWidth: 220,
+            }}
+          >
+            <SearchIcon sx={{ fontSize: 12, color: darkMode ? '#555' : '#aaa' }} />
+            <InputBase
+              value={logSearch}
+              onChange={e => setLogSearch(e.target.value)}
+              placeholder="Search..."
+              sx={{
+                fontSize: 10,
+                color: darkMode ? '#ccc' : '#333',
+                fontFamily: 'SF Mono, Monaco, Menlo, monospace',
+                '& input': { p: 0 },
+                '& input::placeholder': { color: darkMode ? '#555' : '#aaa', opacity: 1 },
+                flex: 1,
+              }}
+            />
+            {logSearch && (
+              <ClearIcon
+                onClick={() => setLogSearch('')}
+                sx={{
+                  fontSize: 11,
+                  cursor: 'pointer',
+                  color: darkMode ? '#555' : '#aaa',
+                  '&:hover': { color: darkMode ? '#aaa' : '#555' },
+                }}
+              />
+            )}
+          </Box>
+        </>
+      )}
+
+      <Box sx={{ flex: 1 }} />
+
+      {/* Copy */}
+      <Tooltip title="Copy all logs" arrow placement="top">
+        <IconButton
+          onClick={handleCopyLogs}
+          sx={{
+            width: 24,
+            height: 24,
+            padding: 0.5,
+            bgcolor: darkMode ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.03)',
+            '&:hover': { bgcolor: darkMode ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.07)' },
+          }}
+        >
+          <ContentCopyIcon sx={{ fontSize: 12, color: darkMode ? '#666' : '#aaa' }} />
+        </IconButton>
+      </Tooltip>
+    </Box>
+  );
+
   return (
     <Box
       className="log-console"
       sx={{
         ...boxSx,
         position: 'relative',
-        '&:hover .copy-logs-button': {
-          opacity: 1,
-        },
+        '&:hover .log-console-actions': { opacity: 1 },
       }}
     >
-      {/* Expand or Copy button - hidden by default, visible on hover */}
-      {normalizedLogs.length > 0 && (
-        <Tooltip title={onExpand ? 'Expand logs' : 'Copy all logs'} arrow placement="left">
-          <IconButton
-            className="copy-logs-button"
-            onClick={onExpand ?? handleCopyLogs}
-            sx={{
-              position: 'absolute',
-              top: 8,
-              right: 8,
-              zIndex: 10,
-              opacity: 0,
-              transition: 'opacity 0.2s ease-in-out',
-              bgcolor: darkMode ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.05)',
-              '&:hover': {
-                bgcolor: darkMode ? 'rgba(255, 255, 255, 0.2)' : 'rgba(0, 0, 0, 0.1)',
-                opacity: 1,
-              },
-              width: 28,
-              height: 28,
-              padding: 0.5,
-            }}
-          >
-            {onExpand ? (
-              <OpenInFullIcon
-                sx={{
-                  fontSize: 13,
-                  color: darkMode ? 'rgba(255, 255, 255, 0.7)' : 'rgba(0, 0, 0, 0.6)',
-                }}
-              />
-            ) : (
-              <ContentCopyIcon
-                sx={{
-                  fontSize: 14,
-                  color: darkMode ? 'rgba(255, 255, 255, 0.7)' : 'rgba(0, 0, 0, 0.6)',
-                }}
-              />
-            )}
-          </IconButton>
-        </Tooltip>
-      )}
+      {!simpleStyle && (fullSize ? renderFullSizeHeader() : renderInlineHeader())}
+
       {normalizedLogs.length === 0 ? (
         <Box
           sx={{
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
-            width: '100%',
-            height: '100%',
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
+            flex: 1,
+            minHeight: 40,
           }}
         >
           <Typography
             sx={{
               fontSize: simpleStyle ? 11 : fontSize,
-              color: darkMode ? (simpleStyle ? '#888' : '#666') : simpleStyle ? '#999' : '#999',
+              color: darkMode ? '#666' : '#999',
               fontFamily: 'inherit',
               textAlign: 'center',
               fontStyle: simpleStyle ? 'italic' : 'normal',
@@ -252,7 +429,7 @@ function LogConsole({
           ref={parentRef}
           onScroll={handleScroll}
           sx={{
-            height: '100%',
+            flex: 1,
             width: '100%',
             overflow: 'auto',
             overflowX: 'hidden',
@@ -269,33 +446,21 @@ function LogConsole({
             paddingBottom: simpleStyle
               ? `${PADDING.SIMPLE}px`
               : `${PADDING[compact ? 'COMPACT' : 'NORMAL'].vertical}px`,
-            // Custom scrollbar styling
-            '&::-webkit-scrollbar': {
-              width: 6,
-            },
-            '&::-webkit-scrollbar-track': {
-              background: 'transparent',
-            },
+            '&::-webkit-scrollbar': { width: 6 },
+            '&::-webkit-scrollbar-track': { background: 'transparent' },
             '&::-webkit-scrollbar-thumb': {
-              background: darkMode ? 'rgba(255, 255, 255, 0.15)' : 'rgba(0, 0, 0, 0.15)',
+              background: darkMode ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.15)',
               borderRadius: 3,
-              '&:hover': {
-                background: darkMode ? 'rgba(255, 255, 255, 0.25)' : 'rgba(0, 0, 0, 0.25)',
-              },
+              '&:hover': { background: darkMode ? 'rgba(255,255,255,0.25)' : 'rgba(0,0,0,0.25)' },
             },
           }}
         >
           <Box
-            sx={{
-              height: `${virtualizer.getTotalSize()}px`,
-              width: '100%',
-              position: 'relative',
-            }}
+            sx={{ height: `${virtualizer.getTotalSize()}px`, width: '100%', position: 'relative' }}
           >
             {virtualizer.getVirtualItems().map(virtualItem => {
               const log = normalizedLogs[virtualItem.index];
               if (!log) return null;
-
               return (
                 <Box
                   key={virtualItem.key}
@@ -318,6 +483,7 @@ function LogConsole({
                     compact={compact}
                     showTimestamp={showTimestamp}
                     simpleStyle={simpleStyle}
+                    logMode={simpleStyle ? 'simple' : logMode}
                   />
                 </Box>
               );

--- a/src/components/LogConsole/useLogProcessing.js
+++ b/src/components/LogConsole/useLogProcessing.js
@@ -4,172 +4,224 @@ import { normalizeLog, formatTimestamp } from './utils';
 import { shouldFilterLog } from '../../utils/logging/logFilters';
 
 /**
- * Hook to process and normalize all logs
- *
- * Filtering is handled by the centralized logFilters utility.
+ * Allowlist for simple mode - user-facing events only.
+ * Errors always pass. Everything else must match a pattern.
  */
-export const useLogProcessing = (logs, frontendLogs, appLogs, includeStoreLogs, simpleStyle) => {
+const SIMPLE_ALLOWLIST = [
+  /^connected to/i,
+  /disconnected/i,
+  /connection lost/i,
+  /^enable motors/i,
+  /^disable motors/i,
+  /motors? (enabled|disabled|stiff|compliant)/i,
+  /^(installing|uninstalling|starting|stopping|updating)\s/i,
+  /app.*completed/i,
+  /app.*stopped unexpectedly/i,
+  /set (speaker |microphone )?volume/i,
+  /^(mute|unmute)\s/i,
+  /^wake up/i,
+  /^goto sleep/i,
+  /^sleep animation/i,
+  /^playing (emotion|dance|action):/i,
+  /^manual control (started|ended)/i,
+  /cache cleared/i,
+  /apps? reset/i,
+  /hf (oauth|logout)/i,
+  /^daemon (started|stopped|updated|restarted)/i,
+  /^(update completed|update likely completed)/i,
+  /^simulation mode/i,
+];
+
+const isSimpleModeVisible = log => {
+  if (log.level === 'error') return true;
+  const msg = log.message || '';
+  return SIMPLE_ALLOWLIST.some(p => p.test(msg));
+};
+
+const inferCategory = log => {
+  if (log.category === 'daemon' || log.category === 'app' || log.category === 'frontend') {
+    return log.category;
+  }
+  if (log.source === 'app') return 'app';
+  if (log.source === 'frontend' || log.source === 'api') return 'frontend';
+  if (log.source === 'daemon') return 'daemon';
+  return 'frontend';
+};
+
+function safeNormalize(log, fallbackSource, fallbackCategory) {
+  try {
+    const normalized = normalizeLog(log);
+    return {
+      ...normalized,
+      category: log.category || inferCategory(normalized),
+    };
+  } catch (error) {
+    return {
+      message: `[Normalize error: ${error.message}]`,
+      source: fallbackSource,
+      category: fallbackCategory,
+      timestamp: formatTimestamp(Date.now()),
+      timestampNumeric: Date.now(),
+      level: 'error',
+    };
+  }
+}
+
+/**
+ * Merge pre-sorted arrays by timestampNumeric (avoids full sort).
+ * Each input array is already in chronological order.
+ */
+function mergeByTimestamp(daemonLogs, frontendLogs, appLogs) {
+  const result = [];
+  let di = 0,
+    fi = 0,
+    ai = 0;
+  const dLen = daemonLogs.length,
+    fLen = frontendLogs.length,
+    aLen = appLogs.length;
+
+  while (di < dLen || fi < fLen || ai < aLen) {
+    const dTs = di < dLen ? daemonLogs[di].timestampNumeric || 0 : Infinity;
+    const fTs = fi < fLen ? frontendLogs[fi].timestampNumeric || 0 : Infinity;
+    const aTs = ai < aLen ? appLogs[ai].timestampNumeric || 0 : Infinity;
+
+    if (dTs <= fTs && dTs <= aTs) {
+      result.push(daemonLogs[di++]);
+    } else if (fTs <= aTs) {
+      result.push(frontendLogs[fi++]);
+    } else {
+      result.push(appLogs[ai++]);
+    }
+  }
+  return result;
+}
+
+/**
+ * Hook to process and normalize all logs.
+ * Supports simple + dev modes with category, level, and search filtering.
+ *
+ * Performance: daemon/frontend/app logs arrive pre-sorted so we merge
+ * instead of concat+sort. Deduplication uses a single pass.
+ */
+export const useLogProcessing = (
+  logs,
+  frontendLogs,
+  appLogs,
+  includeStoreLogs,
+  simpleStyle,
+  { mode = 'simple', categoryFilters = null, search = '' } = {}
+) => {
   return useMemo(() => {
-    // Validate inputs
     const safeLogs = Array.isArray(logs) ? logs : [];
     const safeFrontendLogs = Array.isArray(frontendLogs) ? frontendLogs : [];
     const safeAppLogs = Array.isArray(appLogs) ? appLogs : [];
 
+    // simpleStyle = legacy inline overlay, minimal processing
     if (simpleStyle) {
       return safeLogs
         .map(log => {
           try {
             return normalizeLog(log);
-          } catch (error) {
+          } catch {
             return null;
           }
         })
         .filter(Boolean);
     }
 
-    // Filter out confusing logs using centralized filter
-    const filteredLogs = safeLogs.filter(log => {
-      try {
-        const message =
-          typeof log === 'string'
-            ? log
-            : log && typeof log === 'object' && log.message != null
-              ? String(log.message)
-              : String(log || '');
-        return !shouldFilterLog(message);
-      } catch (error) {
-        return false;
+    // --- Normalize each source independently (preserves insertion order) ---
+
+    const isDev = mode === 'dev';
+
+    const normalizedDaemon = [];
+    const daemonDedup = new Map();
+    for (let i = 0; i < safeLogs.length; i++) {
+      const raw = safeLogs[i];
+
+      // In simple mode, pre-filter noisy logs before normalizing (cheaper)
+      if (!isDev) {
+        try {
+          const msg =
+            typeof raw === 'string'
+              ? raw
+              : raw && typeof raw === 'object' && raw.message != null
+                ? String(raw.message)
+                : String(raw || '');
+          if (shouldFilterLog(msg)) continue;
+        } catch {
+          continue;
+        }
       }
-    });
 
-    // Combine all logs with their original order preserved
-    const allLogs = [
-      ...filteredLogs.map((log, idx) => {
-        try {
-          return { ...normalizeLog(log), order: idx };
-        } catch (error) {
-          return {
-            message: `[Error normalizing log: ${error.message}]`,
-            source: 'daemon',
-            timestamp: formatTimestamp(Date.now()),
-            timestampNumeric: Date.now(),
-            level: 'error',
-            order: idx,
-          };
-        }
-      }),
-      ...safeFrontendLogs.map((log, idx) => {
-        try {
-          return { ...normalizeLog(log), order: 1000000 + idx, level: log.level || 'info' };
-        } catch (error) {
-          return {
-            message: `[Error normalizing frontend log: ${error.message}]`,
-            source: 'frontend',
-            timestamp: formatTimestamp(Date.now()),
-            timestampNumeric: Date.now(),
-            level: 'error',
-            order: 1000000 + idx,
-          };
-        }
-      }),
-      ...safeAppLogs.map((log, idx) => {
-        try {
-          return { ...normalizeLog(log), order: 2000000 + idx };
-        } catch (error) {
-          return {
-            message: `[Error normalizing app log: ${error.message}]`,
-            source: 'app',
-            timestamp: formatTimestamp(Date.now()),
-            timestampNumeric: Date.now(),
-            level: 'error',
-            order: 2000000 + idx,
-          };
-        }
-      }),
-    ];
+      const log = safeNormalize(raw, 'daemon', 'daemon');
 
-    // Deduplication
-    const seen = new Set();
-    const daemonLogsSeen = new Map();
-    const uniqueLogs = allLogs.filter((log, index) => {
-      if (log.source === 'daemon') {
-        const messageKey = log.message;
-        const timestamp = log.timestampNumeric > 0 ? log.timestampNumeric : index;
+      // Dedup: skip same message within 1s
+      const key = log.message;
+      const prevTs = daemonDedup.get(key);
+      if (prevTs && log.timestampNumeric > 0 && log.timestampNumeric - prevTs < 1000) continue;
+      daemonDedup.set(key, log.timestampNumeric || 0);
 
-        if (log.timestampNumeric > 0) {
-          const lastSeen = daemonLogsSeen.get(messageKey);
-          if (
-            lastSeen &&
-            typeof lastSeen === 'number' &&
-            lastSeen > 1000000000000 &&
-            timestamp - lastSeen < 1000
-          ) {
-            return false;
-          }
+      normalizedDaemon.push(log);
+    }
+
+    const normalizedFrontend = [];
+    const frontendSeen = new Set();
+    for (let i = 0; i < safeFrontendLogs.length; i++) {
+      const raw = safeFrontendLogs[i];
+      const log = safeNormalize(raw, 'frontend', 'frontend');
+      log.level = raw.level || log.level || 'info';
+
+      const dedupKey = `${log.timestampNumeric || ''}|${log.source}|${log.message}`;
+      if (frontendSeen.has(dedupKey)) continue;
+      frontendSeen.add(dedupKey);
+
+      normalizedFrontend.push(log);
+    }
+
+    const normalizedApp = [];
+    for (let i = 0; i < safeAppLogs.length; i++) {
+      const raw = safeAppLogs[i];
+      const log = safeNormalize(raw, 'app', 'app');
+      normalizedApp.push(log);
+    }
+
+    // --- Merge (already sorted per-source) ---
+    const merged = mergeByTimestamp(normalizedDaemon, normalizedFrontend, normalizedApp);
+
+    // --- Collapse repeated daemon errors within 10s ---
+    const errorSeen = new Map();
+    let filtered = merged;
+    if (merged.length > 0) {
+      filtered = merged.filter(log => {
+        if (log.source === 'daemon' && log.level === 'error') {
+          const ts = log.timestampNumeric || 0;
+          const prev = errorSeen.get(log.message);
+          if (prev && ts - prev < 10000) return false;
+          errorSeen.set(log.message, ts);
         }
-
-        daemonLogsSeen.set(messageKey, timestamp);
         return true;
+      });
+    }
+
+    // --- Mode-specific filtering ---
+    if (mode === 'simple') {
+      filtered = filtered.filter(isSimpleModeVisible);
+    } else {
+      if (categoryFilters && categoryFilters.length > 0) {
+        filtered = filtered.filter(log => categoryFilters.includes(log.category));
       }
-
-      const tsKey = log.timestampNumeric || log.timestamp || '';
-      const key = `${tsKey}|${log.source}|${log.message}|${log.appName || ''}`;
-
-      if (seen.has(key)) {
-        return false;
+      if (search) {
+        const lower = search.toLowerCase();
+        filtered = filtered.filter(log => (log.message || '').toLowerCase().includes(lower));
       }
-      seen.add(key);
-      return true;
-    });
+    }
 
-    // Sort by timestamp
-    const sortedLogs = uniqueLogs.sort((a, b) => {
-      const aOrder = a.order || 0;
-      const bOrder = b.order || 0;
+    // --- Cap display count ---
+    const maxDisplay = DAEMON_CONFIG?.LOGS?.MAX_DISPLAY || 1000;
+    if (includeStoreLogs && filtered.length > maxDisplay) {
+      return filtered.slice(-maxDisplay);
+    }
 
-      if (Math.floor(aOrder / 1000000) !== Math.floor(bOrder / 1000000)) {
-        const aHasTimestamp = a.timestampNumeric && a.timestampNumeric > 0;
-        const bHasTimestamp = b.timestampNumeric && b.timestampNumeric > 0;
-        if (aHasTimestamp && bHasTimestamp) {
-          return a.timestampNumeric - b.timestampNumeric;
-        }
-        return aOrder - bOrder;
-      }
-
-      const aHasTimestamp = a.timestampNumeric && a.timestampNumeric > 0;
-      const bHasTimestamp = b.timestampNumeric && b.timestampNumeric > 0;
-      if (aHasTimestamp && bHasTimestamp) {
-        return a.timestampNumeric - b.timestampNumeric;
-      }
-
-      return aOrder - bOrder;
-    });
-
-    // Filter duplicate errors
-    const errorCounts = new Map();
-    const filteredSortedLogs = sortedLogs.filter((log, index) => {
-      if (log.source === 'daemon' && log.level === 'error') {
-        const errorKey = log.message;
-        const now = log.timestampNumeric || Date.now();
-
-        const lastSeen = errorCounts.get(errorKey);
-
-        if (lastSeen && now - lastSeen < 10000) {
-          return false;
-        }
-
-        errorCounts.set(errorKey, now);
-      }
-
-      return true;
-    });
-
-    // Limit to MAX_DISPLAY
-    const finalLogs =
-      includeStoreLogs && filteredSortedLogs.length > DAEMON_CONFIG.LOGS.MAX_DISPLAY
-        ? filteredSortedLogs.slice(-DAEMON_CONFIG.LOGS.MAX_DISPLAY)
-        : filteredSortedLogs;
-
-    return finalLogs;
-  }, [logs, frontendLogs, appLogs, includeStoreLogs, simpleStyle]);
+    return filtered;
+  }, [logs, frontendLogs, appLogs, includeStoreLogs, simpleStyle, mode, categoryFilters, search]);
 };

--- a/src/components/LogConsole/utils.js
+++ b/src/components/LogConsole/utils.js
@@ -1,132 +1,100 @@
+// Shared formatter - created once, reused for every timestamp
+let _formatter;
+try {
+  _formatter = new Intl.DateTimeFormat('en-GB', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+} catch {
+  _formatter = null;
+}
+
 /**
- * Format timestamp to HH:mm:ss string
- * Robust version with error handling
+ * Format timestamp to HH:mm:ss string.
+ * Uses a cached Intl.DateTimeFormat for performance.
  */
 export const formatTimestamp = timestamp => {
-  try {
-    if (typeof timestamp === 'string' && /^\d{2}:\d{2}:\d{2}$/.test(timestamp)) {
-      return timestamp;
-    }
-    if (typeof timestamp === 'number' && !isNaN(timestamp) && isFinite(timestamp)) {
-      // Validate timestamp is reasonable (not too far in past/future)
-      const now = Date.now();
-      const maxDiff = 365 * 24 * 60 * 60 * 1000; // 1 year
-      if (Math.abs(timestamp - now) > maxDiff) {
-        // Invalid timestamp, use current time
-        timestamp = now;
-      }
-
-      try {
-        return new Date(timestamp).toLocaleTimeString('en-GB', {
-          hour: '2-digit',
-          minute: '2-digit',
-          second: '2-digit',
-          hour12: false,
-        });
-      } catch (e) {
-        // Fallback if toLocaleTimeString fails
-        return new Date(timestamp).toISOString().substring(11, 19);
-      }
-    }
-    // Fallback to current time
-    const now = Date.now();
-    try {
-      return new Date(now).toLocaleTimeString('en-GB', {
-        hour: '2-digit',
-        minute: '2-digit',
-        second: '2-digit',
-        hour12: false,
-      });
-    } catch (e) {
-      return new Date(now).toISOString().substring(11, 19);
-    }
-  } catch (error) {
-    // Ultimate fallback
-    return new Date().toISOString().substring(11, 19);
+  if (typeof timestamp === 'string' && timestamp.length === 8 && timestamp[2] === ':') {
+    return timestamp;
   }
+
+  let ms;
+  if (typeof timestamp === 'number' && timestamp > 1000000000000 && timestamp < 2000000000000) {
+    ms = timestamp;
+  } else {
+    ms = Date.now();
+  }
+
+  if (_formatter) {
+    return _formatter.format(ms);
+  }
+  // Fallback
+  return new Date(ms).toISOString().substring(11, 19);
 };
 
 /**
- * Normalize a log entry to a consistent format
- * Robust version with validation and error handling
+ * Normalize a log entry to a consistent format.
+ * Hot path - called for every log every poll cycle.
  */
 export const normalizeLog = log => {
-  try {
-    if (log && typeof log === 'object' && log.message != null) {
-      // Validate and sanitize message
-      const message = String(log.message || '').slice(0, 10000); // Max 10KB
+  // Object with message property (frontend/app logs, or already-normalized)
+  if (log && typeof log === 'object' && log.message != null) {
+    const message = typeof log.message === 'string' ? log.message : String(log.message);
 
-      // Validate timestamp
-      let timestampNumeric = Date.now();
-      if (typeof log.timestamp === 'number' && !isNaN(log.timestamp) && isFinite(log.timestamp)) {
-        timestampNumeric = log.timestamp;
-      } else if (
-        log.timestampNumeric &&
-        typeof log.timestampNumeric === 'number' &&
-        !isNaN(log.timestampNumeric) &&
-        isFinite(log.timestampNumeric)
-      ) {
-        timestampNumeric = log.timestampNumeric;
-      }
-
-      return {
-        message,
-        source: log.source || 'daemon',
-        timestamp: log.timestamp
-          ? formatTimestamp(log.timestamp)
-          : formatTimestamp(timestampNumeric),
-        level: log.level || 'info',
-        appName: log.appName || undefined,
-        timestampNumeric,
-      };
+    let tsNum = 0;
+    if (typeof log.timestampNumeric === 'number' && log.timestampNumeric > 0) {
+      tsNum = log.timestampNumeric;
+    } else if (typeof log.timestamp === 'number' && log.timestamp > 1000000000000) {
+      tsNum = log.timestamp;
     }
 
-    if (typeof log === 'string') {
-      // Parse Rust logs with format "TIMESTAMP|MESSAGE"
-      // If no pipe found, treat as legacy log without timestamp
-      const pipeIndex = log.indexOf('|');
-      let message = log;
-      let timestampNumeric = 0;
-
-      if (pipeIndex > 0 && pipeIndex < 20) {
-        // Potential timestamp prefix (Unix millis is ~13 digits)
-        const potentialTimestamp = log.substring(0, pipeIndex);
-        const parsedTs = parseInt(potentialTimestamp, 10);
-
-        // Validate it looks like a Unix timestamp (reasonable range)
-        if (!isNaN(parsedTs) && parsedTs > 1600000000000 && parsedTs < 2000000000000) {
-          timestampNumeric = parsedTs;
-          message = log.substring(pipeIndex + 1);
-        }
-      }
-
-      return {
-        message: message.slice(0, 10000), // Max 10KB
-        source: 'daemon',
-        timestamp: timestampNumeric > 0 ? formatTimestamp(timestampNumeric) : '',
-        timestampNumeric,
-        level: 'info',
-      };
-    }
-
-    // Fallback for any other type
-    const now = Date.now();
     return {
-      message: String(log || 'Invalid log entry').slice(0, 10000),
-      source: 'daemon',
-      timestamp: formatTimestamp(now),
-      timestampNumeric: now,
-      level: 'info',
-    };
-  } catch (error) {
-    // Ultimate fallback - return a safe log entry
-    const now = Date.now();
-    return {
-      message: `[Log normalization error: ${error.message}]`,
-      source: 'daemon',
-      timestamp: formatTimestamp(now),
-      timestampNumeric: now,
-      level: 'error',
+      message,
+      source: log.source || 'daemon',
+      timestamp:
+        tsNum > 0
+          ? formatTimestamp(tsNum)
+          : typeof log.timestamp === 'string'
+            ? log.timestamp
+            : formatTimestamp(Date.now()),
+      level: log.level || 'info',
+      appName: log.appName || undefined,
+      timestampNumeric: tsNum || Date.now(),
     };
   }
+
+  // Raw string from Rust VecDeque: "TIMESTAMP|MESSAGE"
+  if (typeof log === 'string') {
+    const pipeIdx = log.indexOf('|');
+    if (pipeIdx > 0 && pipeIdx < 16) {
+      const ts = parseInt(log.substring(0, pipeIdx), 10);
+      if (ts > 1600000000000 && ts < 2000000000000) {
+        return {
+          message: log.substring(pipeIdx + 1),
+          source: 'daemon',
+          timestamp: formatTimestamp(ts),
+          timestampNumeric: ts,
+          level: 'info',
+        };
+      }
+    }
+    return {
+      message: log,
+      source: 'daemon',
+      timestamp: '',
+      timestampNumeric: 0,
+      level: 'info',
+    };
+  }
+
+  const now = Date.now();
+  return {
+    message: String(log || ''),
+    source: 'daemon',
+    timestamp: formatTimestamp(now),
+    timestampNumeric: now,
+    level: 'info',
+  };
 };

--- a/src/hooks/daemon/useDaemon.js
+++ b/src/hooks/daemon/useDaemon.js
@@ -99,13 +99,7 @@ export const useDaemon = () => {
         const errorObject = createErrorFromConfig(data.errorConfig, data.errorLine);
         setHardwareError(errorObject);
         transitionTo.starting();
-        // 📊 Telemetry - Track known hardware errors (NO_MOTORS, CAMERA_ERROR, etc.)
         handleDaemonError('hardware', data.errorLine, { code: data.errorConfig.code });
-      } else if (data.isGeneric) {
-        const currentError = currentState.hardwareError;
-        if (!currentError || !currentError.type) {
-          handleDaemonError('hardware', data.errorLine);
-        }
       }
     });
 
@@ -188,12 +182,14 @@ export const useDaemon = () => {
     };
   }, [eventBus, clearStartupTimeout]);
 
-  // Listen to sidecar stderr events to detect hardware errors
+  // Listen to sidecar stderr events to detect known hardware errors.
+  // Only matches specific patterns from HARDWARE_ERROR_CONFIGS (e.g. "No motors detected",
+  // "Camera communication error"). Generic errors (RuntimeError, Exception, etc.) are NOT
+  // caught here - they are detected via structured daemon status polling below.
   useEffect(() => {
     let isMounted = true;
 
     const setupStderrListener = async () => {
-      // Cleanup previous listener if any
       if (unlistenStderrRef.current) {
         unlistenStderrRef.current();
         unlistenStderrRef.current = null;
@@ -217,12 +213,6 @@ export const useDaemon = () => {
 
           if (errorConfig) {
             eventBus.emit('daemon:hardware:error', { errorConfig, errorLine });
-          } else if (errorLine.includes('RuntimeError')) {
-            eventBus.emit('daemon:hardware:error', {
-              errorConfig: null,
-              errorLine,
-              isGeneric: true,
-            });
           }
         });
 
@@ -244,6 +234,81 @@ export const useDaemon = () => {
       }
     };
   }, [eventBus]);
+
+  // Poll /api/daemon/status during startup to detect daemon-level errors.
+  // The Python daemon exposes a structured state machine (DaemonState enum):
+  //   not_initialized → starting → running | error
+  // When state === "error", the response includes an "error" field with
+  // the actual exception message - much more reliable than parsing stderr.
+  const daemonStatusPollRef = useRef(null);
+
+  useEffect(() => {
+    if (!isStarting) {
+      if (daemonStatusPollRef.current) {
+        clearInterval(daemonStatusPollRef.current);
+        daemonStatusPollRef.current = null;
+      }
+      return;
+    }
+
+    // Wait a few seconds before starting to poll (daemon needs time to start Uvicorn)
+    const startDelay = setTimeout(() => {
+      if (!useAppStore.getState().isStarting) return;
+
+      const pollDaemonStatus = async () => {
+        const state = useAppStore.getState();
+        if (!state.isStarting || state.isActive) {
+          clearInterval(daemonStatusPollRef.current);
+          daemonStatusPollRef.current = null;
+          return;
+        }
+
+        try {
+          const response = await fetchWithTimeout(
+            buildApiUrl(DAEMON_CONFIG.ENDPOINTS.DAEMON_STATUS),
+            {},
+            DAEMON_CONFIG.TIMEOUTS.STARTUP_CHECK,
+            { silent: true }
+          );
+
+          if (!response.ok) return;
+
+          const data = await response.json();
+
+          if (data.state === 'error' && data.error) {
+            // Check if the structured error matches a known hardware error first
+            const errorConfig = findErrorConfig(data.error);
+            if (errorConfig) {
+              eventBus.emit('daemon:hardware:error', {
+                errorConfig,
+                errorLine: data.error,
+              });
+            } else {
+              // Daemon reported a structured error (e.g. serial port, backend init failure)
+              handleDaemonError('startup', { message: data.error });
+              clearStartupTimeout();
+            }
+
+            clearInterval(daemonStatusPollRef.current);
+            daemonStatusPollRef.current = null;
+          }
+        } catch {
+          // Daemon not reachable yet - expected during early startup
+        }
+      };
+
+      pollDaemonStatus();
+      daemonStatusPollRef.current = setInterval(pollDaemonStatus, 2000);
+    }, DAEMON_CONFIG.ANIMATIONS.STARTUP_MIN_DELAY || 3000);
+
+    return () => {
+      clearTimeout(startDelay);
+      if (daemonStatusPollRef.current) {
+        clearInterval(daemonStatusPollRef.current);
+        daemonStatusPollRef.current = null;
+      }
+    };
+  }, [isStarting, eventBus, clearStartupTimeout]);
 
   // Listen to sidecar stdout/stderr events to reset timeout when we see activity
   // Daemon logs go to stderr (Python logging), so we must listen to both

--- a/src/hooks/daemon/useDaemonStartupLogs.js
+++ b/src/hooks/daemon/useDaemonStartupLogs.js
@@ -3,17 +3,20 @@ import { listen } from '@tauri-apps/api/event';
 import { shouldFilterLog } from '../../utils/logging/logFilters';
 
 /**
- * Hook to listen to sidecar logs during daemon startup
- * Provides real-time feedback to the user about what's happening
+ * Hook to listen to sidecar logs during daemon startup.
+ * Pure display hook - collects stdout/stderr lines for the LogConsole UI.
  *
- * Filtering is handled by the centralized logFilters utility.
+ * Error detection is NOT this hook's responsibility. Daemon errors are
+ * detected via structured signals:
+ * - Process termination: Tauri "daemon-status-changed" event (Crashed)
+ * - Daemon-level errors: polling /api/daemon/status (state === "error")
+ * - Hardware errors: specific patterns in hardwareErrors.js
  *
  * @param {boolean} isStarting - Whether daemon is currently starting
- * @returns {object} { logs, hasError, lastMessage }
+ * @returns {object} { logs, lastMessage }
  */
 export function useDaemonStartupLogs(isStarting) {
   const [startupLogs, setStartupLogs] = useState([]);
-  const [hasError, setHasError] = useState(false);
   const [lastMessage, setLastMessage] = useState('');
 
   // Use ref to accumulate logs during startup
@@ -40,9 +43,19 @@ export function useDaemonStartupLogs(isStarting) {
     // Clear logs when starting new daemon
     logsRef.current = [];
     setStartupLogs([]);
-    setHasError(false);
 
     let isMounted = true;
+
+    const addLog = (cleanLine, level) => {
+      const newLog = {
+        message: cleanLine,
+        level,
+        timestamp: Date.now(),
+      };
+      logsRef.current = [...logsRef.current, newLog].slice(-50);
+      setStartupLogs([...logsRef.current]);
+      setLastMessage(cleanLine);
+    };
 
     const setupListeners = async () => {
       try {
@@ -53,24 +66,13 @@ export function useDaemonStartupLogs(isStarting) {
           const logLine =
             typeof event.payload === 'string' ? event.payload : event.payload?.toString() || '';
 
-          // Clean up prefix if present
           const cleanLine = logLine.replace(/^Sidecar stdout:\s*/, '').trim();
 
-          // Skip empty lines or filtered logs (use centralized filter)
           if (!cleanLine || shouldFilterLog(cleanLine)) {
             return;
           }
 
-          // Add to logs
-          const newLog = {
-            message: cleanLine,
-            level: 'info',
-            timestamp: Date.now(),
-          };
-
-          logsRef.current = [...logsRef.current, newLog].slice(-50); // Keep last 50
-          setStartupLogs([...logsRef.current]);
-          setLastMessage(cleanLine);
+          addLog(cleanLine, 'info');
         });
 
         if (isMounted) {
@@ -80,42 +82,20 @@ export function useDaemonStartupLogs(isStarting) {
           return;
         }
 
-        // Listen to stderr (warnings/errors)
+        // Listen to stderr (daemon logs go to stderr via Python logging)
         const unlistenStderr = await listen('sidecar-stderr', event => {
           if (!isMounted) return;
 
           const logLine =
             typeof event.payload === 'string' ? event.payload : event.payload?.toString() || '';
 
-          // Clean up prefix if present
           const cleanLine = logLine.replace(/^Sidecar stderr:\s*/, '').trim();
 
-          // Skip empty lines or filtered logs (use centralized filter)
           if (!cleanLine || shouldFilterLog(cleanLine)) {
             return;
           }
 
-          // Check for actual errors (not just stderr noise)
-          const isError =
-            cleanLine.includes('ERROR') ||
-            cleanLine.includes('error:') ||
-            cleanLine.includes('Exception') ||
-            cleanLine.includes('Traceback');
-
-          if (isError) {
-            setHasError(true);
-          }
-
-          // Add to logs
-          const newLog = {
-            message: cleanLine,
-            level: isError ? 'error' : 'warning',
-            timestamp: Date.now(),
-          };
-
-          logsRef.current = [...logsRef.current, newLog].slice(-50);
-          setStartupLogs([...logsRef.current]);
-          setLastMessage(cleanLine);
+          addLog(cleanLine, 'info');
         });
 
         if (isMounted) {
@@ -143,7 +123,6 @@ export function useDaemonStartupLogs(isStarting) {
 
   return {
     logs: startupLogs,
-    hasError,
     lastMessage,
   };
 }

--- a/src/store/slices/logsSlice.js
+++ b/src/store/slices/logsSlice.js
@@ -1,25 +1,29 @@
 /**
  * Logs Slice - Manages all types of logs (daemon, frontend, app)
  *
- * Note: We don't import DAEMON_CONFIG here to avoid circular dependencies
- * (daemon.js imports useStore which imports slices)
+ * Two display modes:
+ *   - "simple": user-facing actions only (errors, user actions, key events)
+ *   - "dev":    everything with category/level filters and search
  *
- * Filtering is handled by the centralized logFilters utility.
+ * Note: We don't import DAEMON_CONFIG here to avoid circular dependencies
+ * (daemon.js imports useStore which imports slices).
+ * We also avoid importing from utils/logging/constants for the same reason;
+ * the canonical category list lives there, but we inline the values here.
  */
 
-import { filterLogs } from '../../utils/logging/logFilters';
-
-// Default max logs (same as DAEMON_CONFIG.LOGS values)
 const MAX_FRONTEND_LOGS = 500;
-const MAX_APP_LOGS = 500;
+const MAX_APP_LOGS = 1000;
 
-/**
- * Initial state for logs slice
- */
+const ALL_CATEGORIES = ['daemon', 'app', 'frontend'];
+
 export const logsInitialState = {
-  logs: [], // Daemon logs (from Tauri IPC)
-  frontendLogs: [], // Frontend action logs (API calls, user actions)
-  appLogs: [], // App logs (from running apps)
+  logs: [],
+  frontendLogs: [],
+  appLogs: [],
+
+  logMode: 'simple',
+  logSearch: '',
+  logCategoryFilters: [...ALL_CATEGORIES],
 };
 
 /**
@@ -31,27 +35,24 @@ export const logsInitialState = {
 export const createLogsSlice = (set, get) => ({
   ...logsInitialState,
 
-  // Set daemon logs - filter confusing messages and merge intelligently
+  // Set daemon logs - store raw, filtering happens at display time
   setLogs: newLogs =>
     set(state => {
-      // Filter out confusing internal logs using centralized filter
-      const filteredLogs = filterLogs(newLogs);
-
       if (
-        state.logs === filteredLogs ||
+        state.logs === newLogs ||
         (Array.isArray(state.logs) &&
-          Array.isArray(filteredLogs) &&
-          state.logs.length === filteredLogs.length &&
+          Array.isArray(newLogs) &&
+          state.logs.length === newLogs.length &&
           state.logs.length > 0 &&
-          state.logs[state.logs.length - 1] === filteredLogs[filteredLogs.length - 1])
+          state.logs[state.logs.length - 1] === newLogs[newLogs.length - 1])
       ) {
         return state;
       }
-      return { logs: filteredLogs };
+      return { logs: newLogs };
     }),
 
-  // Add frontend log
-  addFrontendLog: (message, level = 'info') => {
+  // Add frontend log with optional category
+  addFrontendLog: (message, level = 'info', category = 'frontend') => {
     if (message == null) {
       if (process.env.NODE_ENV === 'development') {
         console.warn('[addFrontendLog] Received null/undefined message, skipping');
@@ -83,6 +84,7 @@ export const createLogsSlice = (set, get) => ({
           timestampNumeric: now,
           message: sanitizedMessage,
           source: 'frontend',
+          category: category || 'frontend',
           level: normalizedLevel,
         };
 
@@ -170,5 +172,18 @@ export const createLogsSlice = (set, get) => ({
       logs: [],
       frontendLogs: [],
       appLogs: [],
+    }),
+
+  // Log mode & filters
+  setLogMode: mode => set({ logMode: mode }),
+  setLogSearch: search => set({ logSearch: search }),
+  toggleLogCategory: category =>
+    set(state => {
+      const current = state.logCategoryFilters;
+      return {
+        logCategoryFilters: current.includes(category)
+          ? current.filter(c => c !== category)
+          : [...current, category],
+      };
     }),
 });

--- a/src/utils/logging/constants.js
+++ b/src/utils/logging/constants.js
@@ -1,10 +1,7 @@
 /**
- * Constants for logging system
+ * Constants for logging system - single source of truth
  */
 
-/**
- * Log levels
- */
 export const LOG_LEVELS = {
   INFO: 'info',
   SUCCESS: 'success',
@@ -12,19 +9,12 @@ export const LOG_LEVELS = {
   ERROR: 'error',
 };
 
-/**
- * Log sources
- */
-export const LOG_SOURCES = {
-  FRONTEND: 'frontend',
+export const LOG_CATEGORIES = {
   DAEMON: 'daemon',
   APP: 'app',
-  API: 'api',
+  FRONTEND: 'frontend',
 };
 
-/**
- * Standard emojis for log messages
- */
 export const LOG_EMOJIS = {
   SUCCESS: '✓',
   ERROR: '❌',
@@ -38,11 +28,17 @@ export const LOG_EMOJIS = {
   INFO: 'ℹ️',
 };
 
-/**
- * Log prefixes
- */
 export const LOG_PREFIXES = {
   DAEMON: '[Daemon]',
   API: '[API]',
   APP: appName => `[App: ${appName}]`,
+};
+
+/**
+ * Display metadata for category filter chips (used in LogConsole UI)
+ */
+export const CATEGORY_META = {
+  daemon: { label: 'Daemon', color: '#60a5fa' },
+  app: { label: 'Apps', color: '#c084fc' },
+  frontend: { label: 'Frontend', color: '#5db3ff' },
 };

--- a/src/utils/logging/index.js
+++ b/src/utils/logging/index.js
@@ -1,31 +1,3 @@
-/**
- * Centralized logging utilities
- *
- * Provides two ways to log:
- * 1. useLogger() hook - for React components
- * 2. Static functions - for use outside React components
- *
- * @example
- * ```jsx
- * // In React components
- * import { useLogger } from '@/utils/logging';
- *
- * function MyComponent() {
- *   const logger = useLogger();
- *   logger.success('Action completed');
- * }
- * ```
- *
- * @example
- * ```javascript
- * // Outside React components
- * import { logSuccess, logError } from '@/utils/logging';
- *
- * logSuccess('Action completed');
- * logError('Something went wrong');
- * ```
- */
-
 // Hook for React components
 export { useLogger } from './useLogger';
 
@@ -44,7 +16,7 @@ export {
 } from './logger';
 
 // Constants
-export { LOG_LEVELS, LOG_SOURCES, LOG_EMOJIS, LOG_PREFIXES } from './constants';
+export { LOG_LEVELS, LOG_EMOJIS, LOG_PREFIXES, LOG_CATEGORIES, CATEGORY_META } from './constants';
 
-// Log filtering (single source of truth)
-export { FILTERED_PATTERNS, shouldFilterLog, filterLogs } from './logFilters';
+// Log filtering (single source of truth for simple-mode noise reduction)
+export { FILTERED_PATTERNS, shouldFilterLog } from './logFilters';

--- a/src/utils/logging/logFilters.js
+++ b/src/utils/logging/logFilters.js
@@ -1,57 +1,34 @@
 /**
- * Log Filters - Single source of truth for all log filtering
+ * Log Filters - patterns to hide from simple mode
  *
- * Use this module to filter out confusing/verbose logs from the UI.
+ * In dev mode these are bypassed and all logs are shown.
  * This is the ONLY place where filter patterns should be defined.
  */
 
-/**
- * Patterns to filter from daemon logs (confusing for users)
- * These are internal logs that don't provide useful information to end users
- */
 export const FILTERED_PATTERNS = [
-  // Uvicorn internal logs - the "uvicorn.error" logger name is confusing (not actually errors)
   'uvicorn.error',
   'uvicorn.access',
   'Started server process',
   'Waiting for application startup',
   'Application startup complete',
   'Uvicorn running on',
-  // HTTP request logs (noisy)
   'GET /api/',
   'POST /api/',
   'INFO:     127.0.0.1',
   '127.0.0.1:',
-  // WebSocket internal logs
   'WebSocket connection',
   'connection open',
   'connection closed',
-  // Daemon lifecycle (already shown via UI state)
   '🧹 Cleaning up existing daemons',
   '✓ Daemon started',
   '✓ Daemon stopped',
 ];
 
 /**
- * Check if a log message should be filtered out
- * @param {string} message - The log message to check
- * @returns {boolean} - True if the message should be HIDDEN (filtered out)
+ * Check if a log message should be filtered out (simple mode only)
+ * @returns {boolean} True if the message should be HIDDEN
  */
 export const shouldFilterLog = message => {
   if (!message || typeof message !== 'string') return false;
   return FILTERED_PATTERNS.some(pattern => message.includes(pattern));
-};
-
-/**
- * Filter an array of logs
- * @param {Array} logs - Array of log objects or strings
- * @returns {Array} - Filtered array with confusing logs removed
- */
-export const filterLogs = logs => {
-  if (!Array.isArray(logs)) return logs;
-
-  return logs.filter(log => {
-    const message = typeof log === 'string' ? log : log?.message || '';
-    return !shouldFilterLog(message);
-  });
 };

--- a/src/utils/logging/logger.js
+++ b/src/utils/logging/logger.js
@@ -1,146 +1,88 @@
-import { useStore } from '../../store';
-import { LOG_LEVELS, LOG_EMOJIS, LOG_PREFIXES } from './constants';
+import { LOG_LEVELS, LOG_PREFIXES, LOG_CATEGORIES } from './constants';
 
-/**
- * Helper to safely get logs store instance
- */
+let _store = null;
+
 const getLogsStore = () => {
   try {
-    return useStore.getState();
-  } catch (e) {
-    // Fallback for cases where store might not be initialized
-    if (process.env.NODE_ENV === 'development') {
-      console.warn('[Logger] Logs store not available:', e);
+    if (!_store) {
+      // Lazy import to break circular dependency (daemon.js -> logging -> store -> slices)
+      const mod = import('../../store');
+      mod
+        .then(m => {
+          _store = m.useStore;
+        })
+        .catch(() => {});
+      return null;
     }
+    return _store.getState();
+  } catch {
     return null;
   }
 };
 
-/**
- * Helper to add log (synchronous for main window, async fallback for secondary windows)
- * In main window: adds directly to store (synchronous)
- * In secondary windows: emits event to main window (async, but we don't wait)
- */
-const addLog = (message, level = LOG_LEVELS.INFO) => {
-  // Main window: add directly to logs store (synchronous, fast path)
+const addLog = (message, level = LOG_LEVELS.INFO, category = LOG_CATEGORIES.FRONTEND) => {
   const logsStore = getLogsStore();
   if (logsStore?.addFrontendLog) {
-    logsStore.addFrontendLog(message, level);
+    logsStore.addFrontendLog(message, level, category);
     return;
   }
 
-  // Fallback: try async window detection (for secondary windows or if store not available)
-  // We don't await this to keep functions synchronous
   (async () => {
     try {
       const { getCurrentWindow } = await import('@tauri-apps/api/window');
       const { emit } = await import('@tauri-apps/api/event');
       const currentWindow = await getCurrentWindow();
       if (currentWindow.label !== 'main') {
-        await emit('add-log', { message, level });
+        await emit('add-log', { message, level, category });
       }
-    } catch (error) {
-      // Silently fail - logs are not critical
+    } catch {
+      // Silently fail
     }
   })();
 };
 
-/**
- * Static logging functions for use outside React components
- *
- * These functions can be used in utility files, event handlers, etc.
- * where React hooks are not available.
- *
- * @example
- * ```javascript
- * import { logSuccess, logError } from '@/utils/logging';
- *
- * async function fetchData() {
- *   try {
- *     const data = await fetch('/api/data');
- *     logSuccess('Data fetched successfully');
- *     return data;
- *   } catch (error) {
- *     logError('Failed to fetch data', error.message);
- *   }
- * }
- * ```
- */
-
-/**
- * Log an info message
- */
-export const logInfo = (message, context = {}) => {
-  addLog(message, LOG_LEVELS.INFO);
+export const logInfo = (message, category = LOG_CATEGORIES.FRONTEND) => {
+  addLog(message, LOG_LEVELS.INFO, category);
 };
 
-/**
- * Log a success message
- */
-export const logSuccess = (message, context = {}) => {
-  if (process.env.NODE_ENV === 'development') {
-  }
-  addLog(message, LOG_LEVELS.SUCCESS);
+export const logSuccess = (message, category = LOG_CATEGORIES.FRONTEND) => {
+  addLog(message, LOG_LEVELS.SUCCESS, category);
 };
 
-/**
- * Log a warning message
- */
-export const logWarning = (message, context = {}) => {
-  addLog(message, LOG_LEVELS.WARNING);
+export const logWarning = (message, category = LOG_CATEGORIES.FRONTEND) => {
+  addLog(message, LOG_LEVELS.WARNING, category);
 };
 
-/**
- * Log an error message
- */
-export const logError = (message, context = {}) => {
-  addLog(message, LOG_LEVELS.ERROR);
+export const logError = (message, category = LOG_CATEGORIES.FRONTEND) => {
+  addLog(message, LOG_LEVELS.ERROR, category);
 };
 
-/**
- * Log an API call
- */
 export const logApiCall = (method, endpoint, success, details = '') => {
   const message = details ? `${method} ${endpoint}: ${details}` : `${method} ${endpoint}`;
-  addLog(message, success ? LOG_LEVELS.SUCCESS : LOG_LEVELS.ERROR);
+  addLog(message, success ? LOG_LEVELS.SUCCESS : LOG_LEVELS.ERROR, LOG_CATEGORIES.FRONTEND);
 };
 
-/**
- * Log a daemon message
- */
 export const logDaemon = (message, level = LOG_LEVELS.INFO) => {
   const formattedMessage = `${LOG_PREFIXES.DAEMON} ${message}`;
-  addLog(formattedMessage, level);
+  addLog(formattedMessage, level, LOG_CATEGORIES.DAEMON);
 };
 
-/**
- * Log an app message (uses addAppLog)
- */
 export const logApp = (appName, message, level = LOG_LEVELS.INFO) => {
-  const appStore = useStore.getState();
-  if (appStore?.addAppLog) {
-    appStore.addAppLog(message, appName, level);
+  const store = getLogsStore();
+  if (store?.addAppLog) {
+    store.addAppLog(message, appName, level);
   }
 };
 
-/**
- * Log a user action
- */
 export const logUserAction = (action, details = '') => {
   const message = details ? `${action}: ${details}` : action;
-  addLog(message, LOG_LEVELS.INFO);
+  addLog(message, LOG_LEVELS.INFO, LOG_CATEGORIES.FRONTEND);
 };
 
-/**
- * Log a permission-related message
- */
 export const logPermission = message => {
-  addLog(message, LOG_LEVELS.WARNING);
+  addLog(message, LOG_LEVELS.WARNING, LOG_CATEGORIES.FRONTEND);
 };
 
-/**
- * Log a timeout message
- */
 export const logTimeout = message => {
-  addLog(message, LOG_LEVELS.WARNING);
+  addLog(message, LOG_LEVELS.WARNING, LOG_CATEGORIES.FRONTEND);
 };

--- a/src/utils/logging/useLogger.js
+++ b/src/utils/logging/useLogger.js
@@ -1,99 +1,65 @@
 import { useCallback } from 'react';
 import { useStore } from '../../store';
-import { LOG_LEVELS, LOG_EMOJIS, LOG_PREFIXES } from './constants';
+import { LOG_LEVELS, LOG_EMOJIS, LOG_PREFIXES, LOG_CATEGORIES } from './constants';
 
 /**
- * React hook for logging in components
- *
- * Provides standardized logging functions with consistent formatting
- *
- * @example
- * ```jsx
- * function MyComponent() {
- *   const logger = useLogger();
- *
- *   const handleAction = () => {
- *     logger.success('Action completed');
- *     logger.error('Something went wrong');
- *   };
- * }
- * ```
+ * React hook for logging in components.
+ * Each method routes to addFrontendLog with the appropriate category.
  */
 export function useLogger() {
   const addFrontendLog = useStore(state => state.addFrontendLog);
   const addAppLog = useStore(state => state.addAppLog);
 
-  /**
-   * Log an info message
-   */
   const info = useCallback(
-    (message, context = {}) => {
-      addFrontendLog(message, LOG_LEVELS.INFO);
+    (message, category = LOG_CATEGORIES.FRONTEND) => {
+      addFrontendLog(message, LOG_LEVELS.INFO, category);
     },
     [addFrontendLog]
   );
 
-  /**
-   * Log a success message
-   */
   const success = useCallback(
-    (message, context = {}) => {
-      const formattedMessage = `${LOG_EMOJIS.SUCCESS} ${message}`;
-      addFrontendLog(formattedMessage, LOG_LEVELS.SUCCESS);
+    (message, category = LOG_CATEGORIES.FRONTEND) => {
+      const formatted = `${LOG_EMOJIS.SUCCESS} ${message}`;
+      addFrontendLog(formatted, LOG_LEVELS.SUCCESS, category);
     },
     [addFrontendLog]
   );
 
-  /**
-   * Log a warning message
-   */
   const warning = useCallback(
-    (message, context = {}) => {
-      const formattedMessage = `${LOG_EMOJIS.WARNING} ${message}`;
-      addFrontendLog(formattedMessage, LOG_LEVELS.WARNING);
+    (message, category = LOG_CATEGORIES.FRONTEND) => {
+      const formatted = `${LOG_EMOJIS.WARNING} ${message}`;
+      addFrontendLog(formatted, LOG_LEVELS.WARNING, category);
     },
     [addFrontendLog]
   );
 
-  /**
-   * Log an error message
-   */
   const error = useCallback(
-    (message, context = {}) => {
-      const formattedMessage = `${LOG_EMOJIS.ERROR} ${message}`;
-      addFrontendLog(formattedMessage, LOG_LEVELS.ERROR);
+    (message, category = LOG_CATEGORIES.FRONTEND) => {
+      const formatted = `${LOG_EMOJIS.ERROR} ${message}`;
+      addFrontendLog(formatted, LOG_LEVELS.ERROR, category);
     },
     [addFrontendLog]
   );
 
-  /**
-   * Log an API call
-   */
   const api = useCallback(
-    (method, endpoint, success, details = '') => {
-      const icon = success ? LOG_EMOJIS.SUCCESS : LOG_EMOJIS.ERROR;
+    (method, endpoint, ok, details = '') => {
+      const icon = ok ? LOG_EMOJIS.SUCCESS : LOG_EMOJIS.ERROR;
       const message = details
         ? `${icon} ${method} ${endpoint}: ${details}`
         : `${icon} ${method} ${endpoint}`;
-      addFrontendLog(message, success ? LOG_LEVELS.SUCCESS : LOG_LEVELS.ERROR);
+      addFrontendLog(message, ok ? LOG_LEVELS.SUCCESS : LOG_LEVELS.ERROR, LOG_CATEGORIES.FRONTEND);
     },
     [addFrontendLog]
   );
 
-  /**
-   * Log a daemon message
-   */
   const daemon = useCallback(
     (message, level = LOG_LEVELS.INFO) => {
-      const formattedMessage = `${LOG_PREFIXES.DAEMON} ${message}`;
-      addFrontendLog(formattedMessage, level);
+      const formatted = `${LOG_PREFIXES.DAEMON} ${message}`;
+      addFrontendLog(formatted, level, LOG_CATEGORIES.DAEMON);
     },
     [addFrontendLog]
   );
 
-  /**
-   * Log an app message (uses addAppLog)
-   */
   const app = useCallback(
     (appName, message, level = LOG_LEVELS.INFO) => {
       addAppLog(message, appName, level);
@@ -101,35 +67,26 @@ export function useLogger() {
     [addAppLog]
   );
 
-  /**
-   * Log a user action
-   */
   const userAction = useCallback(
     (action, details = '') => {
       const message = details ? `${action}: ${details}` : action;
-      addFrontendLog(message, LOG_LEVELS.INFO);
+      addFrontendLog(message, LOG_LEVELS.INFO, LOG_CATEGORIES.FRONTEND);
     },
     [addFrontendLog]
   );
 
-  /**
-   * Log a permission-related message
-   */
   const permission = useCallback(
     message => {
-      const formattedMessage = `${LOG_EMOJIS.PERMISSION} ${message}`;
-      addFrontendLog(formattedMessage, LOG_LEVELS.WARNING);
+      const formatted = `${LOG_EMOJIS.PERMISSION} ${message}`;
+      addFrontendLog(formatted, LOG_LEVELS.WARNING, LOG_CATEGORIES.FRONTEND);
     },
     [addFrontendLog]
   );
 
-  /**
-   * Log a timeout message
-   */
   const timeout = useCallback(
     message => {
-      const formattedMessage = `${LOG_EMOJIS.TIMEOUT} ${message}`;
-      addFrontendLog(formattedMessage, LOG_LEVELS.WARNING);
+      const formatted = `${LOG_EMOJIS.TIMEOUT} ${message}`;
+      addFrontendLog(formatted, LOG_LEVELS.WARNING, LOG_CATEGORIES.FRONTEND);
     },
     [addFrontendLog]
   );

--- a/src/views/active-robot/ActiveRobotView.jsx
+++ b/src/views/active-robot/ActiveRobotView.jsx
@@ -13,6 +13,7 @@ import {
 } from '@mui/material';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import useDaemonLogStream from '../../hooks/useDaemonLogStream';
+import { logInfo } from '../../utils/logging';
 import FullscreenOverlay from '../../components/FullscreenOverlay';
 import WarningAmberOutlinedIcon from '@mui/icons-material/WarningAmberOutlined';
 import Viewer3D from '../../components/viewer3d';
@@ -172,15 +173,9 @@ function ActiveRobotView({
   // Logs fullscreen modal
   const [logsFullscreenOpen, setLogsFullscreenOpen] = useState(false);
 
-  // Remote daemon log filters (off by default)
-  const [daemonLogFilters, setDaemonLogFilters] = useState([]);
+  // Remote daemon log stream
+  const [daemonLogFilters] = useState([]);
   const remoteLogs = useDaemonLogStream(daemonLogFilters);
-
-  const toggleLogFilter = useCallback(cat => {
-    setDaemonLogFilters(prev =>
-      prev.includes(cat) ? prev.filter(c => c !== cat) : [...prev, cat]
-    );
-  }, []);
 
   // Audio controls - Extracted to hook
   const {
@@ -240,14 +235,19 @@ function ActiveRobotView({
   // Wrapper for Quick Actions with toast and visual effects
   const handleQuickAction = useCallback(
     action => {
+      const prefix =
+        action.type === 'dance'
+          ? 'Playing dance'
+          : action.type === 'action'
+            ? 'Playing action'
+            : 'Playing emotion';
+      logInfo(`${prefix}: ${action.label || action.name}`);
+
       if (action.type === 'action') {
-        // Actions like sleep/wake_up
         sendCommand(`/api/move/play/${action.name}`, action.label);
       } else if (action.type === 'dance') {
-        // Dances
         playRecordedMove(CHOREOGRAPHY_DATASETS.DANCES, action.name);
       } else {
-        // Emotions
         playRecordedMove(CHOREOGRAPHY_DATASETS.EMOTIONS, action.name);
       }
 
@@ -543,37 +543,14 @@ function ActiveRobotView({
               }}
             >
               <Box
-                sx={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: 'center',
-                  mb: 1.5,
-                  flexShrink: 0,
-                }}
-              >
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                  <Typography
-                    sx={{
-                      fontSize: 11,
-                      fontWeight: 600,
-                      color: darkMode ? '#888' : '#999',
-                      textTransform: 'uppercase',
-                      letterSpacing: '0.5px',
-                    }}
-                  >
-                    Logs
-                  </Typography>
-                </Box>
-              </Box>
-
-              <Box
                 sx={{ flex: '1 1 auto', minHeight: 0, display: 'flex', flexDirection: 'column' }}
               >
                 <LogConsole
                   logs={logs}
                   remoteLogs={remoteLogs}
                   darkMode={darkMode}
-                  lines={4}
+                  maxHeight={120}
+                  compact={true}
                   onExpand={() => setLogsFullscreenOpen(true)}
                 />
               </Box>
@@ -610,72 +587,40 @@ function ActiveRobotView({
 
         {/* Toast Notifications - handled by global Toast in App.jsx */}
 
-        {/* Logs Fullscreen Modal */}
+        {/* Logs Fullscreen Modal - only mount LogConsole when open */}
         <FullscreenOverlay
           open={logsFullscreenOpen}
           onClose={() => setLogsFullscreenOpen(false)}
           darkMode={darkMode}
           debugName="LogsFullscreen"
           showCloseButton={true}
+          centeredY={false}
         >
-          <Box
-            sx={{
-              width: 'calc(100vw - 80px)',
-              maxWidth: '1200px',
-              height: '85vh',
-              maxHeight: '800px',
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 2,
-              overflow: 'hidden',
-            }}
-          >
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flexShrink: 0 }}>
-              <Typography
-                sx={{
-                  fontSize: 12,
-                  fontWeight: 600,
-                  color: darkMode ? '#888' : '#999',
-                  textTransform: 'uppercase',
-                  letterSpacing: '0.5px',
-                }}
-              >
-                Logs
-              </Typography>
-              {[
-                { key: 'daemon', label: 'Daemon', color: '#60a5fa' },
-                { key: 'api', label: 'API', color: '#34d399' },
-                { key: 'app', label: 'App', color: '#c084fc' },
-              ].map(({ key, label, color }) => (
-                <Box
-                  key={key}
-                  onClick={() => toggleLogFilter(key)}
-                  sx={{
-                    fontSize: 10,
-                    fontWeight: 600,
-                    px: 1,
-                    py: 0.25,
-                    borderRadius: '4px',
-                    cursor: 'pointer',
-                    transition: 'all 0.15s',
-                    userSelect: 'none',
-                    color: daemonLogFilters.includes(key) ? color : darkMode ? '#555' : '#bbb',
-                    bgcolor: daemonLogFilters.includes(key) ? `${color}18` : 'transparent',
-                    border: `1px solid ${daemonLogFilters.includes(key) ? `${color}40` : darkMode ? '#333' : '#ddd'}`,
-                    '&:hover': {
-                      bgcolor: `${color}15`,
-                      borderColor: `${color}30`,
-                    },
-                  }}
-                >
-                  {label}
-                </Box>
-              ))}
+          {logsFullscreenOpen && (
+            <Box
+              sx={{
+                width: 'calc(100vw - 80px)',
+                maxWidth: '1200px',
+                height: '82vh',
+                maxHeight: '800px',
+                display: 'flex',
+                flexDirection: 'column',
+                overflow: 'hidden',
+                mt: 'auto',
+                mb: 5,
+              }}
+            >
+              <Box sx={{ flex: 1, minHeight: 0, overflow: 'hidden' }}>
+                <LogConsole
+                  logs={logs}
+                  remoteLogs={remoteLogs}
+                  darkMode={darkMode}
+                  height="100%"
+                  fullSize={true}
+                />
+              </Box>
             </Box>
-            <Box sx={{ flex: 1, minHeight: 0, overflow: 'hidden' }}>
-              <LogConsole logs={logs} remoteLogs={remoteLogs} darkMode={darkMode} height="100%" />
-            </Box>
-          </Box>
+          )}
         </FullscreenOverlay>
       </Box>
     </WebRTCStreamProvider>

--- a/src/views/active-robot/RobotHeader.jsx
+++ b/src/views/active-robot/RobotHeader.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Box, Typography } from '@mui/material';
 import { getVersion } from '@utils/tauriCompat';
+import { invoke } from '@tauri-apps/api/core';
 import useAppStore from '../../store/useAppStore';
 
 /**
@@ -10,11 +11,19 @@ import useAppStore from '../../store/useAppStore';
 export default function RobotHeader({ daemonVersion, darkMode = false }) {
   const { connectionMode } = useAppStore();
   const [appVersion, setAppVersion] = useState('');
+  const [sidecarBranch, setSidecarBranch] = useState(null);
 
   useEffect(() => {
     getVersion()
       .then(setAppVersion)
       .catch(() => setAppVersion(null));
+    invoke('get_sidecar_source')
+      .then(info => {
+        if (info?.source && info.source !== 'pypi') {
+          setSidecarBranch(info.source);
+        }
+      })
+      .catch(() => {});
   }, []);
 
   // Get connection type label
@@ -89,7 +98,11 @@ export default function RobotHeader({ daemonVersion, darkMode = false }) {
             verticalAlign: 'middle',
           }}
         />
-        {daemonVersion ? `Daemon v${daemonVersion}` : 'Daemon ?'}
+        {sidecarBranch
+          ? `Daemon @${sidecarBranch}`
+          : daemonVersion
+            ? `Daemon v${daemonVersion}`
+            : 'Daemon ?'}
       </Typography>
     </Box>
   );

--- a/src/views/active-robot/controller/Controller.jsx
+++ b/src/views/active-robot/controller/Controller.jsx
@@ -1,11 +1,12 @@
-import React, { useMemo, useEffect } from 'react';
+import React, { useMemo, useEffect, useRef } from 'react';
 import { Box, Typography } from '@mui/material';
-import { ControllerProvider } from './context/ControllerContext';
+import { ControllerProvider, useController } from './context/ControllerContext';
 import { useControllerHandlers } from './hooks/useControllerHandlers';
 import { useControllerSmoothing } from './hooks/useControllerSmoothing';
 import { useControllerSync } from './hooks/useControllerSync';
 import { useControllerAPI } from './hooks/useControllerAPI';
 import { useControllerInput } from './hooks/useControllerInput';
+import { logInfo } from '../../../utils/logging';
 import { Joystick2D, VerticalSlider, SimpleSlider, CircularSlider } from './components';
 import { EXTENDED_ROBOT_RANGES } from '../../../utils/inputConstants';
 import { mapRobotToDisplay, mapDisplayToRobot } from '../../../utils/inputMappings';
@@ -30,7 +31,18 @@ import bodyIcon from '../../../assets/reachy-body-icon.svg';
  * Inner controller component (uses context)
  */
 function ControllerInner({ darkMode, onResetReady, onIsAtInitialPosition }) {
+  const { isDragging } = useController();
   const { sendCommand, forceSendCommand } = useControllerAPI();
+
+  const wasDraggingRef = useRef(false);
+  useEffect(() => {
+    if (isDragging && !wasDraggingRef.current) {
+      logInfo('Manual control started');
+    } else if (!isDragging && wasDraggingRef.current) {
+      logInfo('Manual control ended');
+    }
+    wasDraggingRef.current = isDragging;
+  }, [isDragging]);
 
   // Handlers
   const {

--- a/src/views/active-robot/right-panel/expressions/ExpressionsSection.jsx
+++ b/src/views/active-robot/right-panel/expressions/ExpressionsSection.jsx
@@ -122,8 +122,8 @@ export default function ExpressionsSection({ isBusy: isBusyProp = false, darkMod
         emoji = DANCE_EMOJIS[action.name] || null;
       }
 
-      const logMessage = emoji ? `${emoji} ${action.label}` : action.label;
-      logger.userAction(logMessage);
+      const prefix = action.type === 'dance' ? 'Playing dance' : 'Playing emotion';
+      logger.userAction(`${prefix}: ${action.label}`);
 
       // 📊 Telemetry
       telemetry.expressionPlayed({ name: action.name, type: action.type });

--- a/src/views/permissions-required/PermissionsRequiredView.jsx
+++ b/src/views/permissions-required/PermissionsRequiredView.jsx
@@ -13,7 +13,6 @@ import useAppStore from '../../store/useAppStore';
 import { usePermissions } from '../../hooks/system';
 
 import { isMacOS } from '../../utils/platform';
-import LogConsole from '@components/LogConsole';
 import LockedReachy from '../../assets/locked-reachy.svg';
 import SleepingReachy from '../../assets/sleeping-reachy.svg';
 
@@ -511,38 +510,6 @@ export default function PermissionsRequiredView({ isRestarting: externalIsRestar
         position: 'relative',
       }}
     >
-      {/* LogConsole at bottom */}
-      <Box
-        sx={{
-          position: 'fixed',
-          bottom: 8,
-          left: '50%',
-          transform: 'translateX(-50%)',
-          width: 'calc(100% - 32px)',
-          maxWidth: '420px',
-          zIndex: 1000,
-          opacity: 0.2,
-          transition: 'opacity 0.3s ease-in-out',
-          '&:hover': { opacity: 1 },
-        }}
-      >
-        <LogConsole
-          logs={[]}
-          darkMode={darkMode}
-          includeStoreLogs={true}
-          compact={true}
-          showTimestamp={false}
-          lines={1}
-          emptyMessage="Waiting for logs..."
-          sx={{
-            bgcolor: darkMode ? 'rgba(0, 0, 0, 0.6)' : 'rgba(255, 255, 255, 0.7)',
-            border: `1px solid ${darkMode ? 'rgba(255, 255, 255, 0.15)' : 'rgba(0, 0, 0, 0.12)'}`,
-            backdropFilter: 'blur(8px)',
-            WebkitBackdropFilter: 'blur(8px)',
-          }}
-        />
-      </Box>
-
       <Box
         sx={{
           display: 'flex',

--- a/src/views/starting/HardwareScanView.jsx
+++ b/src/views/starting/HardwareScanView.jsx
@@ -180,11 +180,7 @@ function HardwareScanView({ startupError, onScanComplete: onScanCompleteCallback
   // ✅ App fetching hooks for pre-loading apps before transition
   const { fetchAppsFromWebsite, fetchInstalledApps } = useAppFetching();
   const isStarting = robotStatus === 'starting';
-  const {
-    logs: startupLogs,
-    hasError: hasStartupError,
-    lastMessage,
-  } = useDaemonStartupLogs(isStarting);
+  const { logs: startupLogs, lastMessage } = useDaemonStartupLogs(isStarting);
   const totalScanParts = getTotalScanParts(); // Static total from scan parts list
   const [scanProgress, setScanProgress] = useState({ current: 0, total: totalScanParts });
   const [currentPart, setCurrentPart] = useState(null);


### PR DESCRIPTION
## Summary

Complete overhaul of the logging system with two distinct modes and significant performance/UX improvements.

### Logging modes
- **Simple mode** - strict allowlist showing only user-facing events: connection, motors, app lifecycle, volume, sleep/wake, emotions, dances, manual control. Internal daemon logs (uvicorn access, ReSpeaker warnings, Central Relay, etc.) are hidden.
- **Dev mode** - shows all raw daemon logs with category filters (Daemon / Apps / Frontend), full-text search, and no filtering.

### Performance
- **O(N) merge** via `mergeByTimestamp` replacing O(N log N) `concat+sort`
- **Cached `Intl.DateTimeFormat`** in `formatTimestamp` (avoids per-log allocation)
- **Memoized `mergedAppLogs`** to stabilize array references and prevent unnecessary recalculations
- **Conditional mount** of fullscreen LogConsole (no processing when hidden)
- **`shouldFilterLog` applied before `normalizeLog`** in simple mode for early exit

### UI/UX
- **Inline console**: compact 120px max height with hover-revealed controls
- **Fullscreen**: mode toggle (Simple/Dev pill) + category filter chips + search input on a single line, bottom-aligned at 80vh
- **LogItem** adapts rendering per mode (colored dot in simple, category badge in dev)
- **Removed LogConsole from PermissionsRequiredView**
- **Error text in ErrorBoundary** is now user-selectable (`.selectable-text` class override)
- **User actions logged in simple mode**: playing emotions/dances, manual control start/end

### Code quality
- Break circular dependency in `logger.js` with lazy dynamic `import()` (fixes "cannot use useAppStore before init")
- Remove dead code: `LOG_SOURCES`, `LEVEL_META`, `filterLogs`, API/System categories
- Consolidate constants in `logging/constants.js` (single source of truth)
- Store raw daemon logs in Zustand (removed premature `filterLogs` in `setLogs`)

**Depends on #250** (log buffer + sidecar source Rust changes).

## Test plan

- [ ] Launch in simulation - simple mode shows only user-facing events (no uvicorn, no ReSpeaker warnings)
- [ ] Switch to dev mode in fullscreen - all daemon logs visible, filters and search functional
- [ ] Play an emotion / dance - appears in simple mode logs
- [ ] Use 3D controller - "Manual control started/ended" appears in simple mode
- [ ] Verify dev mode performance is smooth with 2000+ logs
- [ ] Error boundary text is selectable
- [ ] No "cannot use useAppStore before init" error on startup

Made with [Cursor](https://cursor.com)