### PR TITLE
chore(viewer3d): remove removed sRGBEncoding renderer option

### DIFF
--- a/src/components/viewer3d/Viewer3D.tsx
+++ b/src/components/viewer3d/Viewer3D.tsx
@@ -213,9 +213,6 @@ export default function RobotViewer3D({
             powerPreference: 'high-performance',
             toneMapping: THREE.ACESFilmicToneMapping,
             toneMappingExposure: 1.0,
-            // TODO(ts): `outputEncoding` / `sRGBEncoding` are deprecated in newer
-            // three.js typings but still honored at runtime. Keep 1:1 behavior.
-            outputEncoding: (THREE as unknown as { sRGBEncoding: unknown }).sRGBEncoding,
             stencil: false,
             depth: true,
             logarithmicDepthBuffer: false,


### PR DESCRIPTION
## What

Removes the `outputEncoding` renderer option from `Viewer3D.tsx`, along
with the TODO comment and the type cast around it.

## Why

`sRGBEncoding` / `outputEncoding` were removed from three.js long ago.
On three 0.181, `THREE.sRGBEncoding` resolves to `undefined`, so the
option was silently ignored — dead code. Since r152,
`outputColorSpace` already defaults to `SRGBColorSpace`, so no
replacement is needed. Rendering is identical before and after.

## Note

This PR originally claimed to fix a blank 3D viewer on Linux
(CachyOS/Arch). As pointed out in review, that cannot have been caused
by this line; the blank canvas was environmental (WebKitGTK rendering
on that setup). This change is therefore a cleanup only and should
**not** close #35.

Tested on CachyOS (Linux, webkit2gtk 4.1): viewer renders identically
with and without this change.