### PR TITLE
feat(wifi): WifiConnectingOverlay + back-to-connection flow

### DIFF
--- a/src/components/viewer3d/SettingsOverlay.tsx
+++ b/src/components/viewer3d/SettingsOverlay.tsx
@@ -18,6 +18,7 @@ import {
   SettingsCacheCard,
   SettingsDaemonCard,
   ChangeWifiOverlay,
+  WifiConnectingOverlay,
 } from './settings';
 import type { UpdateInfo } from './settings/SettingsUpdateCard';
 import type { WifiStatus } from './settings/SettingsWifiCard';
@@ -39,7 +40,7 @@ export default function SettingsOverlay({
   onClose,
   darkMode,
 }: SettingsOverlayProps): React.ReactElement {
-  const { connectionMode, remoteHost, blacklistRobot, resetAll, clearApps } = useAppStore();
+  const { connectionMode, remoteHost, resetAll, clearApps } = useAppStore();
   const isWifiMode = connectionMode === 'wifi';
 
   const safelyParkRobot = async (): Promise<boolean> => {
@@ -105,6 +106,10 @@ export default function SettingsOverlay({
 
   const [showUpdateConfirm, setShowUpdateConfirm] = useState<boolean>(false);
   const [showChangeWifiOverlay, setShowChangeWifiOverlay] = useState<boolean>(false);
+  // While the robot reconfigures WiFi, the app link drops for ~20s. During
+  // that window we show ``WifiConnectingOverlay`` and, on timeout, fall back
+  // to ``FindingRobotView`` via ``resetAll()``.
+  const [wifiConnectingTo, setWifiConnectingTo] = useState<string | null>(null);
   const [showClearNetworksConfirm, setShowClearNetworksConfirm] = useState<boolean>(false);
   const [isClearingNetworks, setIsClearingNetworks] = useState<boolean>(false);
   const [showResetAppsConfirm, setShowResetAppsConfirm] = useState<boolean>(false);
@@ -373,10 +378,6 @@ export default function SettingsOverlay({
       );
 
       if (response.ok) {
-        if (remoteHost) {
-          blacklistRobot(remoteHost, 10000);
-        }
-
         setShowClearNetworksConfirm(false);
         onClose();
 
@@ -393,7 +394,7 @@ export default function SettingsOverlay({
       showToast('Failed to clear networks', 'error');
       setIsClearingNetworks(false);
     }
-  }, [onClose, showToast, remoteHost, blacklistRobot, resetAll]);
+  }, [onClose, showToast, resetAll]);
 
   const handleResetAppsClick = useCallback((): void => {
     setShowResetAppsConfirm(true);
@@ -467,37 +468,46 @@ export default function SettingsOverlay({
     }
   }, [showToast, onClose, resetAll]);
 
-  const handleWifiConnect = useCallback(async (): Promise<void> => {
+  const handleWifiConnect = useCallback((): void => {
     if (!selectedSSID || !wifiPassword) return;
-    setIsConnecting(true);
+
+    const ssid = selectedSSID;
+    const password = wifiPassword;
+
+    // Close the credentials form and surface the transition modal immediately.
+    // The POST is fire-and-forget because the daemon's response is very likely
+    // to be cut short when the robot tears down the current connection to join
+    // the new SSID; we don't want to block the UI on a request that may never
+    // complete. See ``WifiConnectingOverlay`` for the UX rationale.
+    setShowChangeWifiOverlay(false);
+    setIsConnecting(false);
     setWifiError(null);
+    setWifiPassword('');
+    setSelectedSSID('');
+    setWifiConnectingTo(ssid);
 
-    try {
-      const response = await fetchWithTimeout(
-        buildApiUrl(
-          `/wifi/connect?ssid=${encodeURIComponent(selectedSSID)}&password=${encodeURIComponent(wifiPassword)}`
-        ),
-        { method: 'POST' },
-        DAEMON_CONFIG.TIMEOUTS.COMMAND * 3,
-        { label: 'WiFi connect' }
-      );
+    fetchWithTimeout(
+      buildApiUrl(
+        `/wifi/connect?ssid=${encodeURIComponent(ssid)}&password=${encodeURIComponent(password)}`
+      ),
+      { method: 'POST' },
+      DAEMON_CONFIG.TIMEOUTS.COMMAND,
+      { label: 'WiFi connect', silent: true }
+    ).catch(err => {
+      // Losing the link is expected (that's literally the point of the
+      // overlay), so we swallow network errors and rely on the countdown to
+      // hand the user back to the robot-selection screen.
+      console.debug('[SettingsOverlay] /wifi/connect request ended (expected):', err);
+    });
+  }, [selectedSSID, wifiPassword]);
 
-      if (response.ok) {
-        setShowChangeWifiOverlay(false);
-        setWifiPassword('');
-        setSelectedSSID('');
-        setTimeout(fetchWifiStatus, 5000);
-      } else {
-        const error = await response.json();
-        setWifiError(error.detail || 'Failed to connect');
-      }
-    } catch (err) {
-      console.error('Failed to connect to WiFi:', err);
-      setWifiError('Connection failed');
-    } finally {
-      setIsConnecting(false);
-    }
-  }, [selectedSSID, wifiPassword, fetchWifiStatus]);
+  const handleWifiConnectingTimeout = useCallback((): void => {
+    // Drop the WiFi transition overlay, close the settings modal and wipe the
+    // store so ``useViewRouter`` falls back to ``FindingRobotView``.
+    setWifiConnectingTo(null);
+    onClose();
+    setTimeout(() => resetAll(), 250);
+  }, [onClose, resetAll]);
 
   useEffect(() => {
     if (open) {
@@ -1317,6 +1327,13 @@ export default function SettingsOverlay({
         onPasswordChange={setWifiPassword}
         onConnect={handleWifiConnect}
         onRefresh={fetchWifiStatus}
+      />
+
+      <WifiConnectingOverlay
+        open={wifiConnectingTo !== null}
+        targetSsid={wifiConnectingTo ?? ''}
+        darkMode={darkMode}
+        onTimeout={handleWifiConnectingTimeout}
       />
 
       {isWifiMode && updateJobId && (

--- a/src/components/viewer3d/settings/WifiConnectingOverlay.tsx
+++ b/src/components/viewer3d/settings/WifiConnectingOverlay.tsx
@@ -1,0 +1,248 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { Box, Typography, LinearProgress } from '@mui/material';
+import WifiIcon from '@mui/icons-material/Wifi';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import FullscreenOverlay from '../../FullscreenOverlay';
+
+export interface WifiConnectingOverlayProps {
+  /** Controls visibility of the overlay. */
+  open: boolean;
+  /** SSID the robot is being reconfigured to join. Used for display only. */
+  targetSsid: string;
+  darkMode: boolean;
+  /**
+   * Total duration of the countdown, in seconds. Defaults to 20s which matches
+   * the typical time NetworkManager takes to tear down the current connection,
+   * associate with the new SSID, negotiate DHCP and let the daemon come back.
+   */
+  durationSeconds?: number;
+  /**
+   * Called once the countdown hits zero. The caller is expected to close the
+   * settings view and ``resetAll()`` the store so the app falls back to
+   * ``FindingRobotView`` (the Reachy selection screen).
+   */
+  onTimeout: () => void;
+}
+
+/**
+ * Full-screen modal shown while Reachy is reconfiguring its WiFi.
+ *
+ * UX goals:
+ *   - Tell the user the robot is **currently reconfiguring its network** and
+ *     the app link will drop for a short moment (~20s).
+ *   - Make it clear that a wrong password is not destructive: NetworkManager
+ *     will fall back to the previous known network on failure.
+ *   - After the countdown we return the user to the robot-selection screen
+ *     (owner handles that via ``onTimeout``).
+ *
+ * This component is purely presentational: it only owns the countdown timer.
+ * The actual POST to ``/wifi/connect`` and the ``resetAll()`` transition are
+ * driven by the caller (``SettingsOverlay``).
+ */
+export default function WifiConnectingOverlay({
+  open,
+  targetSsid,
+  darkMode,
+  durationSeconds = 20,
+  onTimeout,
+}: WifiConnectingOverlayProps): React.ReactElement {
+  const [remaining, setRemaining] = useState<number>(durationSeconds);
+  // Keep the latest ``onTimeout`` in a ref so the interval effect doesn't need
+  // the callback in its dependency list (would cause the interval to restart
+  // on every parent re-render and reset the countdown).
+  const onTimeoutRef = useRef(onTimeout);
+  useEffect(() => {
+    onTimeoutRef.current = onTimeout;
+  }, [onTimeout]);
+
+  useEffect(() => {
+    if (!open) {
+      setRemaining(durationSeconds);
+      return;
+    }
+
+    setRemaining(durationSeconds);
+    const startedAt = Date.now();
+    const interval = setInterval(() => {
+      const elapsed = Math.floor((Date.now() - startedAt) / 1000);
+      const next = Math.max(0, durationSeconds - elapsed);
+      setRemaining(next);
+      if (next === 0) {
+        clearInterval(interval);
+        onTimeoutRef.current();
+      }
+    }, 250);
+
+    return () => clearInterval(interval);
+  }, [open, durationSeconds]);
+
+  const progressPct = useMemo(() => {
+    if (durationSeconds <= 0) return 100;
+    return ((durationSeconds - remaining) / durationSeconds) * 100;
+  }, [durationSeconds, remaining]);
+
+  const textPrimary = darkMode ? '#f5f5f5' : '#222';
+  const textSecondary = darkMode ? '#aaa' : '#555';
+  const textMuted = darkMode ? '#888' : '#777';
+
+  return (
+    <FullscreenOverlay
+      open={open}
+      onClose={() => {
+        /* non-dismissable: user must wait for the countdown */
+      }}
+      darkMode={darkMode}
+      zIndex={10005}
+      backdropOpacity={0.92}
+      backdropBlur={16}
+      debugName="WifiConnecting"
+      showCloseButton={false}
+    >
+      <Box
+        sx={{
+          width: '100%',
+          maxWidth: 460,
+          mx: 'auto',
+          px: 3,
+          textAlign: 'center',
+        }}
+      >
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            mb: 2.5,
+          }}
+        >
+          <Box
+            sx={{
+              width: 72,
+              height: 72,
+              borderRadius: '50%',
+              bgcolor: darkMode ? 'rgba(255, 149, 0, 0.14)' : 'rgba(255, 149, 0, 0.1)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              position: 'relative',
+            }}
+          >
+            <WifiIcon
+              color="primary"
+              sx={{
+                fontSize: 36,
+                animation: 'wifiPulse 1.6s ease-in-out infinite',
+                '@keyframes wifiPulse': {
+                  '0%, 100%': { opacity: 0.55 },
+                  '50%': { opacity: 1 },
+                },
+              }}
+            />
+          </Box>
+        </Box>
+
+        <Typography
+          variant="h5"
+          sx={{
+            fontWeight: 700,
+            color: textPrimary,
+            mb: 1,
+            letterSpacing: '0.2px',
+          }}
+        >
+          Reconfiguring Reachy&apos;s WiFi
+        </Typography>
+
+        {targetSsid && (
+          <Typography
+            sx={{
+              fontSize: 13,
+              color: textSecondary,
+              mb: 3,
+            }}
+          >
+            Connecting to <strong style={{ color: textPrimary }}>{targetSsid}</strong>&hellip;
+          </Typography>
+        )}
+
+        <Box
+          sx={{
+            mb: 2.5,
+            px: 1,
+          }}
+        >
+          <LinearProgress
+            variant="determinate"
+            value={progressPct}
+            color="primary"
+            sx={{
+              height: 6,
+              borderRadius: 3,
+              bgcolor: darkMode ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)',
+              '& .MuiLinearProgress-bar': {
+                borderRadius: 3,
+                transition: 'transform 0.25s linear',
+              },
+            }}
+          />
+          <Typography
+            sx={{
+              mt: 1,
+              fontSize: 12,
+              color: textMuted,
+              fontVariantNumeric: 'tabular-nums',
+            }}
+          >
+            Returning to robot selection in {remaining}s&hellip;
+          </Typography>
+        </Box>
+
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'flex-start',
+            gap: 1.25,
+            textAlign: 'left',
+            p: 2,
+            borderRadius: '12px',
+            bgcolor: darkMode ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.03)',
+            border: `1px solid ${darkMode ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)'}`,
+            mb: 1.5,
+          }}
+        >
+          <InfoOutlinedIcon
+            color="primary"
+            sx={{
+              fontSize: 18,
+              mt: '2px',
+              flexShrink: 0,
+            }}
+          />
+          <Typography
+            sx={{
+              fontSize: 12.5,
+              color: textSecondary,
+              lineHeight: 1.6,
+            }}
+          >
+            Reachy is switching networks, so the app will lose its link for about{' '}
+            {durationSeconds} seconds. You&apos;ll then be taken back to the robot selection
+            screen to reconnect.
+          </Typography>
+        </Box>
+
+        <Typography
+          sx={{
+            fontSize: 11.5,
+            color: textMuted,
+            lineHeight: 1.6,
+            px: 0.5,
+          }}
+        >
+          If the password is wrong, Reachy will automatically fall back to its previous network -
+          nothing is lost, you can just try again from the selection screen.
+        </Typography>
+      </Box>
+    </FullscreenOverlay>
+  );
+}

--- a/src/components/viewer3d/settings/index.ts
+++ b/src/components/viewer3d/settings/index.ts
@@ -6,3 +6,4 @@ export { default as SettingsCacheCard } from './SettingsCacheCard';
 export { default as SettingsDaemonCard } from './SettingsDaemonCard';
 export { default as SettingsResetCard } from './SettingsResetCard';
 export { default as ChangeWifiOverlay } from './ChangeWifiOverlay';
+export { default as WifiConnectingOverlay } from './WifiConnectingOverlay';

--- a/src/views/active-robot/ActiveRobotView.tsx
+++ b/src/views/active-robot/ActiveRobotView.tsx
@@ -44,7 +44,6 @@ const Viewer3D = Viewer3DUntyped as unknown as React.FC<{
 }>;
 const LogConsole = LogConsoleUntyped as unknown as React.FC<{
   logs?: unknown;
-  remoteLogs?: unknown;
   darkMode?: boolean;
   maxHeight?: number | string;
   height?: number | string;
@@ -239,13 +238,16 @@ function ActiveRobotView({
   // Logs fullscreen modal
   const [logsFullscreenOpen, setLogsFullscreenOpen] = useState<boolean>(false);
 
-  // Remote daemon log stream (WiFi mode only)
+  // Remote daemon log stream (WiFi mode only).
+  // Side-effect hook: pushes incoming lines into `state.logs`, so every
+  // surface (LogConsole, standalone LogViewerWindow via windowSync) sees them
+  // without needing its own WebSocket.
   const logMode = useAppStore((s: FullAppState) => (s as { logMode?: string }).logMode as string);
   const remoteCategories = useMemo<DaemonLogSource[]>(
     () => (logMode === 'dev' ? ['daemon', 'app', 'api'] : ['daemon']),
     [logMode]
   );
-  const remoteLogs = useDaemonLogStream(remoteCategories);
+  useDaemonLogStream(remoteCategories);
 
   // Audio controls - Extracted to hook
   const {
@@ -262,7 +264,7 @@ function ActiveRobotView({
     handleMicrophoneMute,
   } = useAudioControls(isActive);
 
-  // Apps and robot position are pre-loaded during HardwareScanView + wake-up sequence.
+  // Apps and robot position are pre-loaded during StartupScanView + wake-up sequence.
   // The "Preparing robot..." overlay only shows if position data isn't ready yet.
   const hasHeadJoints =
     robotStateFull?.data?.head_joints &&
@@ -348,16 +350,21 @@ function ActiveRobotView({
   // Quick Actions: Curated mix of emotions, dances, and actions (no redundancy)
   const quickActions = QUICK_ACTIONS;
 
-  const handleRestartDaemon = useCallback(async (): Promise<void> => {
+  const handleBackToConnection = useCallback((): void => {
+    // Leave the "daemon crashed" overlay and return to ``FindingRobotView``.
+    // ``resetAll()`` wipes ``connectionMode`` (so ``useViewRouter`` falls back
+    // to the connection screen) and resets ``isDaemonCrashed`` via
+    // ``buildDerivedState(DISCONNECTED)`` (so the overlay closes).
     resetTimeouts();
-    try {
-      await stopDaemon();
-      setTimeout(() => {
-        window.location.reload();
-      }, 2000);
-    } catch {
-      window.location.reload();
-    }
+
+    // Best-effort daemon stop: fire-and-forget so the UI transitions instantly.
+    // If the daemon has genuinely crashed, ``stopDaemon`` will time out and we
+    // don't want to keep the user staring at the overlay while that happens.
+    Promise.resolve(stopDaemon()).catch(() => {
+      /* best effort */
+    });
+
+    useAppStore.getState().resetAll();
   }, [resetTimeouts, stopDaemon]);
 
   return (
@@ -428,11 +435,11 @@ function ActiveRobotView({
               power, the network dropped, or the daemon crashed.
             </Typography>
 
-            {/* Restart button */}
+            {/* Back-to-connection button */}
             <Button
               variant="outlined"
               color="primary"
-              onClick={handleRestartDaemon}
+              onClick={handleBackToConnection}
               sx={{
                 fontWeight: 600,
                 fontSize: 13,
@@ -442,7 +449,7 @@ function ActiveRobotView({
                 textTransform: 'none',
               }}
             >
-              Restart
+              Back to connection
             </Button>
           </Box>
         </FullscreenOverlay>
@@ -608,7 +615,6 @@ function ActiveRobotView({
               >
                 <LogConsole
                   logs={logs}
-                  remoteLogs={remoteLogs}
                   darkMode={darkMode}
                   maxHeight={120}
                   compact={true}
@@ -672,13 +678,7 @@ function ActiveRobotView({
               }}
             >
               <Box sx={{ flex: 1, minHeight: 0, overflow: 'hidden' }}>
-                <LogConsole
-                  logs={logs}
-                  remoteLogs={remoteLogs}
-                  darkMode={darkMode}
-                  height="100%"
-                  fullSize={true}
-                />
+                <LogConsole logs={logs} darkMode={darkMode} height="100%" fullSize={true} />
               </Box>
             </Box>
           )}


### PR DESCRIPTION
## Summary

UX improvements around the WiFi reconfiguration flow and the daemon-crash overlay.

- **New \`WifiConnectingOverlay\`**: full-screen modal shown when the user triggers a WiFi switch from settings. Displays a 20s countdown, explains that the link will drop, and reassures that an invalid password makes the robot fall back to its previous network.
- **\`SettingsOverlay\`**: the \`/wifi/connect\` request is now fire-and-forget (losing the link is the expected outcome). On timeout we \`onClose()\` and \`resetAll()\` so \`useViewRouter\` lands back on \`FindingRobotView\`.
- **\`ActiveRobotView\`**: the daemon-crash overlay's \"Restart\" button becomes \"Back to connection\". It stops the daemon best-effort and resets the store, instead of reloading the whole window.

## Base / stacking

Based on \`chore/typescript-migration-setup\` and depends on #258. After #258 merges, I'll retarget this PR to \`develop\`.

## Test plan

- [ ] Open settings > Change network > pick SSID > enter password > \"Connect\": overlay appears, countdown runs, app returns to \`FindingRobotView\` after 20s.
- [ ] With a wrong password: robot reverts to previous SSID, app still lands on \`FindingRobotView\` at countdown end (no crash).
- [ ] Kill the daemon while on \`ActiveRobotView\`: the "daemon crashed" overlay shows a \"Back to connection\" button that returns to \`FindingRobotView\` without a full reload.

Made with [Cursor](https://cursor.com)