### PR TITLE
Feat/Fix: re-embed app on pop-out window close and prevent duplicate app view

### DIFF
--- a/src/utils/windowManager.ts
+++ b/src/utils/windowManager.ts
@@ -169,7 +169,16 @@ export async function openAppWindow(
     });
 
     void win.once('tauri://error', () => purge(label));
-    void win.once('tauri://destroyed', () => purge(label));
+    void win.once('tauri://destroyed', () => {
+      if (useAppStore.getState().currentApp) {
+        try {
+          useAppStore.getState().openEmbeddedApp?.(url);
+        } catch {
+          // Store may be unavailable
+        }
+      }
+      purge(label);
+    });
 
     return win;
   } catch {

--- a/src/views/active-robot/application-store/installed/InstalledAppsSection.tsx
+++ b/src/views/active-robot/application-store/installed/InstalledAppsSection.tsx
@@ -274,12 +274,14 @@ interface OpenAppButtonProps {
   customAppUrl?: string;
   isStartingOrRunning: boolean;
   isRunning: boolean;
+  isPoppedOut?: boolean;
   onTimeout?: () => void;
 }
 
 function OpenAppButton({
   customAppUrl,
   isStartingOrRunning,
+  isPoppedOut,
   onTimeout,
 }: OpenAppButtonProps): React.ReactElement | null {
   const palette = useAppPalette();
@@ -350,6 +352,8 @@ function OpenAppButton({
       console.error('Failed to open app web interface:', err);
     }
   };
+
+  if (isPoppedOut) return null;
 
   const isGhostMode = isChecking && !isAccessible;
 
@@ -453,7 +457,10 @@ export default function InstalledAppsSection({
   onOpenCreateTutorial,
 }: InstalledAppsSectionProps): React.ReactElement {
   const palette = useAppPalette();
-  const { robotStatus } = useAppStore() as unknown as { robotStatus: string };
+  const { robotStatus, openWindows } = useAppStore() as unknown as {
+    robotStatus: string;
+    openWindows: string[];
+  };
   const isSleeping = robotStatus === 'sleeping';
 
   const [menuAnchorEl, setMenuAnchorEl] = useState<HTMLElement | null>(null);
@@ -583,6 +590,9 @@ export default function InstalledAppsSection({
               const isStartingOrRunning = isStarting || isCurrentlyRunning;
 
               const author = app.extra?.id?.split('/')?.[0] || app.extra?.author || null;
+              const isPoppedOut = openWindows.includes(
+                'app-' + app.name.replace(/[^a-zA-Z0-9_-]/g, '-').toLowerCase()
+              );
 
               const isMenuOpen = menuAppName === app.name;
 
@@ -773,6 +783,20 @@ export default function InstalledAppsSection({
                           }
                           return null;
                         })()}
+
+                        {isPoppedOut && (
+                          <Typography
+                            sx={{
+                              fontSize: TYPO.micro,
+                              fontWeight: FONT_WEIGHT.medium,
+                              color: palette.textMuted,
+                              fontStyle: 'italic',
+                              letterSpacing: '0.2px',
+                            }}
+                          >
+                            Viewing in separate window
+                          </Typography>
+                        )}
                       </Box>
                     </Box>
 
@@ -854,6 +878,7 @@ export default function InstalledAppsSection({
                         customAppUrl={app.extra?.custom_app_url}
                         isStartingOrRunning={isStartingOrRunning}
                         isRunning={isCurrentlyRunning}
+                        isPoppedOut={isPoppedOut}
                         onTimeout={() => {
                           console.error(`[${app.name}] Web interface timeout - stopping app`);
                           if (isThisAppCurrent) {


### PR DESCRIPTION
- Fixes issue #263 
- When the pop-out window is closed by the user while the app is still running, the app is automatically re-embedded into the right panel.
- When the pop-out window is opened, the open button is replaced by "Viewing in separate window" text. This will prevent users clicking "Open" button again and open a duplicate view of the same app.

Now when user pops out the window the app card looks like: 
<img width="1512" height="682" alt="screenshot3" src="https://github.com/user-attachments/assets/8416b521-e3d0-4b8d-b35d-98d5cef3f158" />

Note: tested on simulation + MacOS
Note: I did not remove the "Open" button codes from the project file but I believe that is now redundant. I'm not sure if there can be another use case for that button or if its still needed.