### PR TITLE
chore(release): pin reachy-mini daemon to 1.7.1 in release pipeline

### DIFF
--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -44,6 +44,19 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    env:
+      # Pin the reachy-mini daemon version baked into the uv-trampoline
+      # sidecar at build time. The trampoline reads this via
+      # `option_env!("REACHY_MINI_VERSION")` (uv-wrapper/src/lib.rs) and
+      # builds a `reachy-mini==<version>` install spec, so end users
+      # consistently get this exact daemon version on first launch
+      # regardless of what is currently latest on PyPI.
+      #
+      # Bump deliberately when a new daemon release has been validated
+      # against the desktop app's UI (incl. fields like DaemonStatus
+      # exposed via the WS / HTTP API).
+      REACHY_MINI_VERSION: 1.7.1
+
     steps:
       - name: Dry run mode notification
         if: github.event.inputs.dry_run == 'true'

--- a/uv-wrapper/build.rs
+++ b/uv-wrapper/build.rs
@@ -1,0 +1,13 @@
+//! Tell cargo to rebuild the trampoline whenever the env vars consumed by
+//! `option_env!()` in `get_reachy_mini_spec()` change. Without this, cargo's
+//! incremental cache happily serves a stale binary that still bakes in the
+//! previous branch, and you end up debugging a "wrong daemon version is
+//! installed" bug for an hour.
+//!
+//! Also tracks `REACHY_MINI_PATCH_VERSION` for parity with the desktop
+//! app's release pipeline.
+fn main() {
+    println!("cargo:rerun-if-env-changed=REACHY_MINI_SOURCE");
+    println!("cargo:rerun-if-env-changed=REACHY_MINI_VERSION");
+    println!("cargo:rerun-if-env-changed=REACHY_MINI_PATCH_VERSION");
+}


### PR DESCRIPTION
## Why

Today the release workflow does **not** pass any version hint to \`uv-trampoline\`. As a result, \`get_reachy_mini_spec()\` falls through to \`\"reachy-mini\"\` (latest from PyPI), so the daemon version a user gets on first launch depends on the date they install the desktop app, not on the desktop app version we ship.

That's exactly the kind of skew that just produced issue #266 (\`'DaemonStatus' object is not subscriptable\` raised by a mismatched daemon against a v0.9.29 desktop app).

## What

Two changes that together make the pin watertight:

### 1. Set \`REACHY_MINI_VERSION\` at job level in \`release-unified.yml\`

The uv-trampoline reads this env var via \`option_env!(\"REACHY_MINI_VERSION\")\` at *compile time* (\`uv-wrapper/src/lib.rs\`, \`get_reachy_mini_spec()\`), and produces a \`reachy-mini==1.7.1\` install spec. Dev builds (\`yarn tauri:dev\`) are untouched: they don't go through this workflow, so contributors keep installing whatever they want locally.

### 2. Add \`uv-wrapper/build.rs\`

Three \`cargo:rerun-if-env-changed\` directives for \`REACHY_MINI_SOURCE\`, \`REACHY_MINI_VERSION\` and \`REACHY_MINI_PATCH_VERSION\`. Without this, cargo's incremental cache happily serves a stale \`uv-trampoline\` binary that still bakes in a previous version, **silently** neutralizing the pin (you'd ship 1.7.1 in the workflow YAML but \`reachy-mini\` latest in the actual MSI / DMG / DEB).

This file was already in my working tree but never committed. It's tightly coupled to the pinning, so it ships in the same PR.

## How to bump in the future

Bump the value in \`release-unified.yml\` the moment a new \`reachy-mini\` release has been validated against the desktop app's API expectations (DaemonStatus over WS / HTTP, /api/daemon/status, etc.). The bump shows up in PR review, so it's an explicit decision rather than a side effect of a PyPI publish from another team.

## Test plan

- [ ] Trigger a workflow_dispatch dry run with \`version=0.9.30\` on this branch. The 4 platforms should produce installers, and the contained \`uv-trampoline\` should bake \`reachy-mini==1.7.1\` (verifiable by running it once and looking at the \`pip install\` line in the bootstrap log).

## Made-with: Cursor

Made with [Cursor](https://cursor.com)