### PR TITLE
feat(dances): add Anne-Charlotte music dances library

### DIFF
--- a/src/components/emoji-grid/EmojiPicker.tsx
+++ b/src/components/emoji-grid/EmojiPicker.tsx
@@ -5,6 +5,7 @@ import {
   EMOTION_EMOJIS,
   WHEEL_EMOTIONS,
   labelFromActionName,
+  labelFromDanceName,
   type EmojiGridAction,
 } from '@constants/choreographies';
 
@@ -40,7 +41,7 @@ function buildEmotionItem(name: string): EmojiGridItem & { name: string } {
 }
 
 function buildDanceItem(name: string): EmojiGridItem & { name: string } {
-  const label = name.replace(/_/g, ' ');
+  const label = labelFromDanceName(name);
   return {
     name,
     emoji: (DANCE_EMOJIS as Record<string, string>)[name] ?? FALLBACK_DANCE_EMOJI,

--- a/src/constants/choreographies.ts
+++ b/src/constants/choreographies.ts
@@ -10,12 +10,15 @@
 export const CHOREOGRAPHY_DATASETS = {
   DANCES: 'pollen-robotics/reachy-mini-dances-library',
   EMOTIONS: 'pollen-robotics/reachy-mini-emotions-library',
+  // Community-contributed music choreographies recorded with Marionette.
+  // Played through the same /api/move/play/recorded-move-dataset endpoint.
+  MUSIC: 'Anne-Charlotte/music',
 } as const;
 
 export type ChoreographyDataset =
   (typeof CHOREOGRAPHY_DATASETS)[keyof typeof CHOREOGRAPHY_DATASETS];
 
-export const DANCES = [
+const POLLEN_DANCES = [
   'stumble_and_recover',
   'chin_lead',
   'head_tilt_roll',
@@ -38,7 +41,38 @@ export const DANCES = [
   'sharp_side_tilt',
 ] as const;
 
+const MUSIC_DANCES = [
+  'beyonce-single-ladies',
+  'demon-hunters-1',
+  'eagles-hotel-california',
+  'eminem-lose-yourself',
+  'feel-the-magic-in-the-air',
+  'katy-perry-fireworks',
+  'las-ketchup',
+  'michael-jackson-thriller',
+  'paint-it-black',
+  'pharrell-williams-happy',
+  'queen-we-will-rock-you',
+  'spice-girls',
+  'the-fratellis-whistle-for-the-choir',
+  'the-white-stripes-seven-nation-army',
+] as const;
+
+export const DANCES = [...POLLEN_DANCES, ...MUSIC_DANCES] as const;
+
 export type DanceName = (typeof DANCES)[number];
+
+const MUSIC_DANCE_SET: ReadonlySet<string> = new Set<string>(MUSIC_DANCES);
+
+/**
+ * Resolve which Hugging Face dataset hosts a given dance name.
+ * Pollen-robotics dances live in the official library; Anne-Charlotte's
+ * music dances live in a separate community dataset but are surfaced in
+ * the same "Dances" UI section.
+ */
+export function getDanceDataset(name: string): ChoreographyDataset {
+  return MUSIC_DANCE_SET.has(name) ? CHOREOGRAPHY_DATASETS.MUSIC : CHOREOGRAPHY_DATASETS.DANCES;
+}
 
 // Complete list of all available emotions in the library
 export const EMOTIONS = [
@@ -294,6 +328,21 @@ export const DANCE_EMOJIS: Record<DanceName, string> = {
   neck_recoil: '⚡', // Quick electric snap
   groovy_sway_and_roll: '🪩', // Disco ball groove
   sharp_side_tilt: '📐', // Sharp angle
+  // Anne-Charlotte's music choreographies
+  'beyonce-single-ladies': '💍', // Single Ladies, put a ring on it
+  'demon-hunters-1': '👹', // Demon Hunters
+  'eagles-hotel-california': '🌴', // Hotel California, palm-tree vibe
+  'eminem-lose-yourself': '🎤', // Lose Yourself, mic drop
+  'feel-the-magic-in-the-air': '✨', // Magic in the Air
+  'katy-perry-fireworks': '🎆', // Firework
+  'las-ketchup': '🍅', // Las Ketchup, tomato pun
+  'michael-jackson-thriller': '🧟', // Thriller
+  'paint-it-black': '🖤', // Paint It Black
+  'pharrell-williams-happy': '😀', // Happy
+  'queen-we-will-rock-you': '👑', // Queen, We Will Rock You
+  'spice-girls': '🎀', // Spice Girls
+  'the-fratellis-whistle-for-the-choir': '🎻', // Whistle for the Choir
+  'the-white-stripes-seven-nation-army': '⚔️', // Seven Nation Army
 };
 
 export type QuickActionType = 'emotion' | 'dance' | 'action';
@@ -335,12 +384,21 @@ export const WHEEL_EMOTIONS: readonly EmotionName[] = [
 ];
 
 /**
- * Derive a display label from a raw action name.
- * Example: `loving1` -> `loving`, `head_tilt_roll` -> `head tilt roll`.
- * Used by components that only receive a `name` and need to render a label.
+ * Derive a display label from an emotion name.
+ * Example: `loving1` -> `loving`, `proud3` -> `proud`.
+ * Used for emotion items only; dances and music use {@link labelFromDanceName}.
  */
 export function labelFromActionName(name: string): string {
   return name.replace(/[0-9]+$/, '').replace(/_/g, ' ');
+}
+
+/**
+ * Derive a display label from a dance name (supports both pollen-robotics
+ * snake_case names and Anne-Charlotte's hyphen-separated music names).
+ * Example: `head_tilt_roll` -> `head tilt roll`, `paint-it-black` -> `paint it black`.
+ */
+export function labelFromDanceName(name: string): string {
+  return name.replace(/[-_]/g, ' ');
 }
 
 /**

--- a/src/views/active-robot/ActiveRobotView.tsx
+++ b/src/views/active-robot/ActiveRobotView.tsx
@@ -58,6 +58,7 @@ import { useActiveRobotContext } from './context';
 import {
   CHOREOGRAPHY_DATASETS,
   QUICK_ACTIONS,
+  getDanceDataset,
   type QuickAction,
 } from '../../constants/choreographies';
 import { WebRTCStreamProvider } from '../../contexts/WebRTCStreamContext';
@@ -321,7 +322,7 @@ function ActiveRobotView({
       if (action.type === 'action') {
         sendCommand(`/api/move/play/${action.name}`, action.label);
       } else if (action.type === 'dance') {
-        playRecordedMove(CHOREOGRAPHY_DATASETS.DANCES, action.name);
+        playRecordedMove(getDanceDataset(action.name), action.name);
       } else {
         playRecordedMove(CHOREOGRAPHY_DATASETS.EMOTIONS, action.name);
       }

--- a/src/views/active-robot/right-panel/expressions/ExpressionsSection.tsx
+++ b/src/views/active-robot/right-panel/expressions/ExpressionsSection.tsx
@@ -11,6 +11,7 @@ import {
   EMOTION_EFFECT_MAP,
   EMOTIONS,
   DANCES,
+  getDanceDataset,
   type EmojiGridAction,
 } from '@constants/choreographies';
 import { useRobotCommands } from '@hooks/robot';
@@ -120,7 +121,7 @@ export default function ExpressionsSection({
       telemetry.expressionPlayed({ name: action.name, type: action.type });
 
       const dataset =
-        action.type === 'dance' ? CHOREOGRAPHY_DATASETS.DANCES : CHOREOGRAPHY_DATASETS.EMOTIONS;
+        action.type === 'dance' ? getDanceDataset(action.name) : CHOREOGRAPHY_DATASETS.EMOTIONS;
       playRecordedMove(dataset, action.name);
 
       const effectType = EMOTION_EFFECT_MAP[action.name];


### PR DESCRIPTION
## Summary

Add support for the community-contributed music dances dataset (\`Anne-Charlotte/music\`) alongside the existing \`pollen-robotics/reachy-mini-dances-library\`. Music dances appear in the same Dances UI section as the official ones, but playback dispatches to the right Hugging Face dataset at runtime.

## What changed

- \`CHOREOGRAPHY_DATASETS.MUSIC\` for the community dataset
- \`DANCES\` is now the union of \`POLLEN_DANCES + MUSIC_DANCES\` so consumers iterate over a single name list as before
- \`getDanceDataset(name)\` routes a dance name to the dataset that hosts it
- Emoji metadata for the 14 music dances (Beyonce Single Ladies, MJ Thriller, Queen, Spice Girls, Eminem Lose Yourself, etc.)
- \`labelFromDanceName()\` displays hyphen-separated music names cleanly (\`paint-it-black\` -> \`paint it black\`); \`labelFromActionName()\` is now scoped to emotion items only
- \`getDanceDataset()\` wired into ActiveRobotView quick actions, ExpressionsSection playback, and EmojiPicker labels

## Test plan

- [ ] Open the Expressions panel, switch to the Dances tab → see Pollen dances + 14 music dances with their emojis
- [ ] Play a Pollen dance (e.g. \`head_tilt_roll\`) → still works (routes to pollen-robotics dataset)
- [ ] Play a music dance (e.g. \`michael-jackson-thriller\`) → robot plays the move (routes to Anne-Charlotte/music)
- [ ] Music dance labels render with spaces, no kebab dashes leaking into the UI

Made-with: Cursor

Made with [Cursor](https://cursor.com)