### PR TITLE
release: wireless daemon update gate + daemon 1.8.0 alignment

### DIFF
--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -52,10 +52,17 @@ jobs:
       # consistently get this exact daemon version on first launch
       # regardless of what is currently latest on PyPI.
       #
+      # Scope: this ONLY affects the daemon bundled with the app, i.e.
+      # Reachy Mini Lite (USB) and Simulation, where the daemon ships with
+      # the desktop app and is upgraded whenever the app updates. It does
+      # NOT affect Reachy Mini Wireless: there the daemon runs on the robot
+      # and updates independently via PyPI, gated client-side by
+      # `MIN_WIRELESS_DAEMON_VERSION` (src/constants/daemonVersion.ts).
+      #
       # Bump deliberately when a new daemon release has been validated
       # against the desktop app's UI (incl. fields like DaemonStatus
       # exposed via the WS / HTTP API).
-      REACHY_MINI_VERSION: 1.7.1
+      REACHY_MINI_VERSION: 1.8.0
 
     steps:
       - name: Dry run mode notification

--- a/src/constants/daemonVersion.ts
+++ b/src/constants/daemonVersion.ts
@@ -15,22 +15,25 @@
  *
  * # Bumping policy
  *
- * Bump this constant only when the desktop app starts depending on a daemon
- * API/behaviour that older daemons don't expose. Each bump should:
+ * We deliberately keep this floor ALIGNED with the daemon version bundled
+ * for Lite/Simulation (`REACHY_MINI_VERSION` in
+ * `.github/workflows/release-unified.yml`), so every platform converges on
+ * the same daemon: a release that ships daemon X for Lite/sim also requires
+ * X on Wireless. The trade-off is explicit - wireless robots older than X
+ * are forced to update on first connect, even if they would technically
+ * still work. Each bump should:
  *
- * 1. Reference the PR / commit that introduced the dependency.
- * 2. Be tagged in `MIN_WIRELESS_DAEMON_VERSION_REASON` so we can show users
+ * 1. Move in lockstep with `REACHY_MINI_VERSION` in the release workflow.
+ * 2. Reference the PR / commit that introduced the dependency.
+ * 3. Be tagged in `MIN_WIRELESS_DAEMON_VERSION_REASON` so we can show users
  *    a meaningful "why" in the update view.
- * 3. Be conservative: prefer the oldest version that ships the dependency
- *    rather than "the latest at release time" - users who just ran an
- *    update yesterday should not be forced to update again the next day.
  */
 
-export const MIN_WIRELESS_DAEMON_VERSION = '1.7.1';
+export const MIN_WIRELESS_DAEMON_VERSION = '1.8.0';
 
 /**
  * Short, user-facing rationale shown in the update view subtitle.
  * Keep it under one sentence: the dialog already gives the version numbers.
  */
 export const MIN_WIRELESS_DAEMON_VERSION_REASON =
-  'This version of the desktop app requires daemon features introduced in v1.7.1.';
+  'This version of the desktop app requires daemon v1.8.0 or newer.';

--- a/src/constants/daemonVersion.ts
+++ b/src/constants/daemonVersion.ts
@@ -1,0 +1,36 @@
+/**
+ * Minimum daemon version required by the desktop app.
+ *
+ * Why this gate exists:
+ * - On Reachy Mini Lite (USB) and Simulation, the daemon is bundled with the
+ *   app and gets updated automatically every time the app updates.
+ * - On Reachy Mini Wireless, the daemon runs ON the robot (RPi) and is
+ *   updated independently via PyPI. Users routinely run the latest desktop
+ *   app against a daemon that is several months old, which causes silent
+ *   API mismatches and confusing bug reports.
+ *
+ * When the wireless daemon is older than this constant, we present a
+ * blocking but bienveillant `WirelessUpdateRequiredView` that drives the
+ * built-in `/update/start` endpoint of the daemon to bring it up to par.
+ *
+ * # Bumping policy
+ *
+ * Bump this constant only when the desktop app starts depending on a daemon
+ * API/behaviour that older daemons don't expose. Each bump should:
+ *
+ * 1. Reference the PR / commit that introduced the dependency.
+ * 2. Be tagged in `MIN_WIRELESS_DAEMON_VERSION_REASON` so we can show users
+ *    a meaningful "why" in the update view.
+ * 3. Be conservative: prefer the oldest version that ships the dependency
+ *    rather than "the latest at release time" - users who just ran an
+ *    update yesterday should not be forced to update again the next day.
+ */
+
+export const MIN_WIRELESS_DAEMON_VERSION = '1.7.1';
+
+/**
+ * Short, user-facing rationale shown in the update view subtitle.
+ * Keep it under one sentence: the dialog already gives the version numbers.
+ */
+export const MIN_WIRELESS_DAEMON_VERSION_REASON =
+  'This version of the desktop app requires daemon features introduced in v1.7.1.';

--- a/src/hooks/daemon/index.ts
+++ b/src/hooks/daemon/index.ts
@@ -11,3 +11,5 @@ export type {
   UseExternalDaemonProbeOptions,
   UseExternalDaemonProbeResult,
 } from './useExternalDaemonProbe';
+export { useWirelessDaemonUpdate } from './useWirelessDaemonUpdate';
+export type { UseWirelessDaemonUpdateResult } from './useWirelessDaemonUpdate';

--- a/src/hooks/daemon/useWirelessDaemonUpdate.ts
+++ b/src/hooks/daemon/useWirelessDaemonUpdate.ts
@@ -1,0 +1,340 @@
+/**
+ * useWirelessDaemonUpdate
+ *
+ * Orchestrates the forced wireless-daemon update flow against a remote host:
+ *
+ *   1. Pre-check: confirm the daemon can talk to PyPI (`GET /update/available`).
+ *      If it can't, fail fast with a clear "no internet on the robot" error
+ *      rather than starting a download that will time out two minutes later.
+ *   2. Trigger:   `POST /update/start` to spawn a background install job.
+ *   3. Stream:    open `WS /update/ws/logs?job_id=...` and forward every line
+ *                 into the slice's log buffer.
+ *   4. Restart:   the daemon ends the update by `systemctl restart`, which
+ *                 closes the WS. Poll `/api/daemon/status` until it answers
+ *                 again (budget = `RESTART_BUDGET_MS`, ~60s).
+ *   5. Verify:    re-read the version from `/api/daemon/status` and confirm
+ *                 it's now ≥ `MIN_WIRELESS_DAEMON_VERSION`. If not (PyPI
+ *                 itself is stale, install rolled back, ...), surface a clear
+ *                 error so the user can retry or cancel.
+ *
+ * The hook is intentionally not a singleton: it's mounted by the dedicated
+ * view, which guarantees a single in-flight job at a time. All cleanup
+ * (timers, WebSocket, AbortController) happens on unmount or when the user
+ * cancels.
+ *
+ * Talks to the remote host directly (port 8000). Bypasses the local proxy
+ * because at this point we haven't called `connect(WIFI, host)` yet, so
+ * the proxy isn't bound to anything.
+ */
+
+import { useCallback, useEffect, useRef } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import useAppStore from '../../store/useAppStore';
+import { fetchWithTimeout } from '../../config/daemon';
+import { isVersionBelow } from '../../utils/semverCompare';
+import type { FullAppState } from '../../store/useStore';
+
+// ---------------------------------------------------------------------------
+// Tuning knobs
+// ---------------------------------------------------------------------------
+
+const PRECHECK_TIMEOUT_MS = 8000;
+const START_TIMEOUT_MS = 8000;
+const STATUS_TIMEOUT_MS = 3000;
+/** Budget for the daemon to come back after `systemctl restart`. */
+const RESTART_BUDGET_MS = 60_000;
+/** How often we poll `/api/daemon/status` while waiting for the restart. */
+const RESTART_POLL_INTERVAL_MS = 2000;
+/** How long we wait BEFORE the first poll, to let `systemctl` actually stop. */
+const RESTART_GRACE_MS = 1500;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface AvailableResponse {
+  update?: {
+    reachy_mini?: {
+      is_available?: boolean;
+      current_version?: string;
+      available_version?: string;
+    };
+  };
+}
+
+interface StartResponse {
+  job_id?: string;
+}
+
+interface StatusResponse {
+  state?: string;
+  status?: string;
+  version?: string;
+  [key: string]: unknown;
+}
+
+export interface UseWirelessDaemonUpdateResult {
+  /**
+   * Kick off the full update sequence. Safe to call multiple times: a no-op
+   * if a job is already in flight (status !== 'idle' && !== 'error').
+   */
+  startUpdate: () => Promise<void>;
+  /**
+   * Pre-check only: ping the daemon to confirm it can reach PyPI. Used by
+   * the view to disable the "Update now" button when there's no internet
+   * on the robot, without committing to the full flow.
+   */
+  checkInternet: () => Promise<{ ok: boolean; reason?: string }>;
+}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+function normalizeBase(host: string): string {
+  const trimmed = host
+    .trim()
+    .replace(/^https?:\/\//, '')
+    .replace(/\/$/, '');
+  const withPort = trimmed.includes(':') ? trimmed : `${trimmed}:8000`;
+  return `http://${withPort}`;
+}
+
+function wsBase(host: string): string {
+  const trimmed = host
+    .trim()
+    .replace(/^https?:\/\//, '')
+    .replace(/\/$/, '');
+  const withPort = trimmed.includes(':') ? trimmed : `${trimmed}:8000`;
+  return `ws://${withPort}`;
+}
+
+export function useWirelessDaemonUpdate(): UseWirelessDaemonUpdateResult {
+  const {
+    wirelessUpdate,
+    setWirelessUpdateStatus,
+    setWirelessUpdateJobId,
+    appendWirelessUpdateLog,
+    setWirelessUpdateError,
+    markWirelessUpdateSucceeded,
+  } = useAppStore(
+    useShallow((state: FullAppState) => ({
+      wirelessUpdate: state.wirelessUpdate,
+      setWirelessUpdateStatus: state.setWirelessUpdateStatus,
+      setWirelessUpdateJobId: state.setWirelessUpdateJobId,
+      appendWirelessUpdateLog: state.appendWirelessUpdateLog,
+      setWirelessUpdateError: state.setWirelessUpdateError,
+      markWirelessUpdateSucceeded: state.markWirelessUpdateSucceeded,
+    }))
+  );
+
+  // Refs for cleanup. We intentionally keep them outside React state because
+  // they don't drive renders and we want unmount to abort cleanly even if
+  // the slice has already been reset.
+  const wsRef = useRef<WebSocket | null>(null);
+  const restartTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const cancelControllerRef = useRef<AbortController | null>(null);
+
+  // Cleanup on unmount: kill the WS, abort any in-flight HTTP, clear timers.
+  useEffect(() => {
+    return () => {
+      wsRef.current?.close();
+      wsRef.current = null;
+      if (restartTimerRef.current) {
+        clearTimeout(restartTimerRef.current);
+        restartTimerRef.current = null;
+      }
+      cancelControllerRef.current?.abort();
+      cancelControllerRef.current = null;
+    };
+  }, []);
+
+  const checkInternet = useCallback<UseWirelessDaemonUpdateResult['checkInternet']>(async () => {
+    const host = wirelessUpdate.targetHost;
+    if (!host) return { ok: false, reason: 'no_host' };
+
+    try {
+      const response = await fetchWithTimeout(
+        `${normalizeBase(host)}/update/available`,
+        {},
+        PRECHECK_TIMEOUT_MS,
+        { silent: true, label: 'Wireless update pre-check' }
+      );
+      if (!response.ok) {
+        return { ok: false, reason: `http_${response.status}` };
+      }
+      const data = (await response.json()) as AvailableResponse;
+      const available = data?.update?.reachy_mini?.available_version;
+      // The daemon returns "unknown" for `available_version` when it failed
+      // to reach PyPI (caught ConnectionError). Treat that as "no internet".
+      if (!available || available === 'unknown') {
+        return { ok: false, reason: 'pypi_unreachable' };
+      }
+      return { ok: true };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { ok: false, reason: message };
+    }
+  }, [wirelessUpdate.targetHost]);
+
+  const startUpdate = useCallback<UseWirelessDaemonUpdateResult['startUpdate']>(async () => {
+    const state = useAppStore.getState().wirelessUpdate;
+    const host = state.targetHost;
+    const minVersion = state.minVersion;
+
+    if (!host || !minVersion) {
+      setWirelessUpdateError('Missing target host or min version');
+      return;
+    }
+    // Re-entrancy guard: ignore double-clicks while a job is already running.
+    if (state.status !== 'idle' && state.status !== 'error') {
+      return;
+    }
+
+    // Reset transient state before starting a fresh attempt.
+    setWirelessUpdateError(null);
+    setWirelessUpdateJobId(null);
+    setWirelessUpdateStatus('pre-check');
+
+    cancelControllerRef.current?.abort();
+    cancelControllerRef.current = new AbortController();
+    const signal = cancelControllerRef.current.signal;
+
+    // ----- 1. Pre-check ------------------------------------------------------
+    const precheck = await checkInternet();
+    if (!precheck.ok) {
+      const human =
+        precheck.reason === 'pypi_unreachable'
+          ? "Robot can't reach PyPI. Connect it to a network with Internet, then retry."
+          : precheck.reason === 'no_host'
+            ? 'No target host - please go back and select a robot.'
+            : `Pre-check failed: ${precheck.reason}`;
+      setWirelessUpdateError(human);
+      return;
+    }
+    if (signal.aborted) return;
+
+    // ----- 2. Trigger update -------------------------------------------------
+    setWirelessUpdateStatus('updating');
+    let jobId: string | null = null;
+    try {
+      const response = await fetchWithTimeout(
+        `${normalizeBase(host)}/update/start`,
+        { method: 'POST', signal },
+        START_TIMEOUT_MS,
+        { silent: true, label: 'Wireless update start' }
+      );
+      if (!response.ok) {
+        const text = await response.text().catch(() => '');
+        throw new Error(`HTTP ${response.status}${text ? `: ${text}` : ''}`);
+      }
+      const data = (await response.json()) as StartResponse;
+      jobId = typeof data.job_id === 'string' ? data.job_id : null;
+      if (!jobId) {
+        throw new Error('Daemon did not return a job_id');
+      }
+      setWirelessUpdateJobId(jobId);
+    } catch (err) {
+      if (signal.aborted) return;
+      const message = err instanceof Error ? err.message : String(err);
+      setWirelessUpdateError(`Could not start the update: ${message}`);
+      return;
+    }
+
+    // ----- 3. Stream logs ----------------------------------------------------
+    // The daemon kills the WS when the install completes (which itself ends
+    // with `systemctl restart`), so the close event is our cue to move on.
+    await new Promise<void>(resolve => {
+      const ws = new WebSocket(`${wsBase(host)}/update/ws/logs?job_id=${jobId}`);
+      wsRef.current = ws;
+
+      const onAbort = (): void => {
+        ws.close();
+      };
+      signal.addEventListener('abort', onAbort);
+
+      ws.onmessage = (event: MessageEvent<string>) => {
+        const line = typeof event.data === 'string' ? event.data : String(event.data);
+        appendWirelessUpdateLog(line);
+      };
+      ws.onerror = () => {
+        // Don't fail hard here - the daemon often errors the WS right at
+        // restart time. We treat the close event as authoritative.
+        appendWirelessUpdateLog('[update] log stream lost (daemon restarting?)');
+      };
+      ws.onclose = () => {
+        signal.removeEventListener('abort', onAbort);
+        wsRef.current = null;
+        resolve();
+      };
+    });
+
+    if (signal.aborted) return;
+
+    // ----- 4. Wait for daemon to come back -----------------------------------
+    setWirelessUpdateStatus('restarting');
+    appendWirelessUpdateLog('[update] daemon restarting, waiting for it to come back...');
+
+    // Give systemctl a moment to actually stop the process before we start
+    // polling - otherwise we may catch the dying daemon and think the
+    // restart never happened.
+    await new Promise<void>(resolve => {
+      restartTimerRef.current = setTimeout(resolve, RESTART_GRACE_MS);
+    });
+    if (signal.aborted) return;
+
+    const restartStart = Date.now();
+    let liveStatus: StatusResponse | null = null;
+    while (Date.now() - restartStart < RESTART_BUDGET_MS) {
+      if (signal.aborted) return;
+      try {
+        const response = await fetchWithTimeout(
+          `${normalizeBase(host)}/api/daemon/status`,
+          { signal },
+          STATUS_TIMEOUT_MS,
+          { silent: true }
+        );
+        if (response.ok) {
+          liveStatus = (await response.json()) as StatusResponse;
+          break;
+        }
+      } catch {
+        // Expected during the restart window - swallow and retry.
+      }
+      await new Promise<void>(resolve => {
+        restartTimerRef.current = setTimeout(resolve, RESTART_POLL_INTERVAL_MS);
+      });
+    }
+
+    if (!liveStatus) {
+      setWirelessUpdateError(
+        'Daemon did not come back after the update. Reboot the robot manually and try again.'
+      );
+      return;
+    }
+    if (signal.aborted) return;
+
+    // ----- 5. Verify version -------------------------------------------------
+    setWirelessUpdateStatus('verifying');
+    const newVersion = typeof liveStatus.version === 'string' ? liveStatus.version : null;
+    appendWirelessUpdateLog(`[update] daemon is back at v${newVersion ?? 'unknown'}`);
+
+    if (isVersionBelow(newVersion, minVersion)) {
+      setWirelessUpdateError(
+        `Update finished but the daemon still reports v${newVersion ?? 'unknown'} (need v${minVersion}+). PyPI may not have a fresh enough release yet.`
+      );
+      return;
+    }
+
+    markWirelessUpdateSucceeded();
+  }, [
+    appendWirelessUpdateLog,
+    checkInternet,
+    markWirelessUpdateSucceeded,
+    setWirelessUpdateError,
+    setWirelessUpdateJobId,
+    setWirelessUpdateStatus,
+  ]);
+
+  return { startUpdate, checkInternet };
+}

--- a/src/hooks/daemon/useWirelessDaemonUpdate.ts
+++ b/src/hooks/daemon/useWirelessDaemonUpdate.ts
@@ -32,6 +32,7 @@ import { useShallow } from 'zustand/react/shallow';
 import useAppStore from '../../store/useAppStore';
 import { fetchWithTimeout } from '../../config/daemon';
 import { isVersionBelow } from '../../utils/semverCompare';
+import { telemetry } from '../../utils/telemetry';
 import type { FullAppState } from '../../store/useStore';
 
 // ---------------------------------------------------------------------------
@@ -200,6 +201,15 @@ export function useWirelessDaemonUpdate(): UseWirelessDaemonUpdateResult {
     cancelControllerRef.current = new AbortController();
     const signal = cancelControllerRef.current.signal;
 
+    const startedAt = Date.now();
+    const fromVersion = state.currentVersion;
+    const elapsedSec = (): number => Math.round((Date.now() - startedAt) / 1000);
+
+    telemetry.wirelessUpdateStarted({
+      from_version: fromVersion,
+      min_version: minVersion,
+    });
+
     // ----- 1. Pre-check ------------------------------------------------------
     const precheck = await checkInternet();
     if (!precheck.ok) {
@@ -210,6 +220,12 @@ export function useWirelessDaemonUpdate(): UseWirelessDaemonUpdateResult {
             ? 'No target host - please go back and select a robot.'
             : `Pre-check failed: ${precheck.reason}`;
       setWirelessUpdateError(human);
+      telemetry.wirelessUpdateFailed({
+        from_version: fromVersion,
+        min_version: minVersion,
+        error_class: precheck.reason ?? 'precheck_unknown',
+        duration_sec: elapsedSec(),
+      });
       return;
     }
     if (signal.aborted) return;
@@ -238,6 +254,12 @@ export function useWirelessDaemonUpdate(): UseWirelessDaemonUpdateResult {
       if (signal.aborted) return;
       const message = err instanceof Error ? err.message : String(err);
       setWirelessUpdateError(`Could not start the update: ${message}`);
+      telemetry.wirelessUpdateFailed({
+        from_version: fromVersion,
+        min_version: minVersion,
+        error_class: 'start_failed',
+        duration_sec: elapsedSec(),
+      });
       return;
     }
 
@@ -310,6 +332,12 @@ export function useWirelessDaemonUpdate(): UseWirelessDaemonUpdateResult {
       setWirelessUpdateError(
         'Daemon did not come back after the update. Reboot the robot manually and try again.'
       );
+      telemetry.wirelessUpdateFailed({
+        from_version: fromVersion,
+        min_version: minVersion,
+        error_class: 'restart_timeout',
+        duration_sec: elapsedSec(),
+      });
       return;
     }
     if (signal.aborted) return;
@@ -323,10 +351,22 @@ export function useWirelessDaemonUpdate(): UseWirelessDaemonUpdateResult {
       setWirelessUpdateError(
         `Update finished but the daemon still reports v${newVersion ?? 'unknown'} (need v${minVersion}+). PyPI may not have a fresh enough release yet.`
       );
+      telemetry.wirelessUpdateFailed({
+        from_version: fromVersion,
+        min_version: minVersion,
+        error_class: 'still_too_old',
+        duration_sec: elapsedSec(),
+      });
       return;
     }
 
     markWirelessUpdateSucceeded();
+    telemetry.wirelessUpdateSucceeded({
+      from_version: fromVersion,
+      to_version: newVersion,
+      min_version: minVersion,
+      duration_sec: elapsedSec(),
+    });
   }, [
     appendWirelessUpdateLog,
     checkInternet,

--- a/src/hooks/system/useViewRouter.tsx
+++ b/src/hooks/system/useViewRouter.tsx
@@ -9,6 +9,7 @@ import {
   StartingView,
   ClosingView,
   UpdateView,
+  WirelessUpdateRequiredView,
   ActiveRobotModule,
 } from '../../views';
 import AppTopBar from '../../components/AppTopBar';
@@ -77,6 +78,10 @@ export interface ViewConfig {
  * 2.   Setup choice - WiFi vs Bluetooth choice overlay
  * 2.5. First time WiFi setup - Guided WiFi configuration wizard
  * 2.75. Bluetooth support - Native BLE reset tool
+ * 2.8. Wireless update required - Forces a daemon update when the WiFi
+ *      pre-flight detected a daemon < MIN_WIRELESS_DAEMON_VERSION.
+ *      Sits BEFORE FindingRobot because connectionMode is still null at
+ *      this stage; without this slot the user would never see the gate.
  * 3.   Finding robot - User selects connection (USB/WiFi/Sim) and clicks Start
  * 4.   Starting daemon (visual scan) - Also used for WiFi mode
  * 5.   Stopping daemon - Shutdown spinner
@@ -128,6 +133,11 @@ export function useViewRouter({
     showBluetoothSupportView,
     setShowBluetoothSupportView,
   } = useAppStore();
+
+  // Read just the boolean we route on. Pulling the whole `wirelessUpdate`
+  // object would force a re-render on every appended log line, which is
+  // wasteful given the view itself already subscribes to the slice.
+  const wirelessUpdateRequired = useAppStore(state => state.wirelessUpdate.required);
 
   return useMemo((): ViewConfig => {
     // PRIORITY 0: Permissions view
@@ -183,6 +193,19 @@ export function useViewRouter({
           onBack: () => setShowBluetoothSupportView(false),
         },
         showTopBar: false, // BluetoothSupportView has its own close button
+      };
+    }
+
+    // PRIORITY 2.8: Wireless update required
+    // Set by `FindingRobotView.handleStart` when the WiFi pre-flight detects
+    // a daemon older than MIN_WIRELESS_DAEMON_VERSION. Must sit BEFORE
+    // FindingRobot because we trigger the gate while connectionMode is still
+    // null (we haven't called `connect()` yet).
+    if (wirelessUpdateRequired) {
+      return {
+        viewComponent: WirelessUpdateRequiredView,
+        viewProps: {},
+        showTopBar: true,
       };
     }
 
@@ -255,6 +278,7 @@ export function useViewRouter({
     setShowFirstTimeWifiSetup,
     showBluetoothSupportView,
     setShowBluetoothSupportView,
+    wirelessUpdateRequired,
     shouldShowUsbCheck,
     isUsbConnected,
     connectionMode,

--- a/src/store/slices/index.ts
+++ b/src/store/slices/index.ts
@@ -12,6 +12,7 @@ export { createRobotSlice } from './robotSlice';
 export { createLogsSlice } from './logsSlice';
 export { createUISlice, setupSystemPreferenceListener } from './uiSlice';
 export { createAppsSlice } from './appsSlice';
+export { createWirelessUpdateSlice } from './wirelessUpdateSlice';
 
 // ============================================================================
 // SELECTORS - Derive state from robotStatus (single source of truth)

--- a/src/store/slices/wirelessUpdateSlice.ts
+++ b/src/store/slices/wirelessUpdateSlice.ts
@@ -1,0 +1,140 @@
+/**
+ * Wireless Update Slice - Manages the forced-update flow for wireless robots.
+ *
+ * Responsibilities (single domain):
+ *   - Hold the "we need to update the remote daemon before connecting" flag
+ *     and the related metadata (target host, current version, min version).
+ *   - Hold the live status of an in-flight update job + its log buffer.
+ *
+ * Not responsible for:
+ *   - Calling the daemon endpoints (that's `useWirelessDaemonUpdate`'s job).
+ *   - Routing to a specific view (that's `useViewRouter`'s job).
+ *
+ * The slice is intentionally inert when `required === false`: the
+ * orchestrator hook short-circuits and the view router skips the dedicated
+ * view, keeping the rest of the app unaffected.
+ */
+import type { StateCreator } from 'zustand';
+import type {
+  AppState,
+  WirelessUpdateSlice,
+  WirelessUpdateSliceState,
+  WirelessUpdateStatus,
+} from '../../types/store';
+
+/** Cap log buffer to keep memory bounded during long-tailed PyPI installs. */
+const MAX_LOG_LINES = 1000;
+
+export const wirelessUpdateInitialState: WirelessUpdateSliceState = {
+  wirelessUpdate: {
+    required: false,
+    targetHost: null,
+    currentVersion: null,
+    minVersion: null,
+    status: 'idle',
+    jobId: null,
+    logs: [],
+    error: null,
+    lastSucceededAt: null,
+  },
+};
+
+export const createWirelessUpdateSlice: StateCreator<AppState, [], [], WirelessUpdateSlice> = (
+  set,
+  get
+) => ({
+  ...wirelessUpdateInitialState,
+
+  requestWirelessUpdate: ({ targetHost, currentVersion, minVersion }) => {
+    set({
+      wirelessUpdate: {
+        required: true,
+        targetHost,
+        currentVersion,
+        minVersion,
+        status: 'idle',
+        jobId: null,
+        logs: [],
+        error: null,
+        lastSucceededAt: get().wirelessUpdate.lastSucceededAt,
+      },
+    });
+  },
+
+  setWirelessUpdateStatus: (status: WirelessUpdateStatus) => {
+    set(state => ({
+      wirelessUpdate: { ...state.wirelessUpdate, status },
+    }));
+  },
+
+  setWirelessUpdateJobId: (jobId: string | null) => {
+    set(state => ({
+      wirelessUpdate: { ...state.wirelessUpdate, jobId },
+    }));
+  },
+
+  appendWirelessUpdateLog: (line: string) => {
+    set(state => {
+      const next = [...state.wirelessUpdate.logs, line];
+      if (next.length > MAX_LOG_LINES) {
+        next.splice(0, next.length - MAX_LOG_LINES);
+      }
+      return {
+        wirelessUpdate: { ...state.wirelessUpdate, logs: next },
+      };
+    });
+  },
+
+  setWirelessUpdateError: (error: string | null) => {
+    set(state => ({
+      wirelessUpdate: {
+        ...state.wirelessUpdate,
+        status: error ? 'error' : state.wirelessUpdate.status,
+        error,
+      },
+    }));
+  },
+
+  markWirelessUpdateSucceeded: () => {
+    set(state => ({
+      wirelessUpdate: {
+        ...state.wirelessUpdate,
+        status: 'succeeded',
+        error: null,
+        lastSucceededAt: Date.now(),
+      },
+    }));
+  },
+
+  cancelWirelessUpdate: () => {
+    set({
+      wirelessUpdate: {
+        required: false,
+        targetHost: null,
+        currentVersion: null,
+        minVersion: null,
+        status: 'idle',
+        jobId: null,
+        logs: [],
+        error: null,
+        lastSucceededAt: get().wirelessUpdate.lastSucceededAt,
+      },
+    });
+  },
+
+  resetWirelessUpdate: () => {
+    set({
+      wirelessUpdate: {
+        required: false,
+        targetHost: null,
+        currentVersion: null,
+        minVersion: null,
+        status: 'idle',
+        jobId: null,
+        logs: [],
+        error: null,
+        lastSucceededAt: get().wirelessUpdate.lastSucceededAt,
+      },
+    });
+  },
+});

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -6,8 +6,10 @@ import {
   createLogsSlice,
   createUISlice,
   createAppsSlice,
+  createWirelessUpdateSlice,
   setupSystemPreferenceListener,
 } from './slices';
+import { wirelessUpdateInitialState } from './slices/wirelessUpdateSlice';
 import { logReset } from './storeLogger';
 import { disableSimulationMode } from '../utils/simulationMode';
 import { BUSY_REASON, ROBOT_STATUS, buildDerivedState } from '../constants/robotStatus';
@@ -61,6 +63,7 @@ const storeCreator: StateCreator<FullAppState, [], [], FullAppState> = (set, get
   ...createLogsSlice(set, get, api),
   ...createUISlice(set, get, api),
   ...createAppsSlice(set, get, api),
+  ...createWirelessUpdateSlice(set, get, api),
 
   // ============================================
   // CROSS-SLICE ACTIONS
@@ -124,6 +127,12 @@ const storeCreator: StateCreator<FullAppState, [], [], FullAppState> = (set, get
       logs: [],
       frontendLogs: [],
       appLogs: [],
+
+      // Wireless update reset: any pending forced-update flow is tied to a
+      // specific connection attempt. On a hard disconnect we drop it so the
+      // next attempt starts from scratch rather than re-entering the update
+      // view based on stale state from a previous host.
+      wirelessUpdate: wirelessUpdateInitialState.wirelessUpdate,
     } as Partial<FullAppState>);
   },
 

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -303,7 +303,79 @@ export interface LogsSliceActions {
 export type LogsSlice = LogsSliceState & LogsSliceActions;
 
 // ============================================================================
+// WIRELESS UPDATE SLICE
+// ============================================================================
+
+/**
+ * Lifecycle of the forced wireless-daemon update flow.
+ *
+ *   idle       → no work in progress (initial / after cancel)
+ *   pre-check  → confirming the daemon can reach PyPI before triggering it
+ *   updating   → `POST /update/start` accepted, streaming logs over WS
+ *   restarting → daemon WS closed, waiting for `systemctl restart` to bring
+ *                it back up and answer `/api/daemon/status` again
+ *   verifying  → daemon back, double-checking the new version is ≥ min
+ *   succeeded  → ready to hand off to the regular `connect()` flow
+ *   error      → terminal failure; user can retry or cancel
+ */
+export type WirelessUpdateStatus =
+  | 'idle'
+  | 'pre-check'
+  | 'updating'
+  | 'restarting'
+  | 'verifying'
+  | 'succeeded'
+  | 'error';
+
+export interface WirelessUpdateState {
+  /**
+   * When `true`, the view router replaces the standard "Starting" path with
+   * `WirelessUpdateRequiredView`. Set by `requestWirelessUpdate()` after
+   * the WiFi pre-flight returns `reason: 'too_old'`.
+   */
+  required: boolean;
+  /** WiFi target the user picked (kept across the update so we can reconnect). */
+  targetHost: string | null;
+  /** Daemon version we observed during the pre-flight (e.g. "1.6.2"). */
+  currentVersion: string | null;
+  /** App-required minimum version (mirrors `MIN_WIRELESS_DAEMON_VERSION`). */
+  minVersion: string | null;
+  status: WirelessUpdateStatus;
+  /** Background job UUID returned by the daemon's `/update/start`. */
+  jobId: string | null;
+  /** Capped buffer of log lines streamed from `/update/ws/logs`. */
+  logs: string[];
+  /** Last terminal error (network, no internet, version still too old, ...). */
+  error: string | null;
+  /** Timestamp of the last successful update; used to dampen retry noise. */
+  lastSucceededAt: number | null;
+}
+
+export interface WirelessUpdateSliceState {
+  wirelessUpdate: WirelessUpdateState;
+}
+
+export interface WirelessUpdateSliceActions {
+  requestWirelessUpdate: (params: {
+    targetHost: string;
+    currentVersion: string | null;
+    minVersion: string;
+  }) => void;
+  setWirelessUpdateStatus: (status: WirelessUpdateStatus) => void;
+  setWirelessUpdateJobId: (jobId: string | null) => void;
+  appendWirelessUpdateLog: (line: string) => void;
+  setWirelessUpdateError: (error: string | null) => void;
+  markWirelessUpdateSucceeded: () => void;
+  /** Bail out of the flow (user pressed "Cancel and disconnect"). */
+  cancelWirelessUpdate: () => void;
+  /** Same as cancel, but called internally after a successful handoff. */
+  resetWirelessUpdate: () => void;
+}
+
+export type WirelessUpdateSlice = WirelessUpdateSliceState & WirelessUpdateSliceActions;
+
+// ============================================================================
 // COMBINED STORE
 // ============================================================================
 
-export type AppState = RobotSlice & AppsSlice & UiSlice & LogsSlice;
+export type AppState = RobotSlice & AppsSlice & UiSlice & LogsSlice & WirelessUpdateSlice;

--- a/src/utils/__tests__/semverCompare.test.ts
+++ b/src/utils/__tests__/semverCompare.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { parseVersion, compareVersions, isVersionBelow } from '../semverCompare';
+
+describe('parseVersion', () => {
+  it('parses a plain X.Y.Z', () => {
+    expect(parseVersion('1.7.1')).toEqual([1, 7, 1]);
+    expect(parseVersion('0.0.0')).toEqual([0, 0, 0]);
+    expect(parseVersion('10.20.30')).toEqual([10, 20, 30]);
+  });
+
+  it('strips a leading "v" or "V"', () => {
+    expect(parseVersion('v1.7.1')).toEqual([1, 7, 1]);
+    expect(parseVersion('V2.0.0')).toEqual([2, 0, 0]);
+  });
+
+  it('strips non-numeric suffixes from the patch (PEP 440 style)', () => {
+    expect(parseVersion('1.7.0rc1')).toEqual([1, 7, 0]);
+    expect(parseVersion('1.7.0.dev0')).toEqual([1, 7, 0]);
+    expect(parseVersion('1.7.0+build.5')).toEqual([1, 7, 0]);
+    expect(parseVersion('1.7.0-rc.1')).toEqual([1, 7, 0]);
+  });
+
+  it('returns null for unparseable input (fail-open)', () => {
+    expect(parseVersion(null)).toBeNull();
+    expect(parseVersion(undefined)).toBeNull();
+    expect(parseVersion('')).toBeNull();
+    expect(parseVersion('   ')).toBeNull();
+    expect(parseVersion('not-a-version')).toBeNull();
+    expect(parseVersion('1.7')).toBeNull();
+    expect(parseVersion('1')).toBeNull();
+    expect(parseVersion('a.b.c')).toBeNull();
+  });
+});
+
+describe('compareVersions', () => {
+  it('returns -1 / 0 / 1 like Array#sort', () => {
+    expect(compareVersions('1.7.0', '1.7.1')).toBe(-1);
+    expect(compareVersions('1.7.1', '1.7.1')).toBe(0);
+    expect(compareVersions('1.7.2', '1.7.1')).toBe(1);
+  });
+
+  it('compares major then minor then patch', () => {
+    expect(compareVersions('2.0.0', '1.99.99')).toBe(1);
+    expect(compareVersions('1.8.0', '1.7.99')).toBe(1);
+    expect(compareVersions('1.7.0', '1.6.99')).toBe(1);
+  });
+
+  it('treats pre-releases as their stable counterpart', () => {
+    expect(compareVersions('1.7.0rc1', '1.7.0')).toBe(0);
+    expect(compareVersions('1.7.0rc1', '1.7.1')).toBe(-1);
+  });
+
+  it('returns null when either side is unparseable', () => {
+    expect(compareVersions('1.7.1', null)).toBeNull();
+    expect(compareVersions(null, '1.7.1')).toBeNull();
+    expect(compareVersions('garbage', '1.7.1')).toBeNull();
+  });
+});
+
+describe('isVersionBelow', () => {
+  it('returns true when current is strictly older', () => {
+    expect(isVersionBelow('1.6.0', '1.7.1')).toBe(true);
+    expect(isVersionBelow('1.7.0', '1.7.1')).toBe(true);
+    expect(isVersionBelow('0.9.99', '1.0.0')).toBe(true);
+  });
+
+  it('returns false when current matches min', () => {
+    expect(isVersionBelow('1.7.1', '1.7.1')).toBe(false);
+  });
+
+  it('returns false when current is newer', () => {
+    expect(isVersionBelow('1.7.2', '1.7.1')).toBe(false);
+    expect(isVersionBelow('2.0.0', '1.7.1')).toBe(false);
+  });
+
+  it('fails open on unparseable input (never blocks the user)', () => {
+    expect(isVersionBelow(null, '1.7.1')).toBe(false);
+    expect(isVersionBelow('', '1.7.1')).toBe(false);
+    expect(isVersionBelow('weird-build', '1.7.1')).toBe(false);
+    expect(isVersionBelow('dev', '1.7.1')).toBe(false);
+  });
+
+  it('treats pre-releases as their stable counterpart (does not force update on rc)', () => {
+    expect(isVersionBelow('1.7.1rc1', '1.7.1')).toBe(false);
+    expect(isVersionBelow('1.7.0rc1', '1.7.1')).toBe(true);
+  });
+});

--- a/src/utils/diagnosticExport.ts
+++ b/src/utils/diagnosticExport.ts
@@ -97,6 +97,21 @@ export interface DiagnosticSnapshot {
     is_app_running: boolean;
     current_app: string | null;
   };
+  /**
+   * Snapshot of the wireless forced-update flow. `null` when the slice has
+   * never been touched in the current session.
+   */
+  wireless_update: {
+    required: boolean;
+    status: string;
+    target_host: string | null;
+    current_version: string | null;
+    min_version: string | null;
+    job_id: string | null;
+    error: string | null;
+    last_succeeded_at: number | null;
+    recent_logs: string[];
+  } | null;
   logs: {
     recent_errors: string[];
     recent_daemon: LogEntry[];
@@ -258,6 +273,8 @@ export const generateDiagnosticSnapshot = (): DiagnosticSnapshot => {
     code?: string | null;
   } | null;
 
+  const wirelessUpdate = state.wirelessUpdate ?? null;
+
   return {
     robot: {
       status: state.robotStatus,
@@ -279,6 +296,20 @@ export const generateDiagnosticSnapshot = (): DiagnosticSnapshot => {
       is_app_running: Boolean(state.isAppRunning),
       current_app: state.currentAppName || null,
     },
+    wireless_update: wirelessUpdate
+      ? {
+          required: Boolean(wirelessUpdate.required),
+          status: wirelessUpdate.status,
+          target_host: wirelessUpdate.targetHost,
+          current_version: wirelessUpdate.currentVersion,
+          min_version: wirelessUpdate.minVersion,
+          job_id: wirelessUpdate.jobId,
+          error: wirelessUpdate.error,
+          last_succeeded_at: wirelessUpdate.lastSucceededAt,
+          // Cap the log slice to keep payloads small in PostHog events.
+          recent_logs: (wirelessUpdate.logs ?? []).slice(-30),
+        }
+      : null,
     logs: {
       recent_errors: recentErrors,
       recent_daemon: recentDaemonLogs,
@@ -319,6 +350,23 @@ const getRobotState = () => {
     isCommandRunning: state.isCommandRunning,
 
     activeMoves: state.activeMoves,
+
+    // Wireless forced-update flow snapshot. Surfaced in both the full report
+    // and the lightweight telemetry snapshot so we can correlate connection
+    // failures against in-flight or recently-failed daemon updates.
+    wirelessUpdate: state.wirelessUpdate
+      ? {
+          required: Boolean(state.wirelessUpdate.required),
+          status: state.wirelessUpdate.status,
+          targetHost: state.wirelessUpdate.targetHost,
+          currentVersion: state.wirelessUpdate.currentVersion,
+          minVersion: state.wirelessUpdate.minVersion,
+          jobId: state.wirelessUpdate.jobId,
+          error: state.wirelessUpdate.error,
+          lastSucceededAt: state.wirelessUpdate.lastSucceededAt,
+          recentLogs: (state.wirelessUpdate.logs ?? []).slice(-30),
+        }
+      : null,
   };
 };
 
@@ -505,6 +553,27 @@ export const formatReportAsText = (report: DiagnosticReport): string => {
     lines.push(`  Startup Error: ${report.robot.startupError}`);
   }
   lines.push('');
+
+  if (report.robot.wirelessUpdate) {
+    const wu = report.robot.wirelessUpdate;
+    lines.push('WIRELESS UPDATE');
+    lines.push('───────────────────────────────────────────────────────────────────');
+    lines.push(`  Required: ${wu.required}`);
+    lines.push(`  Status: ${wu.status}`);
+    if (wu.targetHost) lines.push(`  Target Host: ${wu.targetHost}`);
+    lines.push(`  Current Version: ${wu.currentVersion ?? 'unknown'}`);
+    lines.push(`  Min Version: ${wu.minVersion ?? 'unknown'}`);
+    if (wu.jobId) lines.push(`  Job ID: ${wu.jobId}`);
+    if (wu.error) lines.push(`  Error: ${wu.error}`);
+    if (wu.lastSucceededAt) {
+      lines.push(`  Last Succeeded: ${new Date(wu.lastSucceededAt).toISOString()}`);
+    }
+    if (wu.recentLogs && wu.recentLogs.length > 0) {
+      lines.push(`  Recent Logs (${wu.recentLogs.length}):`);
+      wu.recentLogs.forEach(line => lines.push(`    ${line}`));
+    }
+    lines.push('');
+  }
 
   lines.push('APPS');
   lines.push('───────────────────────────────────────────────────────────────────');

--- a/src/utils/probeWifiHost.ts
+++ b/src/utils/probeWifiHost.ts
@@ -1,15 +1,19 @@
 import { fetchWithTimeout } from '../config/daemon';
+import { MIN_WIRELESS_DAEMON_VERSION } from '../constants/daemonVersion';
+import { isVersionBelow } from './semverCompare';
 
 /**
  * Pre-flight validation for a WiFi target host, used before committing to the
  * full `startDaemon` sequence. Returns a definitive outcome so the caller can
- * decide whether to connect or surface a clear error instead of waiting out
- * the ~90s startup timeout when the address is wrong.
+ * decide whether to connect, force a daemon update, or surface a clear error
+ * instead of waiting out the ~90s startup timeout when the address is wrong.
  *
  * Scope (minimal on purpose):
  *   - Confirm the host is reachable on port 8000.
  *   - Confirm SOMETHING Reachy-shaped is answering (a JSON body that exposes
  *     at least one of `state`, `status`, or `version`).
+ *   - Capture the daemon version so the caller can decide whether to gate
+ *     on `MIN_WIRELESS_DAEMON_VERSION` (`reason: 'too_old'`).
  *
  * Non-goals (intentional):
  *   - We do NOT probe `/api/state/full`. That endpoint only returns 200 once
@@ -38,10 +42,24 @@ function normalizeHost(host: string): string {
   return trimmed.includes(':') ? trimmed : `${trimmed}:8000`;
 }
 
+export type WifiProbeReason = 'unreachable' | 'wrong_service' | 'daemon_error' | 'too_old';
+
 export interface WifiProbeResult {
   ok: boolean;
   /** `null` on success. Otherwise a short code for the failure class. */
-  reason: null | 'unreachable' | 'wrong_service' | 'daemon_error';
+  reason: null | WifiProbeReason;
+  /**
+   * Daemon version string as returned by `/api/daemon/status`. Always
+   * populated when we got a parseable JSON body back, regardless of `ok`,
+   * so that callers handling `too_old` can show "current vX.Y.Z" without
+   * a second round-trip.
+   */
+  version: string | null;
+  /**
+   * Minimum version required by the desktop app, surfaced here so callers
+   * don't have to reach into `constants/daemonVersion` themselves.
+   */
+  minVersion: string;
 }
 
 /**
@@ -60,20 +78,40 @@ export async function probeWifiHost(host: string): Promise<WifiProbeResult> {
       silent: true,
     });
     if (!response.ok) {
-      return { ok: false, reason: 'wrong_service' };
+      return {
+        ok: false,
+        reason: 'wrong_service',
+        version: null,
+        minVersion: MIN_WIRELESS_DAEMON_VERSION,
+      };
     }
     try {
       statusBody = (await response.json()) as DaemonStatusBody;
     } catch {
       // Non-JSON body on /api/daemon/status → definitely not a Reachy daemon.
-      return { ok: false, reason: 'wrong_service' };
+      return {
+        ok: false,
+        reason: 'wrong_service',
+        version: null,
+        minVersion: MIN_WIRELESS_DAEMON_VERSION,
+      };
     }
   } catch {
-    return { ok: false, reason: 'unreachable' };
+    return {
+      ok: false,
+      reason: 'unreachable',
+      version: null,
+      minVersion: MIN_WIRELESS_DAEMON_VERSION,
+    };
   }
 
   if (!statusBody || typeof statusBody !== 'object') {
-    return { ok: false, reason: 'wrong_service' };
+    return {
+      ok: false,
+      reason: 'wrong_service',
+      version: null,
+      minVersion: MIN_WIRELESS_DAEMON_VERSION,
+    };
   }
 
   // Shape gate: require at least one Reachy-typical field. Kept permissive on
@@ -82,15 +120,45 @@ export async function probeWifiHost(host: string): Promise<WifiProbeResult> {
   // expected fields is present.
   const hasReachyShape = 'state' in statusBody || 'status' in statusBody || 'version' in statusBody;
   if (!hasReachyShape) {
-    return { ok: false, reason: 'wrong_service' };
+    return {
+      ok: false,
+      reason: 'wrong_service',
+      version: null,
+      minVersion: MIN_WIRELESS_DAEMON_VERSION,
+    };
   }
+
+  const version = typeof statusBody.version === 'string' ? statusBody.version : null;
 
   // Only one value is a hard stop: an explicit error state reported by the
   // daemon itself. Everything else is a "maybe not ready yet" that the normal
   // startup polling will resolve.
   if (statusBody.state === 'error' || statusBody.status === 'error') {
-    return { ok: false, reason: 'daemon_error' };
+    return {
+      ok: false,
+      reason: 'daemon_error',
+      version,
+      minVersion: MIN_WIRELESS_DAEMON_VERSION,
+    };
   }
 
-  return { ok: true, reason: null };
+  // Version gate: we have a real Reachy daemon answering, but it's older than
+  // what this app supports. The caller switches to the forced-update flow
+  // instead of trying to connect (which would either crash later on a missing
+  // endpoint or behave subtly wrong).
+  if (isVersionBelow(version, MIN_WIRELESS_DAEMON_VERSION)) {
+    return {
+      ok: false,
+      reason: 'too_old',
+      version,
+      minVersion: MIN_WIRELESS_DAEMON_VERSION,
+    };
+  }
+
+  return {
+    ok: true,
+    reason: null,
+    version,
+    minVersion: MIN_WIRELESS_DAEMON_VERSION,
+  };
 }

--- a/src/utils/semverCompare.ts
+++ b/src/utils/semverCompare.ts
@@ -1,0 +1,83 @@
+/**
+ * Tiny semver comparison utility.
+ *
+ * The desktop app already pulls in dozens of dependencies for the UI; we
+ * deliberately avoid adding `semver` (~25 KB) just to compare three integers.
+ * Logic mirrors the parser used in `uv-wrapper/src/lib.rs::get_installed_version`
+ * so the two stay in sync semantically:
+ *
+ *   - We only look at the first three numeric segments (`MAJOR.MINOR.PATCH`).
+ *   - Anything after a non-digit in the patch (`1.7.0rc1`, `1.7.0.dev0`,
+ *     `1.7.0+build.5`, `1.7.0-rc.1`) is stripped before parsing, so a
+ *     pre-release is treated as the matching stable release for the purpose
+ *     of "is this version too old?". That matches the daemon's
+ *     `_semver_version` parser on `pre_release=False`.
+ *   - Any unparseable input returns `null` from `parseVersion()` and makes
+ *     `isVersionBelow()` return `false` (fail-open, never block on garbage).
+ */
+
+export type SemverTuple = readonly [number, number, number];
+
+/**
+ * Parse a version string into `[major, minor, patch]`.
+ * Returns `null` if the string doesn't expose at least three numeric segments.
+ */
+export function parseVersion(version: string | null | undefined): SemverTuple | null {
+  if (!version) return null;
+  const trimmed = version.trim();
+  if (!trimmed) return null;
+
+  // Strip a leading "v" so both "1.7.0" and "v1.7.0" parse the same.
+  const normalized =
+    trimmed.startsWith('v') || trimmed.startsWith('V') ? trimmed.slice(1) : trimmed;
+
+  const segments = normalized.split('.');
+  if (segments.length < 3) return null;
+
+  const major = parseLeadingDigits(segments[0]);
+  const minor = parseLeadingDigits(segments[1]);
+  const patch = parseLeadingDigits(segments[2]);
+
+  if (major === null || minor === null || patch === null) return null;
+  return [major, minor, patch] as const;
+}
+
+/**
+ * Compare two version strings the way semver would, ignoring pre-release tags.
+ * Returns `-1` when `a < b`, `0` when equal, `1` when `a > b`. Returns `null`
+ * if either side is unparseable.
+ */
+export function compareVersions(
+  a: string | null | undefined,
+  b: string | null | undefined
+): -1 | 0 | 1 | null {
+  const pa = parseVersion(a);
+  const pb = parseVersion(b);
+  if (!pa || !pb) return null;
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] < pb[i]) return -1;
+    if (pa[i] > pb[i]) return 1;
+  }
+  return 0;
+}
+
+/**
+ * Returns `true` iff `current` is strictly older than `min`.
+ *
+ * Designed to gate features behind a minimum version. Fails open: when either
+ * side is unparseable we return `false` so we never lock the user out because
+ * of an unrecognised version string from a custom build.
+ */
+export function isVersionBelow(current: string | null | undefined, min: string): boolean {
+  const cmp = compareVersions(current, min);
+  if (cmp === null) return false;
+  return cmp < 0;
+}
+
+function parseLeadingDigits(segment: string | undefined): number | null {
+  if (!segment) return null;
+  const digits = segment.match(/^\d+/);
+  if (!digits) return null;
+  const n = Number(digits[0]);
+  return Number.isFinite(n) ? n : null;
+}

--- a/src/utils/telemetry/events.ts
+++ b/src/utils/telemetry/events.ts
@@ -43,6 +43,16 @@ export const EVENTS = {
   WIFI_SETUP_STARTED: 'wifi_setup_started',
   WIFI_SETUP_COMPLETED: 'wifi_setup_completed',
 
+  // Wireless daemon update gate
+  // Emitted when the WiFi pre-flight detected a too-old daemon and the
+  // forced-update view kicked in. Lets us measure how often we block
+  // users on outdated daemons (the whole motivation for the feature).
+  WIRELESS_UPDATE_REQUIRED_SHOWN: 'wireless_update_required_shown',
+  WIRELESS_UPDATE_STARTED: 'wireless_update_started',
+  WIRELESS_UPDATE_SUCCEEDED: 'wireless_update_succeeded',
+  WIRELESS_UPDATE_FAILED: 'wireless_update_failed',
+  WIRELESS_UPDATE_CANCELLED: 'wireless_update_cancelled',
+
   // Crash Reporting
   APP_CRASH: 'app_crash',
   APP_CRASH_REPORT: 'app_crash_report',

--- a/src/utils/telemetry/index.ts
+++ b/src/utils/telemetry/index.ts
@@ -270,6 +270,22 @@ interface AppCrashReportProps {
   log_tail?: string;
 }
 
+interface WirelessUpdateProps {
+  /** Daemon version observed at probe time (`null` if the body had no version). */
+  from_version: string | null;
+  /** App-required minimum version (`MIN_WIRELESS_DAEMON_VERSION`). */
+  min_version: string;
+}
+
+interface WirelessUpdateOutcomeProps extends WirelessUpdateProps {
+  /** Daemon version after the install (only set on success). */
+  to_version?: string | null;
+  /** Wall-clock duration of the full flow in seconds. */
+  duration_sec?: number;
+  /** Short error class on failure (`pypi_unreachable`, `restart_timeout`, ...). */
+  error_class?: string;
+}
+
 export const telemetry = {
   // --------------------------------------------------------------------------
   // Session & Connection
@@ -333,6 +349,7 @@ export const telemetry = {
       diagnostic_logs: diagnostic?.logs ?? null,
       diagnostic_installed_apps: diagnostic?.installed_apps ?? null,
       diagnostic_session: diagnostic?.session ?? null,
+      diagnostic_wireless_update: diagnostic?.wireless_update ?? null,
     });
   },
 
@@ -429,6 +446,49 @@ export const telemetry = {
 
   wifiSetupCompleted: (props: WifiSetupCompletedProps) => {
     void track(EVENTS.WIFI_SETUP_COMPLETED, { success: props.success });
+  },
+
+  // --------------------------------------------------------------------------
+  // Wireless daemon update gate
+  // --------------------------------------------------------------------------
+
+  wirelessUpdateRequiredShown: (props: WirelessUpdateProps) => {
+    void track(EVENTS.WIRELESS_UPDATE_REQUIRED_SHOWN, {
+      from_version: props.from_version,
+      min_version: props.min_version,
+    });
+  },
+
+  wirelessUpdateStarted: (props: WirelessUpdateProps) => {
+    void track(EVENTS.WIRELESS_UPDATE_STARTED, {
+      from_version: props.from_version,
+      min_version: props.min_version,
+    });
+  },
+
+  wirelessUpdateSucceeded: (props: WirelessUpdateOutcomeProps) => {
+    void track(EVENTS.WIRELESS_UPDATE_SUCCEEDED, {
+      from_version: props.from_version,
+      to_version: props.to_version ?? null,
+      min_version: props.min_version,
+      duration_sec: props.duration_sec,
+    });
+  },
+
+  wirelessUpdateFailed: (props: WirelessUpdateOutcomeProps) => {
+    void track(EVENTS.WIRELESS_UPDATE_FAILED, {
+      from_version: props.from_version,
+      min_version: props.min_version,
+      error_class: props.error_class,
+      duration_sec: props.duration_sec,
+    });
+  },
+
+  wirelessUpdateCancelled: (props: WirelessUpdateProps) => {
+    void track(EVENTS.WIRELESS_UPDATE_CANCELLED, {
+      from_version: props.from_version,
+      min_version: props.min_version,
+    });
   },
 
   // --------------------------------------------------------------------------

--- a/src/views/active-robot/application-store/hooks/useAppFetching.ts
+++ b/src/views/active-robot/application-store/hooks/useAppFetching.ts
@@ -288,8 +288,15 @@ export function useAppFetching(): UseAppFetchingReturn {
       const websiteApps = normalizeCatalogApps(websiteData);
       const mergedApps = mergeCatalogApps(websiteApps, daemonCatalogResult.apps);
 
+      // Cache age moved from response body to the standard `Age`
+      // HTTP header (RFC 7234 §5.1) so the body stays byte-stable
+      // across same-cache-window requests and ETag-based 304s
+      // work. Falls back to `?` when the header is absent (older
+      // website deploy or a daemon-only fallback) to keep the log
+      // line readable rather than emitting `null`.
+      const cacheAge = websiteResponse.headers.get('age') ?? '?';
       console.log(
-        `[Apps] Fetched ${mergedApps.length} apps from catalog (website=${websiteApps.length}, daemon=${daemonCatalogResult.apps.length}, cache age: ${websiteData.cacheAge}s)`
+        `[Apps] Fetched ${mergedApps.length} apps from catalog (website=${websiteApps.length}, daemon=${daemonCatalogResult.apps.length}, cache age: ${cacheAge}s)`
       );
 
       return mergedApps;

--- a/src/views/finding-robot/FindingRobotView.tsx
+++ b/src/views/finding-robot/FindingRobotView.tsx
@@ -33,6 +33,7 @@ import { useExternalDaemonProbe } from '../../hooks/daemon';
 import { invoke } from '@tauri-apps/api/core';
 import { useToast } from '../../hooks/useToast';
 import { probeWifiHost, type WifiProbeResult } from '../../utils/probeWifiHost';
+import { MIN_WIRELESS_DAEMON_VERSION } from '../../constants/daemonVersion';
 import reachyBuste from '../../assets/reachy-buste.png';
 import {
   ACCENT,
@@ -297,7 +298,12 @@ function ConnectionCard({
 export default function FindingRobotView() {
   const palette = useAppPalette();
   const isDark = palette.isDark;
-  const { setShowFirstTimeWifiSetup, setShowBluetoothSupportView, clearApps } = useAppStore();
+  const {
+    setShowFirstTimeWifiSetup,
+    setShowBluetoothSupportView,
+    clearApps,
+    requestWirelessUpdate,
+  } = useAppStore();
   const { isScanning, usbRobot, wifiRobot, wifiRobots, selectWifiRobot } = useRobotDiscovery();
   const { connect, isConnecting, isDisconnecting } = useConnection();
   const [selectedMode, setSelectedMode] = useState<ConnectionModeType | null>(null);
@@ -375,31 +381,41 @@ export default function FindingRobotView() {
 
   /**
    * Pre-flight probe for a WiFi target. Returns true if the host answers like
-   * a Reachy daemon; otherwise surfaces a tailored toast and returns false so
-   * the caller bails without going through the 90s startup timeout.
+   * a Reachy daemon and is recent enough; otherwise either surfaces a toast
+   * (network-class failures) or hands off to `WirelessUpdateRequiredView`
+   * (`too_old`), and returns false so the caller bails without going through
+   * the 90s startup timeout.
    */
   const verifyWifiHost = useCallback(
     async (host: string): Promise<boolean> => {
       const result = await probeWifiHost(host);
       if (result.ok) return true;
 
-      const messages: Record<Exclude<WifiProbeResult['reason'], null>, string> = {
+      // The version-too-old case is bigger than a toast: we route to the
+      // dedicated forced-update view, which can drive the daemon's own
+      // /update/start endpoint and stream its logs.
+      if (result.reason === 'too_old') {
+        requestWirelessUpdate({
+          targetHost: host,
+          currentVersion: result.version,
+          minVersion: result.minVersion ?? MIN_WIRELESS_DAEMON_VERSION,
+        });
+        return false;
+      }
+
+      const messages: Record<Exclude<WifiProbeResult['reason'], null | 'too_old'>, string> = {
         unreachable: `Cannot reach ${host}. Check the robot is powered on and on the same network.`,
         wrong_service: `${host} responded but does not look like a Reachy daemon.`,
         daemon_error: `The daemon at ${host} reported an error state. Restart the robot and try again.`,
-        // `too_old` is currently surfaced as a toast; a dedicated forced-update
-        // view replaces this message in a follow-up commit. We keep a clear
-        // fallback here so the probe stays useful even if the view layer
-        // isn't wired yet.
-        too_old: result.version
-          ? `Robot daemon is too old (v${result.version}, need v${result.minVersion}+). Update the robot and try again.`
-          : `Robot daemon is too old (need v${result.minVersion}+). Update the robot and try again.`,
       };
-      const reason = result.reason ?? 'unreachable';
+      const reason = (result.reason ?? 'unreachable') as Exclude<
+        WifiProbeResult['reason'],
+        null | 'too_old'
+      >;
       showToast(messages[reason], 'error');
       return false;
     },
-    [showToast]
+    [showToast, requestWirelessUpdate]
   );
 
   // Restore last selected mode from localStorage on mount

--- a/src/views/finding-robot/FindingRobotView.tsx
+++ b/src/views/finding-robot/FindingRobotView.tsx
@@ -387,6 +387,13 @@ export default function FindingRobotView() {
         unreachable: `Cannot reach ${host}. Check the robot is powered on and on the same network.`,
         wrong_service: `${host} responded but does not look like a Reachy daemon.`,
         daemon_error: `The daemon at ${host} reported an error state. Restart the robot and try again.`,
+        // `too_old` is currently surfaced as a toast; a dedicated forced-update
+        // view replaces this message in a follow-up commit. We keep a clear
+        // fallback here so the probe stays useful even if the view layer
+        // isn't wired yet.
+        too_old: result.version
+          ? `Robot daemon is too old (v${result.version}, need v${result.minVersion}+). Update the robot and try again.`
+          : `Robot daemon is too old (need v${result.minVersion}+). Update the robot and try again.`,
       };
       const reason = result.reason ?? 'unreachable';
       showToast(messages[reason], 'error');

--- a/src/views/finding-robot/FindingRobotView.tsx
+++ b/src/views/finding-robot/FindingRobotView.tsx
@@ -34,6 +34,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { useToast } from '../../hooks/useToast';
 import { probeWifiHost, type WifiProbeResult } from '../../utils/probeWifiHost';
 import { MIN_WIRELESS_DAEMON_VERSION } from '../../constants/daemonVersion';
+import { telemetry } from '../../utils/telemetry';
 import reachyBuste from '../../assets/reachy-buste.png';
 import {
   ACCENT,
@@ -395,10 +396,15 @@ export default function FindingRobotView() {
       // dedicated forced-update view, which can drive the daemon's own
       // /update/start endpoint and stream its logs.
       if (result.reason === 'too_old') {
+        const minVersion = result.minVersion ?? MIN_WIRELESS_DAEMON_VERSION;
         requestWirelessUpdate({
           targetHost: host,
           currentVersion: result.version,
-          minVersion: result.minVersion ?? MIN_WIRELESS_DAEMON_VERSION,
+          minVersion,
+        });
+        telemetry.wirelessUpdateRequiredShown({
+          from_version: result.version,
+          min_version: minVersion,
         });
         return false;
       }

--- a/src/views/index.ts
+++ b/src/views/index.ts
@@ -12,3 +12,4 @@ export { default as ActiveRobotView } from './active-robot/ActiveRobotView';
 export { default as ActiveRobotModule } from './active-robot/ActiveRobotModule';
 export { default as ClosingView } from './closing';
 export { default as UpdateView } from './update';
+export { default as WirelessUpdateRequiredView } from './wireless-update-required';

--- a/src/views/wireless-update-required/WirelessUpdateRequiredView.tsx
+++ b/src/views/wireless-update-required/WirelessUpdateRequiredView.tsx
@@ -1,0 +1,443 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { Box, Typography, CircularProgress, Button, Link } from '@mui/material';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import reachyUpdateBoxSvg from '../../assets/reachy-update-box.svg';
+import useAppStore from '../../store/useAppStore';
+import PulseButton from '@components/PulseButton';
+import { useWirelessDaemonUpdate } from '../../hooks/daemon';
+import { useConnection, ConnectionMode } from '../../hooks/useConnection';
+import type { WirelessUpdateState } from '../../types/store';
+import {
+  ACCENT,
+  BLUR,
+  FONT_WEIGHT,
+  RADIUS,
+  STATUS,
+  TYPO,
+  blackAlpha,
+  hexToRgba,
+  useAppPalette,
+  whiteAlpha,
+} from '@styles';
+
+/**
+ * WirelessUpdateRequiredView
+ *
+ * Blocking screen shown when the WiFi pre-flight detected a daemon older
+ * than `MIN_WIRELESS_DAEMON_VERSION`. Drives the daemon's own
+ * `/update/start` endpoint via `useWirelessDaemonUpdate`, displays the
+ * streamed install logs, and on success offers a "Connect now" CTA that
+ * resumes the normal `connect(WIFI, host)` flow.
+ *
+ * Visual language is deliberately aligned with `UpdateView` (same hero
+ * SVG, same PulseButton, same LogConsole-ish bottom strip) so users
+ * recognise it as "the update screen, but for the robot".
+ */
+export default function WirelessUpdateRequiredView() {
+  const palette = useAppPalette();
+  const isDark = palette.isDark;
+
+  const { wirelessUpdate, cancelWirelessUpdate, resetWirelessUpdate } = useAppStore(
+    useShallow(state => ({
+      wirelessUpdate: state.wirelessUpdate as WirelessUpdateState,
+      cancelWirelessUpdate: state.cancelWirelessUpdate,
+      resetWirelessUpdate: state.resetWirelessUpdate,
+    }))
+  );
+
+  const { startUpdate, checkInternet } = useWirelessDaemonUpdate();
+  const { connect, isConnecting } = useConnection();
+
+  // Internet pre-check: runs once on mount so we can disable the CTA when
+  // the robot can't reach PyPI. Re-armed by the "Retry" button after a
+  // failed attempt.
+  type InternetState = 'checking' | 'online' | 'offline' | 'error';
+  const [internet, setInternet] = useState<InternetState>('checking');
+  const [internetReason, setInternetReason] = useState<string | null>(null);
+  const checkSeqRef = useRef(0);
+
+  const runInternetCheck = useMemo(
+    () => async () => {
+      const seq = ++checkSeqRef.current;
+      setInternet('checking');
+      setInternetReason(null);
+      const result = await checkInternet();
+      // Drop stale results if a newer check superseded this one.
+      if (seq !== checkSeqRef.current) return;
+      if (result.ok) {
+        setInternet('online');
+      } else if (result.reason === 'pypi_unreachable') {
+        setInternet('offline');
+        setInternetReason('Robot is online but cannot reach PyPI.');
+      } else {
+        setInternet('error');
+        setInternetReason(result.reason ?? null);
+      }
+    },
+    [checkInternet]
+  );
+
+  useEffect(() => {
+    void runInternetCheck();
+  }, [runInternetCheck]);
+
+  // Auto-scroll the log box to the bottom as new lines arrive.
+  const logBoxRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    const el = logBoxRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [wirelessUpdate.logs.length]);
+
+  const status = wirelessUpdate.status;
+  const isInProgress =
+    status === 'pre-check' ||
+    status === 'updating' ||
+    status === 'restarting' ||
+    status === 'verifying';
+  const isSucceeded = status === 'succeeded';
+  const isErrored = status === 'error';
+
+  const stageLabel = (() => {
+    switch (status) {
+      case 'pre-check':
+        return 'Checking robot Internet...';
+      case 'updating':
+        return 'Updating daemon (this can take 1-2 minutes)...';
+      case 'restarting':
+        return 'Daemon restarting...';
+      case 'verifying':
+        return 'Verifying new version...';
+      default:
+        return null;
+    }
+  })();
+
+  const handleCancel = (): void => {
+    cancelWirelessUpdate();
+  };
+
+  const handleConnect = async (): Promise<void> => {
+    if (!wirelessUpdate.targetHost) return;
+    const host = wirelessUpdate.targetHost;
+    // Drop the update flag BEFORE calling connect: otherwise the view
+    // router would briefly render us again on the next render tick.
+    resetWirelessUpdate();
+    await connect(ConnectionMode.WIFI, { host });
+  };
+
+  return (
+    <Box
+      sx={{
+        width: '100vw',
+        height: '100vh',
+        background: palette.surfaceCard,
+        backdropFilter: BLUR.lg,
+        WebkitBackdropFilter: BLUR.lg,
+        overflow: 'hidden',
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          height: '100vh',
+          px: 4,
+        }}
+      >
+        {/* Hero icon */}
+        <Box sx={{ mb: 3 }}>
+          <img src={reachyUpdateBoxSvg} alt="Reachy Update" style={{ width: 200, height: 200 }} />
+        </Box>
+
+        {/* Title */}
+        <Typography
+          sx={{
+            fontSize: 24,
+            fontWeight: FONT_WEIGHT.semibold,
+            color: palette.textPrimary,
+            mb: 1,
+            textAlign: 'center',
+          }}
+        >
+          Robot update required
+        </Typography>
+
+        {/* Version diff */}
+        <Typography
+          sx={{
+            fontSize: TYPO.md,
+            color: palette.textSecondary,
+            textAlign: 'center',
+            maxWidth: 420,
+            lineHeight: 1.6,
+            mb: 0.5,
+          }}
+        >
+          Your Reachy Mini's software is too old for this version of the app.
+        </Typography>
+        <Typography
+          sx={{
+            fontSize: TYPO.sm,
+            color: palette.textFaint,
+            textAlign: 'center',
+            mb: 2.5,
+            fontFamily: 'SF Mono, Monaco, Menlo, monospace',
+          }}
+        >
+          {wirelessUpdate.currentVersion ? `v${wirelessUpdate.currentVersion}` : 'unknown'}
+          {'  →  '}
+          {wirelessUpdate.minVersion ? `v${wirelessUpdate.minVersion}+` : 'unknown'}
+        </Typography>
+
+        {/* Release notes link (idle / pre-update only) */}
+        {status === 'idle' && (
+          <Link
+            href="https://huggingface.co/spaces/pollen-robotics/Reachy_Mini#/download?scrollTo=release-notes"
+            target="_blank"
+            rel="noopener noreferrer"
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 0.5,
+              color: palette.textMuted,
+              fontSize: TYPO.sm,
+              textDecoration: 'none',
+              mb: 2,
+              '&:hover': { color: ACCENT.main },
+            }}
+          >
+            View release notes
+            <OpenInNewIcon sx={{ fontSize: TYPO.md }} />
+          </Link>
+        )}
+
+        {/* Stage indicator + spinner during the flow */}
+        {isInProgress && (
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1.25,
+              mb: 1.5,
+              minHeight: 28,
+            }}
+          >
+            <CircularProgress size={16} thickness={3} sx={{ color: ACCENT.main }} />
+            <Typography
+              sx={{
+                fontSize: TYPO.body,
+                color: palette.textSecondary,
+                fontWeight: FONT_WEIGHT.medium,
+              }}
+            >
+              {stageLabel}
+            </Typography>
+          </Box>
+        )}
+
+        {/* Live log strip during update / restart / verifying */}
+        {(isInProgress || (isErrored && wirelessUpdate.logs.length > 0)) && (
+          <Box
+            ref={logBoxRef}
+            sx={{
+              width: '100%',
+              maxWidth: 480,
+              maxHeight: 140,
+              minHeight: 80,
+              overflowY: 'auto',
+              mb: 2,
+              p: 1.25,
+              borderRadius: RADIUS.md,
+              border: `1px solid ${palette.border}`,
+              bgcolor: isDark ? blackAlpha(0.4) : blackAlpha(0.03),
+              fontFamily: 'SF Mono, Monaco, Menlo, monospace',
+              fontSize: 11,
+              lineHeight: 1.5,
+              color: palette.textMuted,
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-word',
+            }}
+          >
+            {wirelessUpdate.logs.length === 0 ? (
+              <Box sx={{ color: palette.textFaint, fontStyle: 'italic' }}>
+                Waiting for daemon logs...
+              </Box>
+            ) : (
+              wirelessUpdate.logs.map((line, idx) => <div key={idx}>{line}</div>)
+            )}
+          </Box>
+        )}
+
+        {/* Success state */}
+        {isSucceeded && (
+          <Box sx={{ textAlign: 'center', mb: 1, maxWidth: 380 }}>
+            <Typography
+              sx={{
+                fontSize: TYPO.body,
+                color: STATUS.success,
+                fontWeight: FONT_WEIGHT.semibold,
+                mb: 1,
+              }}
+            >
+              Update complete.
+            </Typography>
+          </Box>
+        )}
+
+        {/* Error state */}
+        {isErrored && wirelessUpdate.error && (
+          <Box sx={{ textAlign: 'center', mb: 1, maxWidth: 460 }}>
+            <Typography
+              sx={{
+                fontSize: TYPO.body,
+                color: STATUS.error,
+                fontWeight: FONT_WEIGHT.medium,
+                mb: 0.5,
+                lineHeight: 1.5,
+              }}
+            >
+              {wirelessUpdate.error}
+            </Typography>
+          </Box>
+        )}
+
+        {/* Internet pre-check banner (idle state, before first attempt) */}
+        {status === 'idle' && (
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1,
+              mb: 1.5,
+              px: 1.5,
+              py: 0.75,
+              borderRadius: RADIUS.md,
+              bgcolor:
+                internet === 'online'
+                  ? hexToRgba(STATUS.success, isDark ? 0.1 : 0.06)
+                  : internet === 'offline' || internet === 'error'
+                    ? hexToRgba(STATUS.error, isDark ? 0.1 : 0.06)
+                    : palette.surfaceSubtle,
+              border: '1px solid',
+              borderColor:
+                internet === 'online'
+                  ? hexToRgba(STATUS.success, isDark ? 0.3 : 0.2)
+                  : internet === 'offline' || internet === 'error'
+                    ? hexToRgba(STATUS.error, isDark ? 0.3 : 0.2)
+                    : palette.border,
+              minHeight: 30,
+            }}
+          >
+            {internet === 'checking' ? (
+              <>
+                <CircularProgress size={10} thickness={4} sx={{ color: palette.textMuted }} />
+                <Typography sx={{ fontSize: TYPO.xs, color: palette.textMuted }}>
+                  Checking robot Internet...
+                </Typography>
+              </>
+            ) : internet === 'online' ? (
+              <Typography
+                sx={{
+                  fontSize: TYPO.xs,
+                  color: STATUS.success,
+                  fontWeight: FONT_WEIGHT.medium,
+                }}
+              >
+                Robot can reach PyPI - ready to update.
+              </Typography>
+            ) : (
+              <Typography
+                sx={{
+                  fontSize: TYPO.xs,
+                  color: STATUS.error,
+                  fontWeight: FONT_WEIGHT.medium,
+                }}
+              >
+                {internetReason ??
+                  'Robot has no Internet access. Connect it to a network with Internet, then retry.'}
+              </Typography>
+            )}
+          </Box>
+        )}
+
+        {/* Action buttons */}
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: 1.25,
+            mt: 1,
+            width: '100%',
+            maxWidth: 280,
+          }}
+        >
+          {status === 'idle' && (
+            <PulseButton
+              onClick={() => void startUpdate()}
+              disabled={internet !== 'online'}
+              darkMode={isDark}
+              pulse={internet === 'online'}
+              size="medium"
+              sx={{ minWidth: 200 }}
+            >
+              Update now
+            </PulseButton>
+          )}
+
+          {isErrored && (
+            <PulseButton
+              onClick={() => {
+                void runInternetCheck();
+                void startUpdate();
+              }}
+              darkMode={isDark}
+              pulse
+              size="medium"
+              sx={{ minWidth: 200 }}
+            >
+              Retry update
+            </PulseButton>
+          )}
+
+          {isSucceeded && (
+            <PulseButton
+              onClick={() => void handleConnect()}
+              disabled={isConnecting}
+              darkMode={isDark}
+              pulse
+              size="medium"
+              sx={{ minWidth: 200 }}
+            >
+              {isConnecting ? 'Connecting...' : 'Connect now'}
+            </PulseButton>
+          )}
+
+          {/* Cancel escape hatch: always available except mid-restart, where
+              cancelling could leave the daemon in a half-updated state. */}
+          {status !== 'restarting' && status !== 'verifying' && (
+            <Button
+              variant="text"
+              onClick={handleCancel}
+              sx={{
+                color: palette.textMuted,
+                fontWeight: FONT_WEIGHT.medium,
+                fontSize: TYPO.body,
+                py: 0.5,
+                textTransform: 'none',
+                '&:hover': {
+                  bgcolor: isDark ? whiteAlpha(0.05) : blackAlpha(0.04),
+                },
+              }}
+            >
+              Cancel and disconnect
+            </Button>
+          )}
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/src/views/wireless-update-required/WirelessUpdateRequiredView.tsx
+++ b/src/views/wireless-update-required/WirelessUpdateRequiredView.tsx
@@ -176,7 +176,8 @@ export default function WirelessUpdateRequiredView() {
             fontSize: TYPO.md,
             color: palette.textSecondary,
             textAlign: 'center',
-            maxWidth: 420,
+            width: '60%',
+            mx: 'auto',
             lineHeight: 1.6,
             mb: 0.5,
           }}
@@ -421,9 +422,10 @@ export default function WirelessUpdateRequiredView() {
             </PulseButton>
           )}
 
-          {/* Cancel escape hatch: always available except mid-restart, where
+          {/* Cancel escape hatch: available before the install kicks off, but
+              hidden once it's underway (updating/restarting/verifying), where
               cancelling could leave the daemon in a half-updated state. */}
-          {status !== 'restarting' && status !== 'verifying' && (
+          {status !== 'updating' && status !== 'restarting' && status !== 'verifying' && (
             <Button
               variant="text"
               onClick={handleCancel}

--- a/src/views/wireless-update-required/WirelessUpdateRequiredView.tsx
+++ b/src/views/wireless-update-required/WirelessUpdateRequiredView.tsx
@@ -7,6 +7,7 @@ import useAppStore from '../../store/useAppStore';
 import PulseButton from '@components/PulseButton';
 import { useWirelessDaemonUpdate } from '../../hooks/daemon';
 import { useConnection, ConnectionMode } from '../../hooks/useConnection';
+import { telemetry } from '../../utils/telemetry';
 import type { WirelessUpdateState } from '../../types/store';
 import {
   ACCENT,
@@ -114,6 +115,10 @@ export default function WirelessUpdateRequiredView() {
   })();
 
   const handleCancel = (): void => {
+    telemetry.wirelessUpdateCancelled({
+      from_version: wirelessUpdate.currentVersion,
+      min_version: wirelessUpdate.minVersion ?? 'unknown',
+    });
     cancelWirelessUpdate();
   };
 
@@ -176,7 +181,7 @@ export default function WirelessUpdateRequiredView() {
             mb: 0.5,
           }}
         >
-          Your Reachy Mini's software is too old for this version of the app.
+          Your Reachy Mini&apos;s software is too old for this version of the app.
         </Typography>
         <Typography
           sx={{

--- a/src/views/wireless-update-required/index.ts
+++ b/src/views/wireless-update-required/index.ts
@@ -1,0 +1,4 @@
+/**
+ * Wireless update required view module
+ */
+export { default } from './WirelessUpdateRequiredView';


### PR DESCRIPTION
## Summary

Promote `develop` to `main` for the next release.

Headline changes since the last release (v0.9.31):
- **Forced wireless daemon update gate**: when a Reachy Mini Wireless runs a daemon older than `MIN_WIRELESS_DAEMON_VERSION`, the app shows a blocking `WirelessUpdateRequiredView` that drives the daemon's `/update/start` endpoint (PR #273).
- **Daemon version unified on 1.8.0**: bundled daemon for Lite/sim (`REACHY_MINI_VERSION`) and the wireless floor (`MIN_WIRELESS_DAEMON_VERSION`) now move in lockstep at 1.8.0.
- **UI fix**: right-panel scroll restored once the user is signed in.

## Notes

- Version bump + tag (`v0.9.32`) will be done on `main` after this merge, per the documented release process.
- A dry-run build will be run before tagging the real release.

Made with [Cursor](https://cursor.com)