### PR TITLE
fix(startup): unblock EXTERNAL-mode connection hanging on starting sc…

### DIFF
--- a/src/views/starting/hooks/useBootstrapDetection.ts
+++ b/src/views/starting/hooks/useBootstrapDetection.ts
@@ -18,8 +18,8 @@ export interface BootstrapDetection {
 /**
  * Parse sidecar stdout/stderr to decide whether the daemon is going through
  * a first-run Python environment setup ("bootstrap") and expose a
- * user-friendly label for the current step. WiFi mode is short-circuited
- * since there is no local sidecar.
+ * user-friendly label for the current step. WiFi and external modes are
+ * short-circuited since there is no local sidecar.
  *
  * Also clears any transient `hardwareError` produced during bootstrap:
  * those are false positives, real hardware comms haven't started yet.
@@ -32,10 +32,13 @@ export function useBootstrapDetection(isStarting: boolean): BootstrapDetection {
   useEffect(() => {
     if (!isStarting) return;
 
-    // WiFi mode: no local sidecar, bootstrap doesn't apply.
+    // WiFi and external modes: no local sidecar (the daemon is remote or was
+    // started outside the app), so no sidecar output ever arrives and bootstrap
+    // doesn't apply. Without this short-circuit `isBootstrapping` would stay
+    // `null` forever, stalling StartupView's scan-complete / post-ready gates.
     const currentConnectionMode = (useAppStore.getState() as { connectionMode: ConnectionModeLike })
       .connectionMode;
-    if (currentConnectionMode === 'wifi') {
+    if (currentConnectionMode === 'wifi' || currentConnectionMode === 'external') {
       setIsBootstrapping(false);
       return;
     }


### PR DESCRIPTION
…reen

When attaching to a pre-existing local daemon via EXTERNAL mode (the "External daemon detected on localhost:8000" banner), the app never left the starting screen even though the daemon was healthy and daemon:ready fired.

useBootstrapDetection only short-circuited its "no local sidecar" case for WiFi mode. EXTERNAL mode also has no local sidecar (the daemon was started outside the app, not spawned via start_daemon), so no sidecar-stdout/stderr event ever arrived and isBootstrapping stayed `null` forever. That left StartupView's scan-complete gate (`isBootstrapping !== false`) permanently closed, so the post-ready sequence never ran and the view never advanced to ActiveRobotView. The EXTERNAL branch of startDaemon sets no startup timeout, so it hung indefinitely instead of erroring out.

Treat `external` like `wifi` in the no-sidecar short-circuit. USB and simulation still spawn a local sidecar, so they keep listening for real bootstrap progress.

Assisted-by: Claude:claude-opus-4-8