### PR TITLE
Add Fedora RPM packaging and Linux camera fallback

### DIFF
--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -704,7 +704,7 @@ jobs:
           # Prevent linuxdeploy from leaving temp files
           NO_CLEANUP: 0
         run: |
-          # Install dependencies required for .deb and AppImage build
+          # Install dependencies required for .deb, .rpm and AppImage build
           # patchelf is CRITICAL for linuxdeploy to work
           sudo apt-get update
           sudo apt-get install -y \
@@ -728,6 +728,7 @@ jobs:
             file \
             libc-bin \
             dpkg-dev \
+            rpm \
             libfuse2t64 \
             squashfs-tools \
             patchelf
@@ -1423,6 +1424,15 @@ jobs:
             src-tauri/target/${{ matrix.target }}/release/bundle/deb/*.deb
           retention-days: 30
 
+      - name: Upload .rpm package (Linux)
+        if: matrix.os == 'ubuntu-24.04'
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpm-${{ matrix.platform }}
+          path: |
+            src-tauri/target/${{ matrix.target }}/release/bundle/rpm/*.rpm
+          retention-days: 30
+
       - name: Create GitHub Release
         if: matrix.os == 'macos-latest' && matrix.target == 'aarch64-apple-darwin' && github.event.inputs.dry_run != 'true'
         uses: softprops/action-gh-release@v2
@@ -1435,6 +1445,8 @@ jobs:
           files: |
             src-tauri/target/*/release/bundle/deb/*.deb
             src-tauri/target/*/release/bundle/deb/*.deb.sig
+            src-tauri/target/*/release/bundle/rpm/*.rpm
+            src-tauri/target/*/release/bundle/rpm/*.rpm.sig
             src-tauri/target/*/release/bundle/msi/*.msi
             src-tauri/target/*/release/bundle/msi/*.msi.sig
             src-tauri/target/*/release/bundle/appimage/*.AppImage
@@ -1462,6 +1474,8 @@ jobs:
             ${{ matrix.os == 'windows-latest' && format('src-tauri/target/{0}/release/bundle/msi/*.msi.sig', matrix.target) || '' }}
             ${{ matrix.os == 'ubuntu-24.04' && format('src-tauri/target/{0}/release/bundle/deb/*.deb', matrix.target) || '' }}
             ${{ matrix.os == 'ubuntu-24.04' && format('src-tauri/target/{0}/release/bundle/deb/*.deb.sig', matrix.target) || '' }}
+            ${{ matrix.os == 'ubuntu-24.04' && format('src-tauri/target/{0}/release/bundle/rpm/*.rpm', matrix.target) || '' }}
+            ${{ matrix.os == 'ubuntu-24.04' && format('src-tauri/target/{0}/release/bundle/rpm/*.rpm.sig', matrix.target) || '' }}
             ${{ matrix.os == 'ubuntu-24.04' && format('src-tauri/target/{0}/release/bundle/appimage/*.AppImage', matrix.target) || '' }}
             ${{ matrix.os == 'ubuntu-24.04' && format('src-tauri/target/{0}/release/bundle/appimage/*.AppImage.tar.gz', matrix.target) || '' }}
             ${{ matrix.os == 'ubuntu-24.04' && format('src-tauri/target/{0}/release/bundle/appimage/*.AppImage.tar.gz.sig', matrix.target) || '' }}
@@ -1473,7 +1487,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Dry-run only: upload the raw installers (.msi / .dmg / .deb / .AppImage)
+      # Dry-run only: upload the raw installers (.msi / .dmg / .deb / .rpm / .AppImage)
       # so they can be downloaded from the Actions run directly, since no
       # GitHub Release is created in this mode.
       - name: Upload installers (dry run)
@@ -1488,6 +1502,8 @@ jobs:
             src-tauri/target/${{ matrix.target }}/release/bundle/macos/*.zip
             src-tauri/target/${{ matrix.target }}/release/bundle/deb/*.deb
             src-tauri/target/${{ matrix.target }}/release/bundle/deb/*.deb.sig
+            src-tauri/target/${{ matrix.target }}/release/bundle/rpm/*.rpm
+            src-tauri/target/${{ matrix.target }}/release/bundle/rpm/*.rpm.sig
             src-tauri/target/${{ matrix.target }}/release/bundle/appimage/*.AppImage
             src-tauri/target/${{ matrix.target }}/release/bundle/appimage/*.AppImage.tar.gz
             src-tauri/target/${{ matrix.target }}/release/bundle/appimage/*.AppImage.tar.gz.sig
@@ -1505,7 +1521,7 @@ jobs:
           echo "🧪"
           echo "🧪 Artifacts available in this run:"
           echo "🧪   - update-${{ matrix.platform }}         (updater payload + signed manifests)"
-          echo "🧪   - dry-run-installer-${{ matrix.platform }} (raw installers: .msi / .dmg / .deb / .AppImage)"
+          echo "🧪   - dry-run-installer-${{ matrix.platform }} (raw installers: .msi / .dmg / .deb / .rpm / .AppImage)"
           echo "🧪"
           echo "🧪 Download them from the Actions tab → this workflow run → Artifacts section."
           echo "🧪 No release was created, no users will be notified."

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ yarn tauri build --target aarch64-apple-darwin
 yarn tauri build --target x86_64-apple-darwin
 yarn tauri build --target x86_64-pc-windows-msvc
 yarn tauri build --target x86_64-unknown-linux-gnu
+yarn tauri build --target x86_64-unknown-linux-gnu --bundles rpm  # Fedora RPM only
 ```
 
 #### Installing the daemon from different sources
@@ -178,6 +179,7 @@ yarn build:sidecar:branch             # Interactive branch selection
 
 # Build application
 yarn tauri:build                      # Build production bundle
+yarn tauri:build:rpm                  # Build Fedora RPM package
 
 # Build web dashboard (for daemon)
 yarn build:web                        # Build web version

--- a/docs/LINUX_PACKAGING_STRATEGY.md
+++ b/docs/LINUX_PACKAGING_STRATEGY.md
@@ -38,9 +38,25 @@ Ce document analyse comment les principaux projets Tauri gèrent le packaging et
 - Installation initiale propre avec dépendances système
 - Distribution via repositories APT
 
-### 3. Autres Formats
+### 3. Packages .rpm Fedora
 
-- **RPM** : Pour Fedora/RHEL (même limitations que .deb)
+**Avantages :**
+- ✅ Intégration native avec Fedora via `dnf`
+- ✅ Gestion automatique des dépendances système Fedora
+- ✅ Scripts post-installation (udev rules, permissions)
+- ✅ Alternative propre pour les utilisateurs hors Debian/Ubuntu
+
+**Inconvénients :**
+- ❌ Non supporté par l'auto-updater Tauri
+- ❌ Les noms de dépendances varient entre Fedora, RHEL et openSUSE
+- ❌ Support initial limité à Fedora
+
+**Cas d'usage :**
+- Installation initiale propre sur Fedora
+- Distribution via releases GitHub ou dépôt RPM Fedora à terme
+
+### 4. Autres Formats
+
 - **Flatpak** : Sandboxing, distribution via Flathub
 - **Snap** : Alternative à Flatpak, mais controversé dans la communauté Linux
 

--- a/docs/LINUX_SETUP.md
+++ b/docs/LINUX_SETUP.md
@@ -57,6 +57,21 @@ Cela signifie que :
 
 > **Note** : Les builds Linux sont actuellement désactivés dans le workflow de release en raison de problèmes avec le bundling AppImage et les dépendances natives Python. Voir [issue #35](https://github.com/pollen-robotics/reachy-mini-desktop-app/issues/35).
 
+### Installation via Package .rpm (Fedora)
+
+Le package `.rpm` cible Fedora. Il déclare les dépendances runtime Fedora, installe les règles udev pour l'accès USB au robot et configure l'utilisateur dans le groupe `dialout` quand celui-ci existe.
+
+```bash
+# Installer le package
+sudo dnf install ./reachy-mini-control-*.rpm
+
+# Note: Après l'installation, vous devrez peut-être :
+# 1. Vous déconnecter et vous reconnecter (pour les changements de groupe)
+# 2. Débrancher et rebrancher le câble USB de votre Reachy Mini
+```
+
+Le support RPM est validé comme cible Fedora en priorité. Les distributions RHEL/openSUSE peuvent avoir des noms de dépendances GStreamer/WebKit différents et ne sont pas encore considérées comme supportées officiellement.
+
 ### Build Depuis les Sources
 
 #### Dépendances de Build
@@ -105,7 +120,16 @@ yarn build:sidecar-linux
 yarn tauri:build
 ```
 
-Le package `.deb` sera généré dans `src-tauri/target/release/bundle/deb/`.
+Les packages Linux seront générés dans :
+- `.deb` : `src-tauri/target/release/bundle/deb/`
+- `.rpm` : `src-tauri/target/release/bundle/rpm/`
+- AppImage : `src-tauri/target/release/bundle/appimage/`
+
+Pour compiler uniquement le RPM Fedora :
+
+```bash
+yarn tauri:build:rpm
+```
 
 ## Système de Mises à Jour
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "tauri:dev": "tauri dev --no-watch",
     "tauri:dev:fresh": "yarn kill-daemon && yarn clean && yarn build:sidecar-macos && yarn tauri:dev",
     "tauri:build": "tauri build",
+    "tauri:build:rpm": "tauri build --bundles rpm",
     "build:sidecar-macos": "bash ./scripts/build/build-sidecar-unix.sh",
     "build:sidecar-linux": "bash ./scripts/build/build-sidecar-unix.sh",
     "build:sidecar-windows": "powershell ./scripts/build/build-sidecar-windows.ps1",

--- a/src-tauri/linux/rpm-postinst.sh
+++ b/src-tauri/linux/rpm-postinst.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Post-installation script for Reachy Mini Control Fedora RPM package.
+
+set -e
+
+APP_LIB_DIR="/usr/lib/Reachy Mini Control"
+UDEV_RULES_FILE="/etc/udev/rules.d/99-reachy-mini.rules"
+UDEV_RULES_SOURCE="/usr/share/reachy-mini-control/99-reachy-mini.rules"
+
+echo "Patching Python virtual environment paths..."
+
+PYVENV_CFG="$APP_LIB_DIR/.venv/pyvenv.cfg"
+if [ -f "$PYVENV_CFG" ]; then
+    CPYTHON_FOLDER=$(ls -d "$APP_LIB_DIR"/cpython-* 2>/dev/null | head -1)
+
+    if [ -n "$CPYTHON_FOLDER" ]; then
+        CPYTHON_BIN="$CPYTHON_FOLDER/bin"
+        sed -i "s|^home = .*|home = $CPYTHON_BIN|g" "$PYVENV_CFG"
+        echo "pyvenv.cfg patched: $CPYTHON_BIN"
+    else
+        echo "Warning: cpython folder not found in $APP_LIB_DIR"
+    fi
+else
+    echo "Warning: pyvenv.cfg not found at $PYVENV_CFG"
+fi
+
+echo "Configuring Reachy Mini USB permissions..."
+
+if [ -f "$UDEV_RULES_SOURCE" ]; then
+    if [ ! -f "$UDEV_RULES_FILE" ] || ! cmp -s "$UDEV_RULES_SOURCE" "$UDEV_RULES_FILE"; then
+        cp "$UDEV_RULES_SOURCE" "$UDEV_RULES_FILE"
+        chmod 0644 "$UDEV_RULES_FILE"
+        echo "udev rules installed"
+    else
+        echo "udev rules already up to date"
+    fi
+else
+    echo "Warning: udev rules source file not found at $UDEV_RULES_SOURCE"
+fi
+
+if [ -f "$UDEV_RULES_FILE" ]; then
+    udevadm control --reload-rules || true
+    udevadm trigger || true
+    echo "udev rules reloaded"
+fi
+
+CURRENT_USER="${SUDO_USER:-${USER}}"
+if [ -n "$CURRENT_USER" ] && [ "$CURRENT_USER" != "root" ] && getent group dialout >/dev/null; then
+    if ! groups "$CURRENT_USER" | grep -q "\bdialout\b"; then
+        usermod -aG dialout "$CURRENT_USER" || true
+        echo "User '$CURRENT_USER' added to dialout group"
+        echo "Log out and back in for group changes to take effect"
+    else
+        echo "User '$CURRENT_USER' already in dialout group"
+    fi
+fi
+
+echo "Reachy Mini USB permissions configured"
+
+exit 0

--- a/src-tauri/linux/rpm-postrm.sh
+++ b/src-tauri/linux/rpm-postrm.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Post-removal script for Reachy Mini Control Fedora RPM package.
+
+set -e
+
+UDEV_RULES_FILE="/etc/udev/rules.d/99-reachy-mini.rules"
+
+# RPM passes 0 on final erase and 1 on upgrade. Keep rules during upgrades.
+if [ "${1:-0}" != "0" ]; then
+    exit 0
+fi
+
+echo "Cleaning up Reachy Mini USB permissions..."
+
+if [ -f "$UDEV_RULES_FILE" ]; then
+    if grep -q "Reachy Mini" "$UDEV_RULES_FILE" 2>/dev/null; then
+        rm -f "$UDEV_RULES_FILE"
+        udevadm control --reload-rules || true
+        udevadm trigger || true
+        echo "udev rules removed"
+    else
+        echo "Keeping udev rules not installed by this package"
+    fi
+fi
+
+echo "Cleanup completed"
+
+exit 0

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -30,6 +30,7 @@ use local_proxy::LocalProxyState;
 use std::sync::Arc;
 use tauri::{Manager, State};
 use tauri_plugin_log::{Target, TargetKind};
+use tauri_plugin_opener::OpenerExt;
 
 #[cfg(not(windows))]
 use signal_hook::{consts::TERM_SIGNALS, iterator::Signals};
@@ -140,6 +141,215 @@ fn get_logs(state: State<DaemonState>) -> Result<Vec<String>, String> {
         .lock()
         .map_err(|e| format!("Failed to read logs: {}", e))?;
     Ok(logs.iter().cloned().collect())
+}
+
+#[tauri::command]
+fn open_external_camera_viewer(
+    app_handle: tauri::AppHandle,
+    host: Option<String>,
+) -> Result<String, String> {
+    let host = host
+        .filter(|h| !h.trim().is_empty())
+        .unwrap_or_else(|| "localhost".to_string());
+    let signaling_url = format!("ws://{}:8443", host);
+    let signaling_url_json = serde_json::to_string(&signaling_url)
+        .map_err(|e| format!("Failed to serialize signaling URL: {}", e))?;
+    let html = external_camera_viewer_html().replace("__SIGNALING_URL__", &signaling_url_json);
+    let path = std::env::temp_dir().join("reachy-mini-camera-viewer.html");
+
+    std::fs::write(&path, html)
+        .map_err(|e| format!("Failed to write external camera viewer: {}", e))?;
+
+    let url = tauri::Url::from_file_path(&path)
+        .map_err(|_| format!("Failed to convert path to file URL: {}", path.display()))?
+        .to_string();
+
+    app_handle
+        .opener()
+        .open_url(url.clone(), None::<&str>)
+        .map_err(|e| format!("Failed to open external camera viewer: {}", e))?;
+
+    Ok(url)
+}
+
+fn external_camera_viewer_html() -> &'static str {
+    r#"<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Reachy Mini Camera</title>
+  <style>
+    :root { color-scheme: dark; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      background: #0f1115;
+      color: #f4f4f5;
+      font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    main {
+      width: min(100vw, 1280px);
+      height: min(100vh, 720px);
+      position: relative;
+      background: #050608;
+      overflow: hidden;
+    }
+    video {
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+      background: #050608;
+    }
+    #status {
+      position: absolute;
+      left: 16px;
+      bottom: 16px;
+      max-width: calc(100% - 32px);
+      padding: 10px 12px;
+      border-radius: 10px;
+      background: rgba(0, 0, 0, 0.65);
+      color: #d4d4d8;
+      font: 12px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <video id="video" autoplay playsinline controls muted></video>
+    <div id="status">Connecting...</div>
+  </main>
+  <script>
+    const signalingUrl = __SIGNALING_URL__;
+    const video = document.getElementById('video');
+    const status = document.getElementById('status');
+    let ws = null;
+    let peerId = null;
+    let producerId = null;
+    let sessionId = null;
+    let pc = null;
+    let stream = new MediaStream();
+
+    function log(message) {
+      console.log('[Reachy Camera]', message);
+      status.textContent = message;
+    }
+
+    function send(message) {
+      if (!ws || ws.readyState !== WebSocket.OPEN) return false;
+      ws.send(JSON.stringify(message));
+      return true;
+    }
+
+    function closeSession() {
+      if (sessionId) send({ type: 'endSession', sessionId });
+      sessionId = null;
+      if (pc) pc.close();
+      pc = null;
+      stream = new MediaStream();
+      video.srcObject = stream;
+    }
+
+    function startProducer(id) {
+      if (sessionId || producerId === id) return;
+      producerId = id;
+      log('Starting stream session...');
+      send({ type: 'startSession', peerId: producerId });
+    }
+
+    async function handleOffer(sdp) {
+      if (!pc) {
+        pc = new RTCPeerConnection({
+          iceServers: [
+            { urls: 'stun:stun.l.google.com:19302' },
+            { urls: 'stun:stun1.l.google.com:19302' },
+          ],
+        });
+        pc.ontrack = event => {
+          for (const track of event.streams[0]?.getTracks() ?? [event.track]) {
+            if (!stream.getTracks().some(existing => existing.id === track.id)) {
+              stream.addTrack(track);
+            }
+          }
+          video.srcObject = stream;
+          video.play().catch(() => {});
+          log('Stream connected');
+        };
+        pc.onicecandidate = event => {
+          if (event.candidate && sessionId) {
+            send({ type: 'peer', sessionId, ice: event.candidate.toJSON() });
+          }
+        };
+        pc.onconnectionstatechange = () => log(`Connection: ${pc.connectionState}`);
+        pc.oniceconnectionstatechange = () => log(`ICE: ${pc.iceConnectionState}`);
+      }
+
+      log('Applying offer...');
+      await pc.setRemoteDescription(sdp);
+      const answer = await pc.createAnswer();
+      await pc.setLocalDescription(answer);
+      send({ type: 'peer', sessionId, sdp: pc.localDescription.toJSON() });
+      log('Answer sent, waiting for media...');
+    }
+
+    async function handleMessage(raw) {
+      const message = JSON.parse(raw.data);
+      switch (message.type) {
+        case 'welcome':
+          peerId = message.peerId;
+          send({ type: 'setPeerStatus', roles: ['listener'], meta: { name: 'reachy-external-browser' } });
+          break;
+        case 'peerStatusChanged':
+          if (message.peerId === peerId && message.roles?.includes('listener')) {
+            send({ type: 'list' });
+          } else if (message.roles?.includes('producer') && message.meta?.name === 'reachymini') {
+            startProducer(message.peerId);
+          }
+          break;
+        case 'list':
+          for (const producer of message.producers ?? []) {
+            if (producer.meta?.name === 'reachymini') startProducer(producer.peerId || producer.id);
+          }
+          break;
+        case 'sessionStarted':
+          sessionId = message.sessionId;
+          log('Session started, waiting for offer...');
+          break;
+        case 'peer':
+          if (message.sessionId !== sessionId) return;
+          if (message.sdp) await handleOffer(message.sdp);
+          if (message.ice && pc) await pc.addIceCandidate(new RTCIceCandidate(message.ice));
+          break;
+        case 'endSession':
+          log(message.reason || 'Session ended');
+          closeSession();
+          break;
+        case 'error':
+          throw new Error(message.details || 'Signaling server error');
+      }
+    }
+
+    if (!window.RTCPeerConnection) {
+      log('This browser does not support WebRTC');
+    } else {
+      ws = new WebSocket(signalingUrl);
+      ws.onopen = () => log(`Connected to ${signalingUrl}`);
+      ws.onmessage = event => handleMessage(event).catch(error => {
+        console.error(error);
+        log(`Error: ${error.name || 'Error'}: ${error.message || error}`);
+      });
+      ws.onerror = () => log('WebSocket error');
+      ws.onclose = () => log('Disconnected');
+      window.addEventListener('beforeunload', closeSession);
+    }
+  </script>
+</body>
+</html>
+"#
 }
 
 // ============================================================================
@@ -467,6 +677,7 @@ pub fn run() {
             set_daemon_external_mode,
             get_daemon_status,
             get_logs,
+            open_external_camera_viewer,
             check_crash_marker,
             usb::check_usb_robot,
             window::apply_transparent_titlebar,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -38,6 +38,7 @@
       "app",
       "msi",
       "deb",
+      "rpm",
       "appimage"
     ],
     "icon": [

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -19,6 +19,31 @@
           "/usr/share/reachy-mini-control/gstreamer-plugins/libgstrswebrtc.so": "linux/gstreamer-plugins/x86_64/libgstrswebrtc.so",
           "/usr/share/reachy-mini-control/gstreamer-plugins/libgstrsrtp.so": "linux/gstreamer-plugins/x86_64/libgstrsrtp.so"
         }
+      },
+      "rpm": {
+        "depends": [
+          "webkit2gtk4.1",
+          "gtk3",
+          "libayatana-appindicator-gtk3",
+          "librsvg2",
+          "portaudio",
+          "gstreamer1",
+          "gstreamer1-plugins-base",
+          "gstreamer1-plugins-good",
+          "gstreamer1-plugins-bad-free",
+          "libnice",
+          "libnice-gstreamer1",
+          "gobject-introspection",
+          "python3-gobject",
+          "python3-cairo"
+        ],
+        "files": {
+          "/usr/share/reachy-mini-control/99-reachy-mini.rules": "linux/99-reachy-mini.rules",
+          "/usr/share/reachy-mini-control/gstreamer-plugins/libgstrswebrtc.so": "linux/gstreamer-plugins/x86_64/libgstrswebrtc.so",
+          "/usr/share/reachy-mini-control/gstreamer-plugins/libgstrsrtp.so": "linux/gstreamer-plugins/x86_64/libgstrsrtp.so"
+        },
+        "postInstallScript": "linux/rpm-postinst.sh",
+        "postRemoveScript": "linux/rpm-postrm.sh"
       }
     }
   }

--- a/src/contexts/WebRTCStreamContext.tsx
+++ b/src/contexts/WebRTCStreamContext.tsx
@@ -17,7 +17,7 @@ import React, {
 import useAppStore from '../store/useAppStore';
 import { fetchWithTimeout, buildApiUrl } from '../config/daemon';
 import { ROBOT_STATUS } from '../constants/robotStatus';
-import { isLinux } from '../utils/platform';
+import { invoke } from '../utils/tauriCompat';
 
 // Import the GStreamer WebRTC API for its side effect (registers `window.GstWebRTCAPI`).
 import '../lib/gstwebrtc-api';
@@ -34,6 +34,20 @@ import type {
 const SIGNALING_PORT = 8443;
 const RECONNECT_DELAY = 2000;
 const INITIAL_RECONNECT_DELAY = 500;
+const STREAM_CONNECT_TIMEOUT = 10000;
+const WEBRTC_UNSUPPORTED_MESSAGE = 'WebRTC is not supported by this desktop WebView';
+
+function hasRTCPeerConnection(): boolean {
+  const webkitWindow = window as typeof window & {
+    webkitRTCPeerConnection?: typeof RTCPeerConnection;
+  };
+
+  if (!window.RTCPeerConnection && webkitWindow.webkitRTCPeerConnection) {
+    window.RTCPeerConnection = webkitWindow.webkitRTCPeerConnection;
+  }
+
+  return typeof window.RTCPeerConnection === 'function';
+}
 
 /** Connection states for the WebRTC stream. */
 export const StreamState = {
@@ -63,6 +77,7 @@ export interface WebRTCStreamContextValue {
   shouldConnect: boolean;
   connect: () => void;
   disconnect: () => void;
+  openExternalViewer: () => Promise<void>;
 }
 
 const WebRTCStreamContext = createContext<WebRTCStreamContextValue | null>(null);
@@ -96,10 +111,12 @@ export function WebRTCStreamProvider({ children }: WebRTCStreamProviderProps): R
   const producersListenerRef = useRef<GstWebRTCProducersListener | null>(null);
   const connectionListenerRef = useRef<GstWebRTCConnectionListener | null>(null);
   const hasConnectedRef = useRef<boolean>(false);
+  const connectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
-    if (isLinux()) {
-      // WebKit on Linux is not built with WebRTC support, so streaming is unavailable.
+    if (!hasRTCPeerConnection()) {
+      console.warn('[WebRTC]', WEBRTC_UNSUPPORTED_MESSAGE);
+      setError(WEBRTC_UNSUPPORTED_MESSAGE);
       setIsWebRTCAvailable(false);
       return;
     }
@@ -144,6 +161,11 @@ export function WebRTCStreamProvider({ children }: WebRTCStreamProviderProps): R
     if (reconnectTimeoutRef.current) {
       clearTimeout(reconnectTimeoutRef.current);
       reconnectTimeoutRef.current = null;
+    }
+
+    if (connectTimeoutRef.current) {
+      clearTimeout(connectTimeoutRef.current);
+      connectTimeoutRef.current = null;
     }
 
     if (sessionRef.current) {
@@ -195,10 +217,25 @@ export function WebRTCStreamProvider({ children }: WebRTCStreamProviderProps): R
     const signalingUrl = `ws://${host}:${SIGNALING_PORT}`;
 
     try {
+      console.info('[WebRTC] Connecting to signaling server:', signalingUrl);
+
+      if (!hasRTCPeerConnection()) {
+        throw new Error(WEBRTC_UNSUPPORTED_MESSAGE);
+      }
+
       const GstWebRTCAPI = window.GstWebRTCAPI;
       if (!GstWebRTCAPI) {
         throw new Error('GstWebRTCAPI not loaded');
       }
+
+      connectTimeoutRef.current = setTimeout(() => {
+        if (!mountedRef.current || stream) return;
+
+        const message = `Timed out waiting for WebRTC stream from ${signalingUrl}`;
+        console.error('[WebRTC]', message);
+        setError(message);
+        setState(StreamState.ERROR);
+      }, STREAM_CONNECT_TIMEOUT);
 
       const api = new GstWebRTCAPI({
         signalingServerUrl: signalingUrl,
@@ -217,10 +254,12 @@ export function WebRTCStreamProvider({ children }: WebRTCStreamProviderProps): R
       connectionListenerRef.current = {
         connected: () => {
           if (!mountedRef.current) return;
+          console.info('[WebRTC] Signaling connected:', signalingUrl);
           hasConnectedRef.current = true;
         },
         disconnected: () => {
           if (!mountedRef.current) return;
+          console.warn('[WebRTC] Signaling disconnected:', signalingUrl);
           setState(StreamState.DISCONNECTED);
           setStream(null);
           setAudioTrack(null);
@@ -248,7 +287,10 @@ export function WebRTCStreamProvider({ children }: WebRTCStreamProviderProps): R
         producerAdded: (producer: GstWebRTCProducer) => {
           if (!mountedRef.current) return;
 
+          console.info('[WebRTC] Producer added:', producer.id, producer.meta);
+
           if (sessionRef.current) {
+            console.info('[WebRTC] Ignoring producer; session already exists');
             return;
           }
 
@@ -262,8 +304,17 @@ export function WebRTCStreamProvider({ children }: WebRTCStreamProviderProps): R
 
           session.addEventListener('error', (event: Event) => {
             if (!mountedRef.current) return;
-            const message = (event as Event & { message?: string }).message || 'Stream error';
-            console.error('[WebRTC] Session error:', message);
+            const errorEvent = event as ErrorEvent;
+            const details =
+              errorEvent.error instanceof Error
+                ? `${errorEvent.error.name}: ${errorEvent.error.message}`
+                : errorEvent.error
+                  ? String(errorEvent.error)
+                  : null;
+            const message = [errorEvent.message || 'Stream error', details]
+              .filter(Boolean)
+              .join(' - ');
+            console.error('[WebRTC] Session error:', message, errorEvent.error);
             setError(message);
 
             if (mountedRef.current && !reconnectTimeoutRef.current) {
@@ -284,18 +335,72 @@ export function WebRTCStreamProvider({ children }: WebRTCStreamProviderProps): R
 
           session.addEventListener('closed', () => {
             if (!mountedRef.current) return;
+            console.warn('[WebRTC] Session closed', {
+              sessionId: session.sessionId,
+              state: session.state,
+              peerConnection: session.rtcPeerConnection
+                ? {
+                    connectionState: session.rtcPeerConnection.connectionState,
+                    iceConnectionState: session.rtcPeerConnection.iceConnectionState,
+                    iceGatheringState: session.rtcPeerConnection.iceGatheringState,
+                    signalingState: session.rtcPeerConnection.signalingState,
+                  }
+                : null,
+            });
             sessionRef.current = null;
             setStream(null);
             setAudioTrack(null);
             setState(prev => (prev === StreamState.CONNECTED ? StreamState.DISCONNECTED : prev));
           });
 
+          session.addEventListener('rtcPeerConnectionChanged', () => {
+            if (!mountedRef.current) return;
+            const peerConnection = session.rtcPeerConnection;
+            if (!peerConnection) {
+              console.info('[WebRTC] Peer connection cleared');
+              return;
+            }
+
+            const logPeerState = (label: string): void => {
+              console.info(`[WebRTC] ${label}:`, {
+                connectionState: peerConnection.connectionState,
+                iceConnectionState: peerConnection.iceConnectionState,
+                iceGatheringState: peerConnection.iceGatheringState,
+                signalingState: peerConnection.signalingState,
+              });
+            };
+
+            logPeerState('Peer connection created');
+            peerConnection.addEventListener('connectionstatechange', () =>
+              logPeerState('Peer connection state changed')
+            );
+            peerConnection.addEventListener('iceconnectionstatechange', () =>
+              logPeerState('ICE connection state changed')
+            );
+            peerConnection.addEventListener('icegatheringstatechange', () =>
+              logPeerState('ICE gathering state changed')
+            );
+            peerConnection.addEventListener('signalingstatechange', () =>
+              logPeerState('Signaling state changed')
+            );
+          });
+
           session.addEventListener('streamsChanged', () => {
             if (!mountedRef.current) return;
             const streams = session.streams;
+            console.info('[WebRTC] Streams changed:', streams?.length ?? 0);
 
             if (streams && streams.length > 0) {
+              if (connectTimeoutRef.current) {
+                clearTimeout(connectTimeoutRef.current);
+                connectTimeoutRef.current = null;
+              }
+
               const mediaStream = streams[0];
+              console.info('[WebRTC] Stream connected:', {
+                audioTracks: mediaStream.getAudioTracks().length,
+                videoTracks: mediaStream.getVideoTracks().length,
+              });
               setStream(mediaStream);
               setState(StreamState.CONNECTED);
 
@@ -308,11 +413,14 @@ export function WebRTCStreamProvider({ children }: WebRTCStreamProviderProps): R
             }
           });
 
+          console.info('[WebRTC] Connecting consumer session');
           session.connect();
         },
 
         producerRemoved: () => {
           if (!mountedRef.current) return;
+
+          console.warn('[WebRTC] Producer removed');
 
           if (sessionRef.current) {
             sessionRef.current.close();
@@ -338,6 +446,18 @@ export function WebRTCStreamProvider({ children }: WebRTCStreamProviderProps): R
     cleanup();
     setState(StreamState.DISCONNECTED);
   }, [cleanup]);
+
+  const openExternalViewer = useCallback(async (): Promise<void> => {
+    const host = remoteHost || 'localhost';
+    try {
+      await invoke('open_external_camera_viewer', { host });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      console.error('[WebRTC] Failed to open external camera viewer:', message);
+      setError(message);
+      setState(StreamState.ERROR);
+    }
+  }, [remoteHost]);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -372,6 +492,7 @@ export function WebRTCStreamProvider({ children }: WebRTCStreamProviderProps): R
 
     connect,
     disconnect,
+    openExternalViewer,
   };
 
   return <WebRTCStreamContext.Provider value={value}>{children}</WebRTCStreamContext.Provider>;

--- a/src/types/gstwebrtc.ts
+++ b/src/types/gstwebrtc.ts
@@ -11,6 +11,9 @@ export interface GstWebRTCProducer {
 
 export interface GstWebRTCConsumerSession extends EventTarget {
   streams: readonly MediaStream[];
+  rtcPeerConnection?: RTCPeerConnection | null;
+  sessionId?: string;
+  state?: number;
   connect: () => void;
   close: () => void;
 }

--- a/src/views/active-robot/camera/CameraFeed.tsx
+++ b/src/views/active-robot/camera/CameraFeed.tsx
@@ -1,7 +1,8 @@
 import React, { useRef, useEffect } from 'react';
-import { Box, Typography, CircularProgress } from '@mui/material';
+import { Box, Typography, CircularProgress, Button } from '@mui/material';
 import VideocamOutlinedIcon from '@mui/icons-material/VideocamOutlined';
 import VideocamOffIcon from '@mui/icons-material/VideocamOff';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { STATUS, whiteAlpha, blackAlpha } from '@styles/tokens';
 import { DURATION, RADIUS, TYPO, transition, useAppPalette } from '@styles';
 import { useWebRTCStreamContext, StreamState } from '../../../contexts/WebRTCStreamContext';
@@ -29,7 +30,9 @@ export default function CameraFeed({ isLarge = false }: CameraFeedProps): React.
     isWebRTCAvailable,
     checkFailed,
     isRobotAwake,
+    error,
     connect,
+    openExternalViewer,
   } = useWebRTCStreamContext();
 
   // Attach/detach stream to video element
@@ -74,6 +77,9 @@ export default function CameraFeed({ isLarge = false }: CameraFeedProps): React.
   const spinnerColor = palette.isDark ? whiteAlpha(0.45) : blackAlpha(0.35);
   const errorIconColor = `${STATUS.error}99`;
   const errorTextColor = `${STATUS.error}b3`;
+  const canOpenExternalViewer = error === 'WebRTC is not supported by this desktop WebView';
+  const unavailableLabel =
+    !isLarge && canOpenExternalViewer ? 'Open in browser' : 'Stream not available';
 
   // Common placeholder box style
   const placeholderStyle = {
@@ -119,8 +125,47 @@ export default function CameraFeed({ isLarge = false }: CameraFeedProps): React.
               letterSpacing: '0.5px',
             }}
           >
-            Stream not available
+            {unavailableLabel}
           </Typography>
+          {error && isLarge && (
+            <Typography
+              sx={{
+                maxWidth: '85%',
+                fontSize: isLarge ? TYPO.xs : '9px',
+                color: textColorMuted,
+                fontFamily: 'SF Mono, Monaco, Menlo, monospace',
+                textAlign: 'center',
+                wordBreak: 'break-word',
+              }}
+            >
+              {error}
+            </Typography>
+          )}
+          {canOpenExternalViewer && (
+            <Button
+              size="small"
+              variant="outlined"
+              startIcon={isLarge ? <OpenInNewIcon /> : undefined}
+              onClick={openExternalViewer}
+              sx={{
+                mt: isLarge ? 1 : 0.25,
+                minWidth: 0,
+                px: isLarge ? 1.5 : 0.75,
+                py: isLarge ? 0.375 : 0.25,
+                color: textColorMuted,
+                borderColor: iconColorMuted,
+                fontSize: isLarge ? TYPO.xs : '9px',
+                fontFamily: 'SF Mono, Monaco, Menlo, monospace',
+                textTransform: 'uppercase',
+                '&:hover': {
+                  borderColor: textColorMuted,
+                  bgcolor: hoverBg,
+                },
+              }}
+            >
+              {isLarge ? 'Open in browser' : 'Open'}
+            </Button>
+          )}
         </Box>
       </Box>
     );
@@ -264,6 +309,21 @@ export default function CameraFeed({ isLarge = false }: CameraFeedProps): React.
           >
             {state === StreamState.ERROR ? 'Connection failed' : 'Click to connect'}
           </Typography>
+          {state === StreamState.ERROR && error && (
+            <Typography
+              sx={{
+                maxWidth: '85%',
+                fontSize: isLarge ? TYPO.xs : '9px',
+                color: errorTextColor,
+                fontFamily: 'SF Mono, Monaco, Menlo, monospace',
+                textAlign: 'center',
+                wordBreak: 'break-word',
+                textTransform: 'none',
+              }}
+            >
+              {error}
+            </Typography>
+          )}
         </Box>
       )}
     </Box>


### PR DESCRIPTION
## Summary
- add Fedora RPM bundling, release artifacts, lifecycle scripts, and Linux packaging docs
- add missing Fedora GStreamer WebRTC dependency (`libnice-gstreamer1`)
- detect Linux WebViews without `RTCPeerConnection` and offer an external browser camera viewer fallback

Fixes https://github.com/pollen-robotics/reachy-mini-desktop-app/issues/213

## Testing
- `yarn build`
- `cargo check -q`
- built and installed RPM locally on Fedora
- verified external browser camera viewer works locally