### PR TITLE
feat: add Fedora RPM packaging support

### DIFF
--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -704,7 +704,7 @@ jobs:
           # Prevent linuxdeploy from leaving temp files
           NO_CLEANUP: 0
         run: |
-          # Install dependencies required for .deb and AppImage build
+          # Install dependencies required for .deb, .rpm and AppImage build
           # patchelf is CRITICAL for linuxdeploy to work
           sudo apt-get update
           sudo apt-get install -y \
@@ -728,6 +728,7 @@ jobs:
             file \
             libc-bin \
             dpkg-dev \
+            rpm \
             libfuse2t64 \
             squashfs-tools \
             patchelf
@@ -1423,6 +1424,15 @@ jobs:
             src-tauri/target/${{ matrix.target }}/release/bundle/deb/*.deb
           retention-days: 30
 
+      - name: Upload .rpm package (Linux)
+        if: matrix.os == 'ubuntu-24.04'
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpm-${{ matrix.platform }}
+          path: |
+            src-tauri/target/${{ matrix.target }}/release/bundle/rpm/*.rpm
+          retention-days: 30
+
       - name: Create GitHub Release
         if: matrix.os == 'macos-latest' && matrix.target == 'aarch64-apple-darwin' && github.event.inputs.dry_run != 'true'
         uses: softprops/action-gh-release@v2
@@ -1435,6 +1445,8 @@ jobs:
           files: |
             src-tauri/target/*/release/bundle/deb/*.deb
             src-tauri/target/*/release/bundle/deb/*.deb.sig
+            src-tauri/target/*/release/bundle/rpm/*.rpm
+            src-tauri/target/*/release/bundle/rpm/*.rpm.sig
             src-tauri/target/*/release/bundle/msi/*.msi
             src-tauri/target/*/release/bundle/msi/*.msi.sig
             src-tauri/target/*/release/bundle/appimage/*.AppImage
@@ -1462,6 +1474,8 @@ jobs:
             ${{ matrix.os == 'windows-latest' && format('src-tauri/target/{0}/release/bundle/msi/*.msi.sig', matrix.target) || '' }}
             ${{ matrix.os == 'ubuntu-24.04' && format('src-tauri/target/{0}/release/bundle/deb/*.deb', matrix.target) || '' }}
             ${{ matrix.os == 'ubuntu-24.04' && format('src-tauri/target/{0}/release/bundle/deb/*.deb.sig', matrix.target) || '' }}
+            ${{ matrix.os == 'ubuntu-24.04' && format('src-tauri/target/{0}/release/bundle/rpm/*.rpm', matrix.target) || '' }}
+            ${{ matrix.os == 'ubuntu-24.04' && format('src-tauri/target/{0}/release/bundle/rpm/*.rpm.sig', matrix.target) || '' }}
             ${{ matrix.os == 'ubuntu-24.04' && format('src-tauri/target/{0}/release/bundle/appimage/*.AppImage', matrix.target) || '' }}
             ${{ matrix.os == 'ubuntu-24.04' && format('src-tauri/target/{0}/release/bundle/appimage/*.AppImage.tar.gz', matrix.target) || '' }}
             ${{ matrix.os == 'ubuntu-24.04' && format('src-tauri/target/{0}/release/bundle/appimage/*.AppImage.tar.gz.sig', matrix.target) || '' }}
@@ -1473,7 +1487,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Dry-run only: upload the raw installers (.msi / .dmg / .deb / .AppImage)
+      # Dry-run only: upload the raw installers (.msi / .dmg / .deb / .rpm / .AppImage)
       # so they can be downloaded from the Actions run directly, since no
       # GitHub Release is created in this mode.
       - name: Upload installers (dry run)
@@ -1488,6 +1502,8 @@ jobs:
             src-tauri/target/${{ matrix.target }}/release/bundle/macos/*.zip
             src-tauri/target/${{ matrix.target }}/release/bundle/deb/*.deb
             src-tauri/target/${{ matrix.target }}/release/bundle/deb/*.deb.sig
+            src-tauri/target/${{ matrix.target }}/release/bundle/rpm/*.rpm
+            src-tauri/target/${{ matrix.target }}/release/bundle/rpm/*.rpm.sig
             src-tauri/target/${{ matrix.target }}/release/bundle/appimage/*.AppImage
             src-tauri/target/${{ matrix.target }}/release/bundle/appimage/*.AppImage.tar.gz
             src-tauri/target/${{ matrix.target }}/release/bundle/appimage/*.AppImage.tar.gz.sig
@@ -1505,7 +1521,7 @@ jobs:
           echo "🧪"
           echo "🧪 Artifacts available in this run:"
           echo "🧪   - update-${{ matrix.platform }}         (updater payload + signed manifests)"
-          echo "🧪   - dry-run-installer-${{ matrix.platform }} (raw installers: .msi / .dmg / .deb / .AppImage)"
+          echo "🧪   - dry-run-installer-${{ matrix.platform }} (raw installers: .msi / .dmg / .deb / .rpm / .AppImage)"
           echo "🧪"
           echo "🧪 Download them from the Actions tab → this workflow run → Artifacts section."
           echo "🧪 No release was created, no users will be notified."

--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -704,7 +704,7 @@ jobs:
           # Prevent linuxdeploy from leaving temp files
           NO_CLEANUP: 0
         run: |
-          # Install dependencies required for .deb, .rpm and AppImage build
+          # Install dependencies required for .deb and AppImage build
           # patchelf is CRITICAL for linuxdeploy to work
           sudo apt-get update
           sudo apt-get install -y \
@@ -728,7 +728,6 @@ jobs:
             file \
             libc-bin \
             dpkg-dev \
-            rpm \
             libfuse2t64 \
             squashfs-tools \
             patchelf
@@ -761,6 +760,13 @@ jobs:
 
           # Build with verbose output
           yarn tauri build --target ${{ matrix.target }} -v
+
+      - name: Build RPM package (Linux, best effort)
+        if: matrix.os == 'ubuntu-24.04'
+        continue-on-error: true
+        shell: bash
+        working-directory: src-tauri
+        run: yarn tauri build --target ${{ matrix.target }} --bundles rpm
 
       - name: Add post-install scripts to .deb (Linux)
         if: matrix.os == 'ubuntu-24.04'
@@ -1446,7 +1452,6 @@ jobs:
             src-tauri/target/*/release/bundle/deb/*.deb
             src-tauri/target/*/release/bundle/deb/*.deb.sig
             src-tauri/target/*/release/bundle/rpm/*.rpm
-            src-tauri/target/*/release/bundle/rpm/*.rpm.sig
             src-tauri/target/*/release/bundle/msi/*.msi
             src-tauri/target/*/release/bundle/msi/*.msi.sig
             src-tauri/target/*/release/bundle/appimage/*.AppImage
@@ -1475,7 +1480,6 @@ jobs:
             ${{ matrix.os == 'ubuntu-24.04' && format('src-tauri/target/{0}/release/bundle/deb/*.deb', matrix.target) || '' }}
             ${{ matrix.os == 'ubuntu-24.04' && format('src-tauri/target/{0}/release/bundle/deb/*.deb.sig', matrix.target) || '' }}
             ${{ matrix.os == 'ubuntu-24.04' && format('src-tauri/target/{0}/release/bundle/rpm/*.rpm', matrix.target) || '' }}
-            ${{ matrix.os == 'ubuntu-24.04' && format('src-tauri/target/{0}/release/bundle/rpm/*.rpm.sig', matrix.target) || '' }}
             ${{ matrix.os == 'ubuntu-24.04' && format('src-tauri/target/{0}/release/bundle/appimage/*.AppImage', matrix.target) || '' }}
             ${{ matrix.os == 'ubuntu-24.04' && format('src-tauri/target/{0}/release/bundle/appimage/*.AppImage.tar.gz', matrix.target) || '' }}
             ${{ matrix.os == 'ubuntu-24.04' && format('src-tauri/target/{0}/release/bundle/appimage/*.AppImage.tar.gz.sig', matrix.target) || '' }}
@@ -1503,7 +1507,6 @@ jobs:
             src-tauri/target/${{ matrix.target }}/release/bundle/deb/*.deb
             src-tauri/target/${{ matrix.target }}/release/bundle/deb/*.deb.sig
             src-tauri/target/${{ matrix.target }}/release/bundle/rpm/*.rpm
-            src-tauri/target/${{ matrix.target }}/release/bundle/rpm/*.rpm.sig
             src-tauri/target/${{ matrix.target }}/release/bundle/appimage/*.AppImage
             src-tauri/target/${{ matrix.target }}/release/bundle/appimage/*.AppImage.tar.gz
             src-tauri/target/${{ matrix.target }}/release/bundle/appimage/*.AppImage.tar.gz.sig

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ yarn tauri build --target aarch64-apple-darwin
 yarn tauri build --target x86_64-apple-darwin
 yarn tauri build --target x86_64-pc-windows-msvc
 yarn tauri build --target x86_64-unknown-linux-gnu
+yarn tauri build --target x86_64-unknown-linux-gnu --bundles rpm  # Fedora RPM only
 ```
 
 #### Installing the daemon from different sources
@@ -178,6 +179,7 @@ yarn build:sidecar:branch             # Interactive branch selection
 
 # Build application
 yarn tauri:build                      # Build production bundle
+yarn tauri:build:rpm                  # Build Fedora RPM package
 
 # Build web dashboard (for daemon)
 yarn build:web                        # Build web version

--- a/docs/LINUX_PACKAGING_STRATEGY.md
+++ b/docs/LINUX_PACKAGING_STRATEGY.md
@@ -38,9 +38,25 @@ Ce document analyse comment les principaux projets Tauri gèrent le packaging et
 - Installation initiale propre avec dépendances système
 - Distribution via repositories APT
 
-### 3. Autres Formats
+### 3. Packages .rpm Fedora
 
-- **RPM** : Pour Fedora/RHEL (même limitations que .deb)
+**Avantages :**
+- ✅ Intégration native avec Fedora via `dnf`
+- ✅ Gestion automatique des dépendances système Fedora
+- ✅ Scripts post-installation (udev rules, permissions)
+- ✅ Alternative propre pour les utilisateurs hors Debian/Ubuntu
+
+**Inconvénients :**
+- ❌ Non supporté par l'auto-updater Tauri
+- ❌ Les noms de dépendances varient entre Fedora, RHEL et openSUSE
+- ❌ Support initial limité à Fedora
+
+**Cas d'usage :**
+- Installation initiale propre sur Fedora
+- Distribution via releases GitHub ou dépôt RPM Fedora à terme
+
+### 4. Autres Formats
+
 - **Flatpak** : Sandboxing, distribution via Flathub
 - **Snap** : Alternative à Flatpak, mais controversé dans la communauté Linux
 

--- a/docs/LINUX_SETUP.md
+++ b/docs/LINUX_SETUP.md
@@ -63,7 +63,7 @@ Le package `.rpm` cible Fedora. Il déclare les dépendances runtime Fedora, ins
 
 ```bash
 # Installer le package
-sudo dnf install ./reachy-mini-control-*.rpm
+sudo dnf install ./Reachy\ Mini\ Control-*.rpm
 
 # Note: Après l'installation, vous devrez peut-être :
 # 1. Vous déconnecter et vous reconnecter (pour les changements de groupe)
@@ -120,16 +120,17 @@ yarn build:sidecar-linux
 yarn tauri:build
 ```
 
-Les packages Linux seront générés dans :
+Le build Linux par défaut génère :
 - `.deb` : `src-tauri/target/release/bundle/deb/`
-- `.rpm` : `src-tauri/target/release/bundle/rpm/`
 - AppImage : `src-tauri/target/release/bundle/appimage/`
 
-Pour compiler uniquement le RPM Fedora :
+Pour compiler le RPM Fedora séparément :
 
 ```bash
 yarn tauri:build:rpm
 ```
+
+Le package `.rpm` sera généré dans `src-tauri/target/release/bundle/rpm/`.
 
 ## Système de Mises à Jour
 

--- a/docs/LINUX_SETUP.md
+++ b/docs/LINUX_SETUP.md
@@ -57,6 +57,21 @@ Cela signifie que :
 
 > **Note** : Les builds Linux sont actuellement désactivés dans le workflow de release en raison de problèmes avec le bundling AppImage et les dépendances natives Python. Voir [issue #35](https://github.com/pollen-robotics/reachy-mini-desktop-app/issues/35).
 
+### Installation via Package .rpm (Fedora)
+
+Le package `.rpm` cible Fedora. Il déclare les dépendances runtime Fedora, installe les règles udev pour l'accès USB au robot et configure l'utilisateur dans le groupe `dialout` quand celui-ci existe.
+
+```bash
+# Installer le package
+sudo dnf install ./reachy-mini-control-*.rpm
+
+# Note: Après l'installation, vous devrez peut-être :
+# 1. Vous déconnecter et vous reconnecter (pour les changements de groupe)
+# 2. Débrancher et rebrancher le câble USB de votre Reachy Mini
+```
+
+Le support RPM est validé comme cible Fedora en priorité. Les distributions RHEL/openSUSE peuvent avoir des noms de dépendances GStreamer/WebKit différents et ne sont pas encore considérées comme supportées officiellement.
+
 ### Build Depuis les Sources
 
 #### Dépendances de Build
@@ -105,7 +120,16 @@ yarn build:sidecar-linux
 yarn tauri:build
 ```
 
-Le package `.deb` sera généré dans `src-tauri/target/release/bundle/deb/`.
+Les packages Linux seront générés dans :
+- `.deb` : `src-tauri/target/release/bundle/deb/`
+- `.rpm` : `src-tauri/target/release/bundle/rpm/`
+- AppImage : `src-tauri/target/release/bundle/appimage/`
+
+Pour compiler uniquement le RPM Fedora :
+
+```bash
+yarn tauri:build:rpm
+```
 
 ## Système de Mises à Jour
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "tauri:dev": "tauri dev --no-watch",
     "tauri:dev:fresh": "yarn kill-daemon && yarn clean && yarn build:sidecar-macos && yarn tauri:dev",
     "tauri:build": "tauri build",
+    "tauri:build:rpm": "tauri build --bundles rpm",
     "build:sidecar-macos": "bash ./scripts/build/build-sidecar-unix.sh",
     "build:sidecar-linux": "bash ./scripts/build/build-sidecar-unix.sh",
     "build:sidecar-windows": "powershell ./scripts/build/build-sidecar-windows.ps1",

--- a/src-tauri/linux/rpm-postinst.sh
+++ b/src-tauri/linux/rpm-postinst.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Post-installation script for Reachy Mini Control Fedora RPM package.
+
+set -e
+
+APP_LIB_DIR="/usr/lib/Reachy Mini Control"
+UDEV_RULES_FILE="/etc/udev/rules.d/99-reachy-mini.rules"
+UDEV_RULES_SOURCE="/usr/share/reachy-mini-control/99-reachy-mini.rules"
+
+echo "Patching Python virtual environment paths..."
+
+PYVENV_CFG="$APP_LIB_DIR/.venv/pyvenv.cfg"
+if [ -f "$PYVENV_CFG" ]; then
+    CPYTHON_FOLDER=$(ls -d "$APP_LIB_DIR"/cpython-* 2>/dev/null | head -1)
+
+    if [ -n "$CPYTHON_FOLDER" ]; then
+        CPYTHON_BIN="$CPYTHON_FOLDER/bin"
+        sed -i "s|^home = .*|home = $CPYTHON_BIN|g" "$PYVENV_CFG"
+        echo "pyvenv.cfg patched: $CPYTHON_BIN"
+    else
+        echo "Warning: cpython folder not found in $APP_LIB_DIR"
+    fi
+else
+    echo "Warning: pyvenv.cfg not found at $PYVENV_CFG"
+fi
+
+echo "Configuring Reachy Mini USB permissions..."
+
+if [ -f "$UDEV_RULES_SOURCE" ]; then
+    if [ ! -f "$UDEV_RULES_FILE" ] || ! cmp -s "$UDEV_RULES_SOURCE" "$UDEV_RULES_FILE"; then
+        cp "$UDEV_RULES_SOURCE" "$UDEV_RULES_FILE"
+        chmod 0644 "$UDEV_RULES_FILE"
+        echo "udev rules installed"
+    else
+        echo "udev rules already up to date"
+    fi
+else
+    echo "Warning: udev rules source file not found at $UDEV_RULES_SOURCE"
+fi
+
+if [ -f "$UDEV_RULES_FILE" ]; then
+    udevadm control --reload-rules || true
+    udevadm trigger || true
+    echo "udev rules reloaded"
+fi
+
+CURRENT_USER="${SUDO_USER:-${USER}}"
+if [ -n "$CURRENT_USER" ] && [ "$CURRENT_USER" != "root" ] && getent group dialout >/dev/null; then
+    if ! groups "$CURRENT_USER" | grep -q "\bdialout\b"; then
+        usermod -aG dialout "$CURRENT_USER" || true
+        echo "User '$CURRENT_USER' added to dialout group"
+        echo "Log out and back in for group changes to take effect"
+    else
+        echo "User '$CURRENT_USER' already in dialout group"
+    fi
+fi
+
+echo "Reachy Mini USB permissions configured"
+
+exit 0

--- a/src-tauri/linux/rpm-postrm.sh
+++ b/src-tauri/linux/rpm-postrm.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Post-removal script for Reachy Mini Control Fedora RPM package.
+
+set -e
+
+UDEV_RULES_FILE="/etc/udev/rules.d/99-reachy-mini.rules"
+
+# RPM passes 0 on final erase and 1 on upgrade. Keep rules during upgrades.
+if [ "${1:-0}" != "0" ]; then
+    exit 0
+fi
+
+echo "Cleaning up Reachy Mini USB permissions..."
+
+if [ -f "$UDEV_RULES_FILE" ]; then
+    if grep -q "Reachy Mini" "$UDEV_RULES_FILE" 2>/dev/null; then
+        rm -f "$UDEV_RULES_FILE"
+        udevadm control --reload-rules || true
+        udevadm trigger || true
+        echo "udev rules removed"
+    else
+        echo "Keeping udev rules not installed by this package"
+    fi
+fi
+
+echo "Cleanup completed"
+
+exit 0

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -38,7 +38,6 @@
       "app",
       "msi",
       "deb",
-      "rpm",
       "appimage"
     ],
     "icon": [

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -38,6 +38,7 @@
       "app",
       "msi",
       "deb",
+      "rpm",
       "appimage"
     ],
     "icon": [

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -19,6 +19,31 @@
           "/usr/share/reachy-mini-control/gstreamer-plugins/libgstrswebrtc.so": "linux/gstreamer-plugins/x86_64/libgstrswebrtc.so",
           "/usr/share/reachy-mini-control/gstreamer-plugins/libgstrsrtp.so": "linux/gstreamer-plugins/x86_64/libgstrsrtp.so"
         }
+      },
+      "rpm": {
+        "depends": [
+          "webkit2gtk4.1",
+          "gtk3",
+          "libayatana-appindicator-gtk3",
+          "librsvg2",
+          "portaudio",
+          "gstreamer1",
+          "gstreamer1-plugins-base",
+          "gstreamer1-plugins-good",
+          "gstreamer1-plugins-bad-free",
+          "libnice",
+          "libnice-gstreamer1",
+          "gobject-introspection",
+          "python3-gobject",
+          "python3-cairo"
+        ],
+        "files": {
+          "/usr/share/reachy-mini-control/99-reachy-mini.rules": "linux/99-reachy-mini.rules",
+          "/usr/share/reachy-mini-control/gstreamer-plugins/libgstrswebrtc.so": "linux/gstreamer-plugins/x86_64/libgstrswebrtc.so",
+          "/usr/share/reachy-mini-control/gstreamer-plugins/libgstrsrtp.so": "linux/gstreamer-plugins/x86_64/libgstrsrtp.so"
+        },
+        "postInstallScript": "linux/rpm-postinst.sh",
+        "postRemoveScript": "linux/rpm-postrm.sh"
       }
     }
   }


### PR DESCRIPTION
This PR extracts the Fedora RPM packaging work from #283, following the request to split RPM packaging and the Linux camera fallback into separate PRs.

Summary:
- add RPM as a Linux bundle target
- add Fedora runtime dependencies and RPM lifecycle scripts
- upload RPM artifacts from the release workflow
- document Fedora RPM installation and build steps

Fixes #213.

Validation:
- cargo check -q
- parsed package.json, src-tauri/tauri.conf.json, and src-tauri/tauri.linux.conf.json successfully
- bash -n src-tauri/linux/rpm-postinst.sh
- bash -n src-tauri/linux/rpm-postrm.sh
- git diff --check

Note:
- I kept this PR limited to packaging/release/docs changes so it can be reviewed independently from the camera fallback.
