### PR TITLE
fix: add Linux camera browser fallback

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -30,6 +30,7 @@ use local_proxy::LocalProxyState;
 use std::sync::Arc;
 use tauri::{Manager, State};
 use tauri_plugin_log::{Target, TargetKind};
+use tauri_plugin_opener::OpenerExt;
 
 #[cfg(not(windows))]
 use signal_hook::{consts::TERM_SIGNALS, iterator::Signals};
@@ -140,6 +141,215 @@ fn get_logs(state: State<DaemonState>) -> Result<Vec<String>, String> {
         .lock()
         .map_err(|e| format!("Failed to read logs: {}", e))?;
     Ok(logs.iter().cloned().collect())
+}
+
+#[tauri::command]
+fn open_external_camera_viewer(
+    app_handle: tauri::AppHandle,
+    host: Option<String>,
+) -> Result<String, String> {
+    let host = host
+        .filter(|h| !h.trim().is_empty())
+        .unwrap_or_else(|| "localhost".to_string());
+    let signaling_url = format!("ws://{}:8443", host);
+    let signaling_url_json = serde_json::to_string(&signaling_url)
+        .map_err(|e| format!("Failed to serialize signaling URL: {}", e))?;
+    let html = external_camera_viewer_html().replace("__SIGNALING_URL__", &signaling_url_json);
+    let path = std::env::temp_dir().join("reachy-mini-camera-viewer.html");
+
+    std::fs::write(&path, html)
+        .map_err(|e| format!("Failed to write external camera viewer: {}", e))?;
+
+    let url = tauri::Url::from_file_path(&path)
+        .map_err(|_| format!("Failed to convert path to file URL: {}", path.display()))?
+        .to_string();
+
+    app_handle
+        .opener()
+        .open_url(url.clone(), None::<&str>)
+        .map_err(|e| format!("Failed to open external camera viewer: {}", e))?;
+
+    Ok(url)
+}
+
+fn external_camera_viewer_html() -> &'static str {
+    r#"<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Reachy Mini Camera</title>
+  <style>
+    :root { color-scheme: dark; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      background: #0f1115;
+      color: #f4f4f5;
+      font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    main {
+      width: min(100vw, 1280px);
+      height: min(100vh, 720px);
+      position: relative;
+      background: #050608;
+      overflow: hidden;
+    }
+    video {
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+      background: #050608;
+    }
+    #status {
+      position: absolute;
+      left: 16px;
+      bottom: 16px;
+      max-width: calc(100% - 32px);
+      padding: 10px 12px;
+      border-radius: 10px;
+      background: rgba(0, 0, 0, 0.65);
+      color: #d4d4d8;
+      font: 12px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <video id="video" autoplay playsinline controls muted></video>
+    <div id="status">Connecting...</div>
+  </main>
+  <script>
+    const signalingUrl = __SIGNALING_URL__;
+    const video = document.getElementById('video');
+    const status = document.getElementById('status');
+    let ws = null;
+    let peerId = null;
+    let producerId = null;
+    let sessionId = null;
+    let pc = null;
+    let stream = new MediaStream();
+
+    function log(message) {
+      console.log('[Reachy Camera]', message);
+      status.textContent = message;
+    }
+
+    function send(message) {
+      if (!ws || ws.readyState !== WebSocket.OPEN) return false;
+      ws.send(JSON.stringify(message));
+      return true;
+    }
+
+    function closeSession() {
+      if (sessionId) send({ type: 'endSession', sessionId });
+      sessionId = null;
+      if (pc) pc.close();
+      pc = null;
+      stream = new MediaStream();
+      video.srcObject = stream;
+    }
+
+    function startProducer(id) {
+      if (sessionId || producerId === id) return;
+      producerId = id;
+      log('Starting stream session...');
+      send({ type: 'startSession', peerId: producerId });
+    }
+
+    async function handleOffer(sdp) {
+      if (!pc) {
+        pc = new RTCPeerConnection({
+          iceServers: [
+            { urls: 'stun:stun.l.google.com:19302' },
+            { urls: 'stun:stun1.l.google.com:19302' },
+          ],
+        });
+        pc.ontrack = event => {
+          for (const track of event.streams[0]?.getTracks() ?? [event.track]) {
+            if (!stream.getTracks().some(existing => existing.id === track.id)) {
+              stream.addTrack(track);
+            }
+          }
+          video.srcObject = stream;
+          video.play().catch(() => {});
+          log('Stream connected');
+        };
+        pc.onicecandidate = event => {
+          if (event.candidate && sessionId) {
+            send({ type: 'peer', sessionId, ice: event.candidate.toJSON() });
+          }
+        };
+        pc.onconnectionstatechange = () => log(`Connection: ${pc.connectionState}`);
+        pc.oniceconnectionstatechange = () => log(`ICE: ${pc.iceConnectionState}`);
+      }
+
+      log('Applying offer...');
+      await pc.setRemoteDescription(sdp);
+      const answer = await pc.createAnswer();
+      await pc.setLocalDescription(answer);
+      send({ type: 'peer', sessionId, sdp: pc.localDescription.toJSON() });
+      log('Answer sent, waiting for media...');
+    }
+
+    async function handleMessage(raw) {
+      const message = JSON.parse(raw.data);
+      switch (message.type) {
+        case 'welcome':
+          peerId = message.peerId;
+          send({ type: 'setPeerStatus', roles: ['listener'], meta: { name: 'reachy-external-browser' } });
+          break;
+        case 'peerStatusChanged':
+          if (message.peerId === peerId && message.roles?.includes('listener')) {
+            send({ type: 'list' });
+          } else if (message.roles?.includes('producer') && message.meta?.name === 'reachymini') {
+            startProducer(message.peerId);
+          }
+          break;
+        case 'list':
+          for (const producer of message.producers ?? []) {
+            if (producer.meta?.name === 'reachymini') startProducer(producer.peerId || producer.id);
+          }
+          break;
+        case 'sessionStarted':
+          sessionId = message.sessionId;
+          log('Session started, waiting for offer...');
+          break;
+        case 'peer':
+          if (message.sessionId !== sessionId) return;
+          if (message.sdp) await handleOffer(message.sdp);
+          if (message.ice && pc) await pc.addIceCandidate(new RTCIceCandidate(message.ice));
+          break;
+        case 'endSession':
+          log(message.reason || 'Session ended');
+          closeSession();
+          break;
+        case 'error':
+          throw new Error(message.details || 'Signaling server error');
+      }
+    }
+
+    if (!window.RTCPeerConnection) {
+      log('This browser does not support WebRTC');
+    } else {
+      ws = new WebSocket(signalingUrl);
+      ws.onopen = () => log(`Connected to ${signalingUrl}`);
+      ws.onmessage = event => handleMessage(event).catch(error => {
+        console.error(error);
+        log(`Error: ${error.name || 'Error'}: ${error.message || error}`);
+      });
+      ws.onerror = () => log('WebSocket error');
+      ws.onclose = () => log('Disconnected');
+      window.addEventListener('beforeunload', closeSession);
+    }
+  </script>
+</body>
+</html>
+"#
 }
 
 // ============================================================================
@@ -467,6 +677,7 @@ pub fn run() {
             set_daemon_external_mode,
             get_daemon_status,
             get_logs,
+            open_external_camera_viewer,
             check_crash_marker,
             usb::check_usb_robot,
             window::apply_transparent_titlebar,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -154,7 +154,9 @@ fn open_external_camera_viewer(
     let signaling_url = format!("ws://{}:8443", host);
     let signaling_url_json = serde_json::to_string(&signaling_url)
         .map_err(|e| format!("Failed to serialize signaling URL: {}", e))?;
-    let html = external_camera_viewer_html().replace("__SIGNALING_URL__", &signaling_url_json);
+    let html = external_camera_viewer_html()
+        .replace("__SIGNALING_URL__", &signaling_url_json)
+        .replace("__GST_WEBRTC_API__", gstwebrtc_api_js());
     let path = std::env::temp_dir().join("reachy-mini-camera-viewer.html");
 
     std::fs::write(&path, html)
@@ -224,132 +226,107 @@ fn external_camera_viewer_html() -> &'static str {
     <div id="status">Connecting...</div>
   </main>
   <script>
+    __GST_WEBRTC_API__
+  </script>
+  <script>
     const signalingUrl = __SIGNALING_URL__;
     const video = document.getElementById('video');
     const status = document.getElementById('status');
-    let ws = null;
-    let peerId = null;
-    let producerId = null;
-    let sessionId = null;
-    let pc = null;
-    let stream = new MediaStream();
+    let api = null;
+    let session = null;
 
     function log(message) {
       console.log('[Reachy Camera]', message);
       status.textContent = message;
     }
 
-    function send(message) {
-      if (!ws || ws.readyState !== WebSocket.OPEN) return false;
-      ws.send(JSON.stringify(message));
-      return true;
-    }
-
     function closeSession() {
-      if (sessionId) send({ type: 'endSession', sessionId });
-      sessionId = null;
-      if (pc) pc.close();
-      pc = null;
-      stream = new MediaStream();
-      video.srcObject = stream;
+      if (session) {
+        session.close();
+        session = null;
+      }
+      if (api?._channel) {
+        api._channel.close();
+      }
+      api = null;
+      video.srcObject = null;
     }
 
-    function startProducer(id) {
-      if (sessionId || producerId === id) return;
-      producerId = id;
+    function connectToProducer(producer) {
+      if (session || producer.meta?.name !== 'reachymini') return;
+
       log('Starting stream session...');
-      send({ type: 'startSession', peerId: producerId });
+      session = api.createConsumerSession(producer.id);
+      if (!session) {
+        log('Failed to create stream session');
+        return;
+      }
+
+      session.addEventListener('error', event => {
+        console.error(event);
+        log(`Stream error: ${event.message || event.error || 'Unknown error'}`);
+      });
+      session.addEventListener('closed', () => {
+        log('Session closed');
+        session = null;
+        video.srcObject = null;
+      });
+      session.addEventListener('streamsChanged', () => {
+        const [stream] = session.streams || [];
+        if (!stream) return;
+
+        video.srcObject = stream;
+        video.play().catch(() => {});
+        log('Stream connected');
+      });
+      session.connect();
     }
 
-    async function handleOffer(sdp) {
-      if (!pc) {
-        pc = new RTCPeerConnection({
+    try {
+      if (!window.RTCPeerConnection) {
+        throw new Error('This browser does not support WebRTC');
+      }
+      if (!window.GstWebRTCAPI) {
+        throw new Error('GstWebRTCAPI not loaded');
+      }
+
+      api = new window.GstWebRTCAPI({
+        signalingServerUrl: signalingUrl,
+        reconnectionTimeout: 0,
+        meta: { name: 'reachy-external-browser' },
+        webrtcConfig: {
           iceServers: [
             { urls: 'stun:stun.l.google.com:19302' },
             { urls: 'stun:stun1.l.google.com:19302' },
           ],
-        });
-        pc.ontrack = event => {
-          for (const track of event.streams[0]?.getTracks() ?? [event.track]) {
-            if (!stream.getTracks().some(existing => existing.id === track.id)) {
-              stream.addTrack(track);
-            }
-          }
-          video.srcObject = stream;
-          video.play().catch(() => {});
-          log('Stream connected');
-        };
-        pc.onicecandidate = event => {
-          if (event.candidate && sessionId) {
-            send({ type: 'peer', sessionId, ice: event.candidate.toJSON() });
-          }
-        };
-        pc.onconnectionstatechange = () => log(`Connection: ${pc.connectionState}`);
-        pc.oniceconnectionstatechange = () => log(`ICE: ${pc.iceConnectionState}`);
-      }
-
-      log('Applying offer...');
-      await pc.setRemoteDescription(sdp);
-      const answer = await pc.createAnswer();
-      await pc.setLocalDescription(answer);
-      send({ type: 'peer', sessionId, sdp: pc.localDescription.toJSON() });
-      log('Answer sent, waiting for media...');
-    }
-
-    async function handleMessage(raw) {
-      const message = JSON.parse(raw.data);
-      switch (message.type) {
-        case 'welcome':
-          peerId = message.peerId;
-          send({ type: 'setPeerStatus', roles: ['listener'], meta: { name: 'reachy-external-browser' } });
-          break;
-        case 'peerStatusChanged':
-          if (message.peerId === peerId && message.roles?.includes('listener')) {
-            send({ type: 'list' });
-          } else if (message.roles?.includes('producer') && message.meta?.name === 'reachymini') {
-            startProducer(message.peerId);
-          }
-          break;
-        case 'list':
-          for (const producer of message.producers ?? []) {
-            if (producer.meta?.name === 'reachymini') startProducer(producer.peerId || producer.id);
-          }
-          break;
-        case 'sessionStarted':
-          sessionId = message.sessionId;
-          log('Session started, waiting for offer...');
-          break;
-        case 'peer':
-          if (message.sessionId !== sessionId) return;
-          if (message.sdp) await handleOffer(message.sdp);
-          if (message.ice && pc) await pc.addIceCandidate(new RTCIceCandidate(message.ice));
-          break;
-        case 'endSession':
-          log(message.reason || 'Session ended');
-          closeSession();
-          break;
-        case 'error':
-          throw new Error(message.details || 'Signaling server error');
-      }
-    }
-
-    if (!window.RTCPeerConnection) {
-      log('This browser does not support WebRTC');
-    } else {
-      ws = new WebSocket(signalingUrl);
-      ws.onopen = () => log(`Connected to ${signalingUrl}`);
-      ws.onmessage = event => handleMessage(event).catch(error => {
-        console.error(error);
-        log(`Error: ${error.name || 'Error'}: ${error.message || error}`);
+        },
       });
-      ws.onerror = () => log('WebSocket error');
-      ws.onclose = () => log('Disconnected');
+
+      api.registerConnectionListener({
+        connected: () => log(`Connected to ${signalingUrl}`),
+        disconnected: () => log('Disconnected'),
+      });
+      api.registerProducersListener({
+        producerAdded: connectToProducer,
+        producerRemoved: () => {
+          if (session) {
+            session.close();
+          }
+        },
+      });
       window.addEventListener('beforeunload', closeSession);
+    } catch (error) {
+      console.error(error);
+      log(`Error: ${error.name || 'Error'}: ${error.message || error}`);
     }
   </script>
 </body>
 </html>
 "#
+}
+
+fn gstwebrtc_api_js() -> &'static str {
+    include_str!("../../src/lib/gstwebrtc-api.js")
 }
 
 // ============================================================================

--- a/src/contexts/WebRTCStreamContext.tsx
+++ b/src/contexts/WebRTCStreamContext.tsx
@@ -17,7 +17,7 @@ import React, {
 import useAppStore from '../store/useAppStore';
 import { fetchWithTimeout, buildApiUrl } from '../config/daemon';
 import { ROBOT_STATUS } from '../constants/robotStatus';
-import { isLinux } from '../utils/platform';
+import { invoke } from '../utils/tauriCompat';
 
 // Import the GStreamer WebRTC API for its side effect (registers `window.GstWebRTCAPI`).
 import '../lib/gstwebrtc-api';
@@ -34,6 +34,20 @@ import type {
 const SIGNALING_PORT = 8443;
 const RECONNECT_DELAY = 2000;
 const INITIAL_RECONNECT_DELAY = 500;
+const STREAM_CONNECT_TIMEOUT = 10000;
+const WEBRTC_UNSUPPORTED_MESSAGE = 'WebRTC is not supported by this desktop WebView';
+
+function hasRTCPeerConnection(): boolean {
+  const webkitWindow = window as typeof window & {
+    webkitRTCPeerConnection?: typeof RTCPeerConnection;
+  };
+
+  if (!window.RTCPeerConnection && webkitWindow.webkitRTCPeerConnection) {
+    window.RTCPeerConnection = webkitWindow.webkitRTCPeerConnection;
+  }
+
+  return typeof window.RTCPeerConnection === 'function';
+}
 
 /** Connection states for the WebRTC stream. */
 export const StreamState = {
@@ -63,6 +77,7 @@ export interface WebRTCStreamContextValue {
   shouldConnect: boolean;
   connect: () => void;
   disconnect: () => void;
+  openExternalViewer: () => Promise<void>;
 }
 
 const WebRTCStreamContext = createContext<WebRTCStreamContextValue | null>(null);
@@ -96,10 +111,12 @@ export function WebRTCStreamProvider({ children }: WebRTCStreamProviderProps): R
   const producersListenerRef = useRef<GstWebRTCProducersListener | null>(null);
   const connectionListenerRef = useRef<GstWebRTCConnectionListener | null>(null);
   const hasConnectedRef = useRef<boolean>(false);
+  const connectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
-    if (isLinux()) {
-      // WebKit on Linux is not built with WebRTC support, so streaming is unavailable.
+    if (!hasRTCPeerConnection()) {
+      console.warn('[WebRTC]', WEBRTC_UNSUPPORTED_MESSAGE);
+      setError(WEBRTC_UNSUPPORTED_MESSAGE);
       setIsWebRTCAvailable(false);
       return;
     }
@@ -144,6 +161,11 @@ export function WebRTCStreamProvider({ children }: WebRTCStreamProviderProps): R
     if (reconnectTimeoutRef.current) {
       clearTimeout(reconnectTimeoutRef.current);
       reconnectTimeoutRef.current = null;
+    }
+
+    if (connectTimeoutRef.current) {
+      clearTimeout(connectTimeoutRef.current);
+      connectTimeoutRef.current = null;
     }
 
     if (sessionRef.current) {
@@ -195,10 +217,25 @@ export function WebRTCStreamProvider({ children }: WebRTCStreamProviderProps): R
     const signalingUrl = `ws://${host}:${SIGNALING_PORT}`;
 
     try {
+      console.info('[WebRTC] Connecting to signaling server:', signalingUrl);
+
+      if (!hasRTCPeerConnection()) {
+        throw new Error(WEBRTC_UNSUPPORTED_MESSAGE);
+      }
+
       const GstWebRTCAPI = window.GstWebRTCAPI;
       if (!GstWebRTCAPI) {
         throw new Error('GstWebRTCAPI not loaded');
       }
+
+      connectTimeoutRef.current = setTimeout(() => {
+        if (!mountedRef.current) return;
+
+        const message = `Timed out waiting for WebRTC stream from ${signalingUrl}`;
+        console.error('[WebRTC]', message);
+        setError(message);
+        setState(StreamState.ERROR);
+      }, STREAM_CONNECT_TIMEOUT);
 
       const api = new GstWebRTCAPI({
         signalingServerUrl: signalingUrl,
@@ -217,10 +254,12 @@ export function WebRTCStreamProvider({ children }: WebRTCStreamProviderProps): R
       connectionListenerRef.current = {
         connected: () => {
           if (!mountedRef.current) return;
+          console.info('[WebRTC] Signaling connected:', signalingUrl);
           hasConnectedRef.current = true;
         },
         disconnected: () => {
           if (!mountedRef.current) return;
+          console.warn('[WebRTC] Signaling disconnected:', signalingUrl);
           setState(StreamState.DISCONNECTED);
           setStream(null);
           setAudioTrack(null);
@@ -248,7 +287,10 @@ export function WebRTCStreamProvider({ children }: WebRTCStreamProviderProps): R
         producerAdded: (producer: GstWebRTCProducer) => {
           if (!mountedRef.current) return;
 
+          console.info('[WebRTC] Producer added:', producer.id, producer.meta);
+
           if (sessionRef.current) {
+            console.info('[WebRTC] Ignoring producer; session already exists');
             return;
           }
 
@@ -262,8 +304,17 @@ export function WebRTCStreamProvider({ children }: WebRTCStreamProviderProps): R
 
           session.addEventListener('error', (event: Event) => {
             if (!mountedRef.current) return;
-            const message = (event as Event & { message?: string }).message || 'Stream error';
-            console.error('[WebRTC] Session error:', message);
+            const errorEvent = event as ErrorEvent;
+            const details =
+              errorEvent.error instanceof Error
+                ? `${errorEvent.error.name}: ${errorEvent.error.message}`
+                : errorEvent.error
+                  ? String(errorEvent.error)
+                  : null;
+            const message = [errorEvent.message || 'Stream error', details]
+              .filter(Boolean)
+              .join(' - ');
+            console.error('[WebRTC] Session error:', message, errorEvent.error);
             setError(message);
 
             if (mountedRef.current && !reconnectTimeoutRef.current) {
@@ -284,18 +335,72 @@ export function WebRTCStreamProvider({ children }: WebRTCStreamProviderProps): R
 
           session.addEventListener('closed', () => {
             if (!mountedRef.current) return;
+            console.warn('[WebRTC] Session closed', {
+              sessionId: session.sessionId,
+              state: session.state,
+              peerConnection: session.rtcPeerConnection
+                ? {
+                    connectionState: session.rtcPeerConnection.connectionState,
+                    iceConnectionState: session.rtcPeerConnection.iceConnectionState,
+                    iceGatheringState: session.rtcPeerConnection.iceGatheringState,
+                    signalingState: session.rtcPeerConnection.signalingState,
+                  }
+                : null,
+            });
             sessionRef.current = null;
             setStream(null);
             setAudioTrack(null);
             setState(prev => (prev === StreamState.CONNECTED ? StreamState.DISCONNECTED : prev));
           });
 
+          session.addEventListener('rtcPeerConnectionChanged', () => {
+            if (!mountedRef.current) return;
+            const peerConnection = session.rtcPeerConnection;
+            if (!peerConnection) {
+              console.info('[WebRTC] Peer connection cleared');
+              return;
+            }
+
+            const logPeerState = (label: string): void => {
+              console.info(`[WebRTC] ${label}:`, {
+                connectionState: peerConnection.connectionState,
+                iceConnectionState: peerConnection.iceConnectionState,
+                iceGatheringState: peerConnection.iceGatheringState,
+                signalingState: peerConnection.signalingState,
+              });
+            };
+
+            logPeerState('Peer connection created');
+            peerConnection.addEventListener('connectionstatechange', () =>
+              logPeerState('Peer connection state changed')
+            );
+            peerConnection.addEventListener('iceconnectionstatechange', () =>
+              logPeerState('ICE connection state changed')
+            );
+            peerConnection.addEventListener('icegatheringstatechange', () =>
+              logPeerState('ICE gathering state changed')
+            );
+            peerConnection.addEventListener('signalingstatechange', () =>
+              logPeerState('Signaling state changed')
+            );
+          });
+
           session.addEventListener('streamsChanged', () => {
             if (!mountedRef.current) return;
             const streams = session.streams;
+            console.info('[WebRTC] Streams changed:', streams?.length ?? 0);
 
             if (streams && streams.length > 0) {
+              if (connectTimeoutRef.current) {
+                clearTimeout(connectTimeoutRef.current);
+                connectTimeoutRef.current = null;
+              }
+
               const mediaStream = streams[0];
+              console.info('[WebRTC] Stream connected:', {
+                audioTracks: mediaStream.getAudioTracks().length,
+                videoTracks: mediaStream.getVideoTracks().length,
+              });
               setStream(mediaStream);
               setState(StreamState.CONNECTED);
 
@@ -308,11 +413,14 @@ export function WebRTCStreamProvider({ children }: WebRTCStreamProviderProps): R
             }
           });
 
+          console.info('[WebRTC] Connecting consumer session');
           session.connect();
         },
 
         producerRemoved: () => {
           if (!mountedRef.current) return;
+
+          console.warn('[WebRTC] Producer removed');
 
           if (sessionRef.current) {
             sessionRef.current.close();
@@ -338,6 +446,18 @@ export function WebRTCStreamProvider({ children }: WebRTCStreamProviderProps): R
     cleanup();
     setState(StreamState.DISCONNECTED);
   }, [cleanup]);
+
+  const openExternalViewer = useCallback(async (): Promise<void> => {
+    const host = remoteHost || 'localhost';
+    try {
+      await invoke('open_external_camera_viewer', { host });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      console.error('[WebRTC] Failed to open external camera viewer:', message);
+      setError(message);
+      setState(StreamState.ERROR);
+    }
+  }, [remoteHost]);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -372,6 +492,7 @@ export function WebRTCStreamProvider({ children }: WebRTCStreamProviderProps): R
 
     connect,
     disconnect,
+    openExternalViewer,
   };
 
   return <WebRTCStreamContext.Provider value={value}>{children}</WebRTCStreamContext.Provider>;

--- a/src/contexts/WebRTCStreamContext.tsx
+++ b/src/contexts/WebRTCStreamContext.tsx
@@ -35,7 +35,7 @@ const SIGNALING_PORT = 8443;
 const RECONNECT_DELAY = 2000;
 const INITIAL_RECONNECT_DELAY = 500;
 const STREAM_CONNECT_TIMEOUT = 10000;
-const WEBRTC_UNSUPPORTED_MESSAGE = 'WebRTC is not supported by this desktop WebView';
+export const WEBRTC_UNSUPPORTED_MESSAGE = 'WebRTC is not supported by this desktop WebView';
 
 function hasRTCPeerConnection(): boolean {
   const webkitWindow = window as typeof window & {

--- a/src/types/gstwebrtc.ts
+++ b/src/types/gstwebrtc.ts
@@ -7,10 +7,14 @@
 
 export interface GstWebRTCProducer {
   id: string;
+  meta?: Record<string, unknown>;
 }
 
 export interface GstWebRTCConsumerSession extends EventTarget {
   streams: readonly MediaStream[];
+  rtcPeerConnection?: RTCPeerConnection | null;
+  sessionId?: string;
+  state?: number;
   connect: () => void;
   close: () => void;
 }

--- a/src/views/active-robot/camera/CameraFeed.tsx
+++ b/src/views/active-robot/camera/CameraFeed.tsx
@@ -5,7 +5,11 @@ import VideocamOffIcon from '@mui/icons-material/VideocamOff';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { STATUS, whiteAlpha, blackAlpha } from '@styles/tokens';
 import { DURATION, RADIUS, TYPO, transition, useAppPalette } from '@styles';
-import { useWebRTCStreamContext, StreamState } from '../../../contexts/WebRTCStreamContext';
+import {
+  useWebRTCStreamContext,
+  StreamState,
+  WEBRTC_UNSUPPORTED_MESSAGE,
+} from '../../../contexts/WebRTCStreamContext';
 
 export interface CameraFeedProps {
   isLarge?: boolean;
@@ -77,8 +81,7 @@ export default function CameraFeed({ isLarge = false }: CameraFeedProps): React.
   const spinnerColor = palette.isDark ? whiteAlpha(0.45) : blackAlpha(0.35);
   const errorIconColor = `${STATUS.error}99`;
   const errorTextColor = `${STATUS.error}b3`;
-  const canOpenExternalViewer =
-    isWebRTCAvailable === false && error === 'WebRTC is not supported by this desktop WebView';
+  const canOpenExternalViewer = isWebRTCAvailable === false && error === WEBRTC_UNSUPPORTED_MESSAGE;
   const unavailableLabel =
     !isLarge && canOpenExternalViewer ? 'Open in browser' : 'Stream not available';
 

--- a/src/views/active-robot/camera/CameraFeed.tsx
+++ b/src/views/active-robot/camera/CameraFeed.tsx
@@ -77,7 +77,8 @@ export default function CameraFeed({ isLarge = false }: CameraFeedProps): React.
   const spinnerColor = palette.isDark ? whiteAlpha(0.45) : blackAlpha(0.35);
   const errorIconColor = `${STATUS.error}99`;
   const errorTextColor = `${STATUS.error}b3`;
-  const canOpenExternalViewer = error === 'WebRTC is not supported by this desktop WebView';
+  const canOpenExternalViewer =
+    isWebRTCAvailable === false && error === 'WebRTC is not supported by this desktop WebView';
   const unavailableLabel =
     !isLarge && canOpenExternalViewer ? 'Open in browser' : 'Stream not available';
 

--- a/src/views/active-robot/camera/CameraFeed.tsx
+++ b/src/views/active-robot/camera/CameraFeed.tsx
@@ -1,7 +1,8 @@
 import React, { useRef, useEffect } from 'react';
-import { Box, Typography, CircularProgress } from '@mui/material';
+import { Box, Typography, CircularProgress, Button } from '@mui/material';
 import VideocamOutlinedIcon from '@mui/icons-material/VideocamOutlined';
 import VideocamOffIcon from '@mui/icons-material/VideocamOff';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { STATUS, whiteAlpha, blackAlpha } from '@styles/tokens';
 import { DURATION, RADIUS, TYPO, transition, useAppPalette } from '@styles';
 import { useWebRTCStreamContext, StreamState } from '../../../contexts/WebRTCStreamContext';
@@ -29,7 +30,9 @@ export default function CameraFeed({ isLarge = false }: CameraFeedProps): React.
     isWebRTCAvailable,
     checkFailed,
     isRobotAwake,
+    error,
     connect,
+    openExternalViewer,
   } = useWebRTCStreamContext();
 
   // Attach/detach stream to video element
@@ -74,6 +77,9 @@ export default function CameraFeed({ isLarge = false }: CameraFeedProps): React.
   const spinnerColor = palette.isDark ? whiteAlpha(0.45) : blackAlpha(0.35);
   const errorIconColor = `${STATUS.error}99`;
   const errorTextColor = `${STATUS.error}b3`;
+  const canOpenExternalViewer = error === 'WebRTC is not supported by this desktop WebView';
+  const unavailableLabel =
+    !isLarge && canOpenExternalViewer ? 'Open in browser' : 'Stream not available';
 
   // Common placeholder box style
   const placeholderStyle = {
@@ -119,8 +125,47 @@ export default function CameraFeed({ isLarge = false }: CameraFeedProps): React.
               letterSpacing: '0.5px',
             }}
           >
-            Stream not available
+            {unavailableLabel}
           </Typography>
+          {error && isLarge && (
+            <Typography
+              sx={{
+                maxWidth: '85%',
+                fontSize: isLarge ? TYPO.xs : '9px',
+                color: textColorMuted,
+                fontFamily: 'SF Mono, Monaco, Menlo, monospace',
+                textAlign: 'center',
+                wordBreak: 'break-word',
+              }}
+            >
+              {error}
+            </Typography>
+          )}
+          {canOpenExternalViewer && (
+            <Button
+              size="small"
+              variant="outlined"
+              startIcon={isLarge ? <OpenInNewIcon /> : undefined}
+              onClick={openExternalViewer}
+              sx={{
+                mt: isLarge ? 1 : 0.25,
+                minWidth: 0,
+                px: isLarge ? 1.5 : 0.75,
+                py: isLarge ? 0.375 : 0.25,
+                color: textColorMuted,
+                borderColor: iconColorMuted,
+                fontSize: isLarge ? TYPO.xs : '9px',
+                fontFamily: 'SF Mono, Monaco, Menlo, monospace',
+                textTransform: 'uppercase',
+                '&:hover': {
+                  borderColor: textColorMuted,
+                  bgcolor: hoverBg,
+                },
+              }}
+            >
+              {isLarge ? 'Open in browser' : 'Open'}
+            </Button>
+          )}
         </Box>
       </Box>
     );
@@ -264,6 +309,21 @@ export default function CameraFeed({ isLarge = false }: CameraFeedProps): React.
           >
             {state === StreamState.ERROR ? 'Connection failed' : 'Click to connect'}
           </Typography>
+          {state === StreamState.ERROR && error && (
+            <Typography
+              sx={{
+                maxWidth: '85%',
+                fontSize: isLarge ? TYPO.xs : '9px',
+                color: errorTextColor,
+                fontFamily: 'SF Mono, Monaco, Menlo, monospace',
+                textAlign: 'center',
+                wordBreak: 'break-word',
+                textTransform: 'none',
+              }}
+            >
+              {error}
+            </Typography>
+          )}
         </Box>
       )}
     </Box>


### PR DESCRIPTION
This PR extracts the Linux camera fallback work from #283, following the request to split it from the Fedora RPM packaging changes.

Summary:
- detect desktop WebViews that do not expose RTCPeerConnection
- show an external browser fallback action for the camera stream
- add a Tauri command that writes and opens a temporary browser-based camera viewer
- keep this PR free of RPM/release workflow changes

Validation:
- cargo check -q
- yarn --ignore-engines typecheck
- yarn --ignore-engines lint (passes with existing repository warnings only)
- git diff --check

Notes:
- While splitting the PR, I added the missing GstWebRTCProducer.meta type so the branch passes TypeScript checking.
