### PR TITLE
Feat/configure startup app

### DIFF
--- a/src/hooks/daemon/useDaemon.ts
+++ b/src/hooks/daemon/useDaemon.ts
@@ -35,6 +35,23 @@ interface DaemonStatusResponse {
   [key: string]: unknown;
 }
 
+/** Whether a startup app is configured (false on error → proceed with the stop). */
+async function hasStartupApp(): Promise<boolean> {
+  try {
+    const res = await fetchWithTimeout(
+      buildApiUrl('/api/apps/startup-app'),
+      {},
+      DAEMON_CONFIG.TIMEOUTS.COMMAND,
+      { label: 'Check startup app', silent: true }
+    );
+    if (!res.ok) return false;
+    const data = (await res.json()) as { startup_app?: string | null };
+    return !!data?.startup_app;
+  } catch {
+    return false;
+  }
+}
+
 export interface UseDaemonResult {
   isActive: boolean;
   isStarting: boolean;
@@ -354,15 +371,19 @@ export const useDaemon = (): UseDaemonResult => {
     if (currentConnectionMode === 'wifi') {
       await performGracefulShutdown();
 
-      try {
-        await fetchWithTimeout(
-          buildApiUrl('/api/daemon/stop?goto_sleep=false'),
-          { method: 'POST' },
-          DAEMON_CONFIG.TIMEOUTS.COMMAND,
-          { label: 'Daemon stop' }
-        );
-      } catch {
-        // Continue with reset.
+      // Keep the daemon alive (asleep) when a startup app is set, so an antenna
+      // touch can still wake it — the watcher only runs while the backend is up.
+      if (!(await hasStartupApp())) {
+        try {
+          await fetchWithTimeout(
+            buildApiUrl('/api/daemon/stop?goto_sleep=false'),
+            { method: 'POST' },
+            DAEMON_CONFIG.TIMEOUTS.COMMAND,
+            { label: 'Daemon stop' }
+          );
+        } catch {
+          // Continue with reset.
+        }
       }
 
       try {

--- a/src/store/slices/appsSlice.ts
+++ b/src/store/slices/appsSlice.ts
@@ -39,6 +39,8 @@ export const appsInitialState: AppsSliceState = {
   isStoppingApp: false,
 
   pendingDeepLinkInstall: null,
+
+  startupAppName: null,
 };
 
 /**
@@ -114,6 +116,7 @@ export const createAppsSlice: StateCreator<AppState, [], [], AppsSlice> = (set, 
   setAppsLoading: loading => set({ appsLoading: loading }),
   setAppsError: error => set({ appsError: error }),
   setIsStoppingApp: isStopping => set({ isStoppingApp: isStopping }),
+  setStartupApp: appName => set({ startupAppName: appName }),
 
   setAppsOfficialMode: (mode: boolean) =>
     set({
@@ -136,6 +139,7 @@ export const createAppsSlice: StateCreator<AppState, [], [], AppsSlice> = (set, 
       appsCacheValid: false,
       isStoppingApp: false,
       pendingDeepLinkInstall: null,
+      startupAppName: null,
     }),
 
   // ============================================

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -145,6 +145,7 @@ export interface AppsSliceState {
   jobSeenOnce: boolean;
   isStoppingApp: boolean;
   pendingDeepLinkInstall: string | null;
+  startupAppName: string | null;
 }
 
 export interface AppsSliceActions {
@@ -160,6 +161,7 @@ export interface AppsSliceActions {
   setAppsLoading: (loading: boolean) => void;
   setAppsError: (error: string | null) => void;
   setIsStoppingApp: (isStopping: boolean) => void;
+  setStartupApp: (appName: string | null) => void;
   setAppsOfficialMode: (mode: boolean) => void;
   invalidateAppsCache: () => void;
   clearApps: () => void;

--- a/src/views/active-robot/ActiveRobotView.tsx
+++ b/src/views/active-robot/ActiveRobotView.tsx
@@ -153,6 +153,8 @@ function ActiveRobotView({
     startApp: noopAsync as (appName: string) => Promise<unknown>,
     stopCurrentApp: noopAsync as () => Promise<unknown>,
     triggerUpdate: noopAsync as (appName: string) => Promise<unknown>,
+    applyStartupApp: noopAsync as (appName: string | null) => Promise<void>,
+    startupAppName: null,
     showToast,
   });
 

--- a/src/views/active-robot/application-store/hooks/useAppHandlers.ts
+++ b/src/views/active-robot/application-store/hooks/useAppHandlers.ts
@@ -30,6 +30,8 @@ interface UseAppHandlersParams {
   startApp: (appName: string) => Promise<unknown>;
   stopCurrentApp: () => Promise<unknown>;
   triggerUpdate: (appName: string) => Promise<unknown>;
+  applyStartupApp: (appName: string | null) => Promise<void>;
+  startupAppName: string | null;
   showToast?: ShowToast;
 }
 
@@ -41,6 +43,7 @@ interface UseAppHandlersReturn {
   handleUninstall: (appName: string) => Promise<void>;
   handleUpdate: (appName: string) => Promise<void>;
   handleStartApp: (appName: string) => Promise<void>;
+  handleToggleStartupApp: (appName: string) => Promise<void>;
   isJobRunning: (appName: string, jobType: string) => boolean;
   getJobInfo: (appName: string, jobType?: string) => JobLike | null;
   stopCurrentApp: () => Promise<unknown>;
@@ -54,6 +57,8 @@ export function useAppHandlers({
   startApp,
   stopCurrentApp,
   triggerUpdate,
+  applyStartupApp,
+  startupAppName,
   showToast,
 }: UseAppHandlersParams): UseAppHandlersReturn {
   const { robotState, actions, api } = useActiveRobotContext();
@@ -75,6 +80,8 @@ export function useAppHandlers({
     startApp: typeof startApp;
     stopCurrentApp: typeof stopCurrentApp;
     triggerUpdate: typeof triggerUpdate;
+    applyStartupApp: typeof applyStartupApp;
+    startupAppName: string | null;
     showToast: ShowToast | undefined;
     lockForApp: typeof lockForApp;
     unlockApp: typeof unlockApp;
@@ -90,6 +97,8 @@ export function useAppHandlers({
     startApp,
     stopCurrentApp,
     triggerUpdate,
+    applyStartupApp,
+    startupAppName,
     showToast,
     lockForApp,
     unlockApp,
@@ -106,6 +115,8 @@ export function useAppHandlers({
     startApp,
     stopCurrentApp,
     triggerUpdate,
+    applyStartupApp,
+    startupAppName,
     showToast,
     lockForApp,
     unlockApp,
@@ -156,6 +167,23 @@ export function useAppHandlers({
       } else {
         if (showToast) showToast(`Failed to uninstall ${appName}: ${error.message}`, 'error');
       }
+    }
+  }, []);
+
+  const handleToggleStartupApp = useCallback(async (appName: string): Promise<void> => {
+    const { applyStartupApp, startupAppName, showToast } = latest.current;
+    const enabling = appName !== startupAppName;
+    try {
+      await applyStartupApp(enabling ? appName : null);
+      if (showToast) {
+        showToast(
+          enabling ? `${appName} will launch on startup` : `${appName} removed from startup`,
+          'success'
+        );
+      }
+    } catch (err) {
+      const error = err as Error;
+      if (showToast) showToast(`Failed to update startup app: ${error.message}`, 'error');
     }
   }, []);
 
@@ -297,6 +325,7 @@ export function useAppHandlers({
     handleUninstall,
     handleUpdate,
     handleStartApp,
+    handleToggleStartupApp,
     isJobRunning,
     getJobInfo,
     stopCurrentApp,

--- a/src/views/active-robot/application-store/hooks/useAppsStore.ts
+++ b/src/views/active-robot/application-store/hooks/useAppsStore.ts
@@ -465,6 +465,12 @@ export function useAppsStore(isActive: boolean) {
 
         createJob(jobId, 'remove', appName, null, setActiveJobs, startJobPollingRef);
 
+        // The daemon clears the startup app when it's the one removed; mirror it
+        // locally so the menu/border update without a reconnect.
+        if ((useAppStore.getState() as unknown as AnyRecord).startupAppName === appName) {
+          setStartupApp(null);
+        }
+
         return jobId;
       } catch (err) {
         console.error('❌ Removal error:', err);
@@ -484,7 +490,7 @@ export function useAppsStore(isActive: boolean) {
         throw err;
       }
     },
-    [setActiveJobs, logger, setAppsError]
+    [setActiveJobs, logger, setAppsError, setStartupApp]
   );
 
   const startApp = useCallback(

--- a/src/views/active-robot/application-store/hooks/useAppsStore.ts
+++ b/src/views/active-robot/application-store/hooks/useAppsStore.ts
@@ -107,6 +107,8 @@ export function useAppsStore(isActive: boolean) {
   const appsLoading = useAppStore(s => s.appsLoading) as boolean;
   const appsError = useAppStore(s => s.appsError) as string | null;
   const isStoppingApp = useAppStore(s => (s as unknown as AnyRecord).isStoppingApp) as boolean;
+  const startupAppName = useAppStore(s => s.startupAppName) as string | null;
+  const setStartupApp = useAppStore(s => s.setStartupApp) as (name: string | null) => void;
   const setAvailableApps = useAppStore(s => s.setAvailableApps) as (apps: AppLike[]) => void;
   const setInstalledApps = useAppStore(s => s.setInstalledApps) as (apps: AppLike[]) => void;
   const setCurrentApp = useAppStore(s => s.setCurrentApp) as (app: CurrentAppStatus | null) => void;
@@ -286,6 +288,16 @@ export function useAppsStore(isActive: boolean) {
       const status = (await response.json()) as CurrentAppStatus | null;
       const store = useAppStore.getState() as unknown as AnyRecord;
 
+      // Close the opened app UI when it stops, independent of the robot lock
+      // (an external sleep clears the lock before this poll sees the stop).
+      const closeOpenedAppUi = (name?: string): void => {
+        if (name) closeAppWindow(name).catch(() => {});
+        // Don't clobber a non-embedded right-panel view.
+        if (store.rightPanelView === 'embedded-app') {
+          (store.closeEmbeddedApp as () => void)();
+        }
+      };
+
       if (status && status.info && status.state) {
         const appState = status.state;
         const appName = status.info.name as string;
@@ -334,10 +346,11 @@ export function useAppsStore(isActive: boolean) {
 
           if (appState === 'done') {
             setCurrentApp(null);
-            (store.closeEmbeddedApp as () => void)();
+            closeOpenedAppUi(appName);
+          } else if (appState === 'stopping') {
+            closeOpenedAppUi(appName);
           } else if (appState === 'error') {
-            closeAppWindow(appName).catch(() => {});
-            (store.closeEmbeddedApp as () => void)();
+            closeOpenedAppUi(appName);
 
             if (!errorClearTimerRef.current) {
               errorClearTimerRef.current = setTimeout(() => {
@@ -351,15 +364,11 @@ export function useAppsStore(isActive: boolean) {
       } else {
         setCurrentApp(null);
 
+        const lastAppName = (store.currentAppName as string) || undefined;
+        closeOpenedAppUi(lastAppName);
+
         if (store.isAppRunning && store.busyReason === 'app-running') {
-          const lastAppName = (store.currentAppName as string) || 'unknown';
-
-          if (lastAppName !== 'unknown') {
-            closeAppWindow(lastAppName).catch(() => {});
-          }
-          (store.closeEmbeddedApp as () => void)();
-
-          logger.warning(`App ${lastAppName} stopped unexpectedly`);
+          logger.warning(`App ${lastAppName ?? 'unknown'} stopped unexpectedly`);
           (store.unlockApp as () => void)();
         }
       }
@@ -525,6 +534,52 @@ export function useAppsStore(isActive: boolean) {
     [fetchCurrentAppStatus, logger, setAppsError, setCurrentApp]
   );
 
+  // Fetch the app configured to auto-start on the robot's next wake-up.
+  const fetchStartupApp = useCallback(async (): Promise<void> => {
+    try {
+      const response = await fetchWithTimeout(
+        buildApiUrl('/api/apps/startup-app'),
+        {},
+        DAEMON_CONFIG.TIMEOUTS.APPS_LIST,
+        { silent: true }
+      );
+      if (!response.ok) return;
+      const data = (await response.json()) as { startup_app: string | null };
+      setStartupApp(data.startup_app ?? null);
+    } catch {
+      // Best-effort; the border indicator just stays unset on failure.
+    }
+  }, [setStartupApp]);
+
+  // Set (name) or clear (null) the auto-start app; only installed apps are valid.
+  const applyStartupApp = useCallback(
+    async (appName: string | null): Promise<void> => {
+      try {
+        const response = await fetchWithTimeout(
+          buildApiUrl('/api/apps/startup-app'),
+          {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ startup_app: appName }),
+          },
+          DAEMON_CONFIG.TIMEOUTS.COMMAND,
+          { label: appName ? `Set startup app to ${appName}` : 'Clear startup app' }
+        );
+        if (!response.ok) {
+          throw new Error(`Failed to set startup app: ${response.status}`);
+        }
+        setStartupApp(appName);
+      } catch (err) {
+        const error = err as Error;
+        console.error('❌ Failed to set startup app:', err);
+        logger.error(`Failed to set startup app (${error.message})`);
+        setAppsError(error.message);
+        throw err;
+      }
+    },
+    [logger, setAppsError, setStartupApp]
+  );
+
   const stopCurrentApp = useCallback(async (): Promise<unknown> => {
     const setIsStoppingAppFn = (useAppStore.getState() as unknown as AnyRecord).setIsStoppingApp as
       | ((v: boolean) => void)
@@ -599,12 +654,13 @@ export function useAppsStore(isActive: boolean) {
     }
 
     fetchAvailableApps(false);
+    fetchStartupApp();
 
     fetchCurrentAppStatus();
     const interval = setInterval(fetchCurrentAppStatus, DAEMON_CONFIG.INTERVALS.APP_STATUS);
 
     return () => clearInterval(interval);
-  }, [isActive, isWindowVisible, fetchAvailableApps, fetchCurrentAppStatus]);
+  }, [isActive, isWindowVisible, fetchAvailableApps, fetchStartupApp, fetchCurrentAppStatus]);
 
   return {
     availableApps,
@@ -615,11 +671,14 @@ export function useAppsStore(isActive: boolean) {
     error: appsError,
     isStoppingApp,
 
+    startupAppName,
     fetchAvailableApps,
     installApp,
     removeApp,
     startApp,
     stopCurrentApp,
+    fetchStartupApp,
+    applyStartupApp,
     fetchCurrentAppStatus,
     startJobPolling,
     invalidateCache: invalidateAppsCache,

--- a/src/views/active-robot/application-store/installed/InstalledAppsSection.tsx
+++ b/src/views/active-robot/application-store/installed/InstalledAppsSection.tsx
@@ -18,6 +18,7 @@ import StopCircleOutlinedIcon from '@mui/icons-material/StopCircleOutlined';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import LaunchIcon from '@mui/icons-material/Launch';
+import RocketLaunchOutlinedIcon from '@mui/icons-material/RocketLaunchOutlined';
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 import DiscoverAppsButton from '../discover/Button';
 import ReachiesCarousel from '@components/ReachiesCarousel';
@@ -427,6 +428,8 @@ interface InstalledAppsSectionProps {
   handleStartApp: (appName: string) => void;
   handleUninstall: (appName: string) => void;
   handleUpdate?: (appName: string) => void;
+  handleToggleStartupApp?: (appName: string) => void;
+  startupAppName?: string | null;
   hasUpdate?: (appName: string) => boolean;
   isCheckingUpdates?: boolean;
   hasCheckedOnce?: boolean;
@@ -446,6 +449,8 @@ export default function InstalledAppsSection({
   handleStartApp,
   handleUninstall,
   handleUpdate,
+  handleToggleStartupApp,
+  startupAppName,
   hasUpdate,
   getJobInfo,
   stopCurrentApp,
@@ -585,6 +590,7 @@ export default function InstalledAppsSection({
               const author = app.extra?.id?.split('/')?.[0] || app.extra?.author || null;
 
               const isMenuOpen = menuAppName === app.name;
+              const isStartupApp = !!startupAppName && startupAppName === app.name;
 
               return (
                 <Box
@@ -592,12 +598,16 @@ export default function InstalledAppsSection({
                   sx={{
                     borderRadius: '14px',
                     bgcolor: palette.isDark ? whiteAlpha(0.02) : 'white',
-                    border: `1px solid ${
+                    // Startup app gets a bold accent border (error still wins);
+                    // the running-app green glow below is kept independently.
+                    border: `${isStartupApp && !hasAppError ? '2px' : '1px'} solid ${
                       hasAppError
                         ? palette.statusError
-                        : isCurrentlyRunning
-                          ? palette.statusSuccess
-                          : palette.border
+                        : isStartupApp
+                          ? ACCENT.main
+                          : isCurrentlyRunning
+                            ? palette.statusSuccess
+                            : palette.border
                     }`,
                     transition: `${transition(['opacity', 'filter'], DURATION.medium)}, ${transition('border-color', DURATION.base)}`,
                     overflow: 'hidden',
@@ -605,7 +615,9 @@ export default function InstalledAppsSection({
                       ? ERROR_GLOW
                       : isCurrentlyRunning
                         ? SUCCESS_GLOW
-                        : 'none',
+                        : isStartupApp
+                          ? `0 0 0 1px ${accentAlpha(0.25)}`
+                          : 'none',
                     opacity: isRemoving ? 0.5 : isBusy && !isCurrentlyRunning ? 0.4 : 1,
                     filter: isBusy && !isCurrentlyRunning ? 'grayscale(50%)' : 'none',
                     '&:hover .more-menu-btn': {
@@ -1021,6 +1033,7 @@ export default function InstalledAppsSection({
                   !!currentApp && !!currentApp.info && currentApp.info.name === menuAppName;
                 const appState = isThisAppCurrent && currentApp?.state ? currentApp.state : null;
                 const isCurrentlyRunning = appState === 'running';
+                const isStartupApp = !!startupAppName && startupAppName === menuAppName;
 
                 return [
                   hfUrl && (
@@ -1044,6 +1057,36 @@ export default function InstalledAppsSection({
                       </ListItemIcon>
                       <ListItemText
                         primary="View on HuggingFace"
+                        primaryTypographyProps={{ fontSize: TYPO.sm }}
+                      />
+                    </MenuItem>
+                  ),
+                  handleToggleStartupApp && (
+                    <MenuItem
+                      key="startup"
+                      onClick={() => {
+                        handleToggleStartupApp(menuAppName as string);
+                        handleMenuClose();
+                      }}
+                      sx={{
+                        fontSize: TYPO.sm,
+                        py: 1,
+                        color: isStartupApp ? ACCENT.main : palette.textSecondary,
+                        '&:hover': {
+                          bgcolor: palette.isDark ? whiteAlpha(0.06) : blackAlpha(0.04),
+                        },
+                      }}
+                    >
+                      <ListItemIcon>
+                        <RocketLaunchOutlinedIcon
+                          sx={{
+                            fontSize: 15,
+                            color: isStartupApp ? ACCENT.main : palette.textMuted,
+                          }}
+                        />
+                      </ListItemIcon>
+                      <ListItemText
+                        primary={isStartupApp ? 'Remove from startup' : 'Launch as startup'}
                         primaryTypographyProps={{ fontSize: TYPO.sm }}
                       />
                     </MenuItem>

--- a/src/views/active-robot/right-panel/applications/ApplicationsSection.tsx
+++ b/src/views/active-robot/right-panel/applications/ApplicationsSection.tsx
@@ -102,6 +102,8 @@ export default function ApplicationsSection({
     startApp: (appName: string) => Promise<unknown>;
     stopCurrentApp: () => Promise<unknown>;
     fetchAvailableApps: (force?: boolean) => Promise<unknown>;
+    applyStartupApp: (appName: string | null) => Promise<void>;
+    startupAppName: string | null;
     isLoading: boolean;
     isStoppingApp: boolean;
     error: string | null;
@@ -120,6 +122,8 @@ export default function ApplicationsSection({
     startApp,
     stopCurrentApp,
     fetchAvailableApps,
+    applyStartupApp,
+    startupAppName,
     isLoading,
     isStoppingApp,
     error: appsError,
@@ -195,6 +199,7 @@ export default function ApplicationsSection({
     handleUninstall,
     handleUpdate,
     handleStartApp,
+    handleToggleStartupApp,
     isJobRunning,
     getJobInfo,
   } = useAppHandlers({
@@ -205,6 +210,8 @@ export default function ApplicationsSection({
     startApp,
     stopCurrentApp,
     triggerUpdate,
+    applyStartupApp,
+    startupAppName,
     showToast,
   });
 
@@ -387,6 +394,8 @@ export default function ApplicationsSection({
             handleStartApp={handleStartApp}
             handleUninstall={handleUninstall}
             handleUpdate={handleUpdate}
+            handleToggleStartupApp={handleToggleStartupApp}
+            startupAppName={startupAppName}
             hasUpdate={hasUpdate as never}
             isCheckingUpdates={isCheckingUpdates}
             hasCheckedOnce={hasCheckedOnce}

--- a/src/views/starting/StartingView.tsx
+++ b/src/views/starting/StartingView.tsx
@@ -23,6 +23,17 @@ function StartingView({ startupError, startDaemon }: StartingViewProps) {
     setHardwareError(null);
 
     try {
+      // Skip the wake if already awake (state WS is stable by now).
+      const controlMode = (
+        useAppStore.getState() as {
+          robotStateFull?: { data?: { control_mode?: string } };
+        }
+      ).robotStateFull?.data?.control_mode;
+      if (controlMode === 'enabled') {
+        transitionTo.ready();
+        return;
+      }
+
       await fetchWithTimeout(
         buildApiUrl('/api/motors/set_mode/enabled'),
         { method: 'POST' },


### PR DESCRIPTION
Desktop companion to pollen-robotics/reachy_mini#1247. Lets the user pick the robot's **startup app** (the app that auto-launches on wake / antenna touch) directly from the Applications list, plus three related robot-lifecycle fixes surfaced while testing it.

Requires the daemon endpoints from pollen-robotics/reachy_mini#1247 (`GET`/`PUT /api/apps/startup-app`).

## Changes

**1. Configure a startup app from the app menu** (`feat(apps)`)
- New **"Launch as startup"** item in each installed app's `⋮` menu; it toggles to **"Remove from startup"** on the current one.
- The app set as startup gets a **bold accent border** on its card.
- State (`startupAppName`) lives in the apps slice, seeded by `GET /api/apps/startup-app` when the app list loads and updated via `PUT` — so it takes effect live (no daemon restart).

**2. Close the app UI when an app stops externally** (`fix`)
- When the daemon reports the running app is gone (`done`/`stopping`/`error`/null), the embedded iframe + any pop-out window are now closed regardless of the robot lock. Previously the close was gated behind the app-running lock, which an external "go to sleep" clears first — so the app UI lingered after the robot slept from within an app.

**3. Skip the wake movement when the robot is already awake** (`fix(startup)`)
- `StartingView` no longer unconditionally replays the wake animation on start; if `control_mode === 'enabled'` it goes straight to ready. Avoids a redundant wake on an already-awake robot (remote daemon already running, or a reload reusing a live daemon).

**4. Keep the daemon alive on exit when a startup app is set** (`fix(daemon)`)
- In `wifi` mode, closing the desktop used to stop the daemon, which tears down the backend and disables the startup-app antenna watcher — so a standalone robot couldn't be woken by an antenna touch afterwards. Now, when a startup app is configured, exit puts the robot to sleep but **leaves the daemon running** so an antenna touch still wakes it and launches the app. With no startup app, it stops as before. USB/sim unchanged.

## How to test

1. Use the app menu to enable the startup mode. 
2. Exit with the power off button of the desktop app. The robot goes to sleep
3. Move an antenna and it should wake up and start the conv app!