### PR TITLE
fix: preserve the DoA right endpoint

### DIFF
--- a/src/hooks/audio/useDoA.ts
+++ b/src/hooks/audio/useDoA.ts
@@ -91,8 +91,8 @@ export function useDoA(isActive: boolean): UseDoAResult {
 export function getDoADirection(angleRad: number | null): string {
   if (angleRad === null) return 'unknown';
 
-  // Normalize to 0-π range.
-  const normalized = Math.abs(angleRad % Math.PI);
+  // Mirror negative samples and clamp values outside the documented 0..π range.
+  const normalized = Math.min(Math.abs(angleRad), Math.PI);
 
   if (normalized < Math.PI / 6) return 'left';
   if (normalized < Math.PI / 3) return 'front-left';


### PR DESCRIPTION
## Summary
- preserve the documented `π` right endpoint in direction-of-arrival labels
- mirror negative samples and clamp out-of-range values instead of wrapping with modulo

## Verification
- `npm test -- --run` — 96/96 passed
- `npm run typecheck` — passed
- `npx prettier --check src/hooks/audio/useDoA.ts` — passed
- `npx eslint src/hooks/audio/useDoA.ts` — passed
- `git diff --check` — passed

The existing regression tests already cover `π`, `-π`, values above `π`, and monotonic left-to-right progression.