### PR TITLE
fix: wire browser dashboard robot controls

### DIFF
--- a/src/components/WebApp.tsx
+++ b/src/components/WebApp.tsx
@@ -13,6 +13,10 @@ import { Box, CircularProgress, Typography } from '@mui/material';
 import ActiveRobotModule from '../views/active-robot/ActiveRobotModule';
 import type { ActiveRobotContextConfig } from '../hooks/adapters/activeRobotContextTypes';
 import { useWebActiveRobotAdapter } from '../hooks/useWebActiveRobotAdapter';
+import { useRobotStateWebSocket } from '../hooks/robot/useRobotStateWebSocket';
+import { useRobotCommands } from '../hooks/robot/useRobotCommands';
+import { useActiveMoves } from '../hooks/robot/useActiveMoves';
+import { useWindowVisible } from '../hooks/system/useWindowVisible';
 import useAppStore from '../store/useAppStore';
 import { ROBOT_STATUS } from '../constants/robotStatus';
 import type { FullAppState } from '../store/useStore';
@@ -35,24 +39,20 @@ export default function WebApp(): React.ReactElement {
   const [error, setError] = useState<string | null>(null);
   const [daemonVersion, setDaemonVersion] = useState<string>('web');
   const isActive = useAppStore((state: FullAppState) => state.isActive);
-  const isCommandRunning = useAppStore((state: FullAppState) => state.isCommandRunning);
   const logs = useAppStore((state: FullAppState) => state.logs);
+  const { sendCommand, playRecordedMove, isCommandRunning } = useRobotCommands();
+  const isWindowVisible = useWindowVisible();
 
   // The web adapter intentionally omits Tauri-only window methods
   // (addOpenWindow, removeOpenWindow, isWindowOpen) since they are no-ops in
   // the browser. ActiveRobotModule's Tauri-typed config is widened here.
   const contextConfig = useWebActiveRobotAdapter() as unknown as ActiveRobotContextConfig;
 
+  useRobotStateWebSocket(isConnected && !error && isWindowVisible);
+  useActiveMoves(isConnected && !error && isWindowVisible);
+
   const stopDaemon = useCallback((): void => {
     console.log('[WebMode] stopDaemon - not available');
-  }, []);
-
-  const sendCommand = useCallback(async (command: unknown): Promise<void> => {
-    console.log('[WebMode] sendCommand:', command);
-  }, []);
-
-  const playRecordedMove = useCallback(async (moveName: unknown): Promise<void> => {
-    console.log('[WebMode] playRecordedMove:', moveName);
   }, []);
 
   useEffect(() => {

--- a/src/views/active-robot/ActiveRobotModule.tsx
+++ b/src/views/active-robot/ActiveRobotModule.tsx
@@ -19,8 +19,13 @@ export interface ActiveRobotModuleProps {
   isStarting: boolean;
   isStopping: boolean;
   stopDaemon: () => Promise<void> | void;
-  sendCommand: (...args: unknown[]) => unknown;
-  playRecordedMove: (...args: unknown[]) => unknown;
+  sendCommand: (
+    endpoint: string,
+    label: string,
+    lockDuration?: number,
+    silent?: boolean
+  ) => Promise<void>;
+  playRecordedMove: (dataset: string, move: string) => Promise<void>;
   isCommandRunning: boolean;
   logs: unknown[];
   daemonVersion?: string | null;

--- a/src/views/active-robot/ActiveRobotView.tsx
+++ b/src/views/active-robot/ActiveRobotView.tsx
@@ -11,6 +11,7 @@ import { RightPanel } from './right-panel';
 import RobotHeader from './RobotHeader';
 import { PowerButton } from './controls';
 import AudioControls from './audio/AudioControls';
+import { isWebMode } from '../../utils/tauriCompat';
 
 // TODO(ts): The following components live outside this agent's migration scope
 // and either expose `.jsx`/`unknown`-typed props; cast locally to `React.FC` shapes
@@ -76,8 +77,13 @@ export interface ActiveRobotViewProps {
   isStarting: boolean;
   isStopping: boolean;
   stopDaemon: () => Promise<void> | void;
-  sendCommand: (...args: unknown[]) => unknown;
-  playRecordedMove: (...args: unknown[]) => unknown;
+  sendCommand: (
+    endpoint: string,
+    label: string,
+    lockDuration?: number,
+    silent?: boolean
+  ) => Promise<void>;
+  playRecordedMove: (dataset: string, move: string) => Promise<void>;
   isCommandRunning: boolean;
   logs: unknown[];
   daemonVersion?: string | null;
@@ -567,8 +573,13 @@ function ActiveRobotView({
                 viewCamera={<CameraFeed width={640} height={480} isLarge={true} />}
               />
 
-              {/* Power Button - top left corner (sleep + disable motors + kill daemon) */}
-              <PowerButton onStopDaemon={stopDaemon} isStopping={isStopping} isBusy={isBusyState} />
+              {!isWebMode && (
+                <PowerButton
+                  onStopDaemon={stopDaemon}
+                  isStopping={isStopping}
+                  isBusy={isBusyState}
+                />
+              )}
             </Box>
 
             {/* Robot Header - Title, version, status, mode */}


### PR DESCRIPTION
## Summary
- start the existing robot-state and active-move WebSockets in browser `WebApp` mode
- use the existing robot command hooks instead of web-mode no-op callbacks
- hide the desktop-only daemon power control in a page served by that daemon
- tighten the command callback types passed through the active-robot module

Related to #137 as a browser-based ARM64 workaround, but this does **not** implement or claim to close Linux ARM64 Tauri packaging. It intentionally does not duplicate the Linux camera fallback merged in #289 or add DGX-specific packaging. The SDK's removed bundled dashboard is also out of scope; this PR only repairs the `WebApp` mode that remains in this repository.

## Verification
- `npm run typecheck` — passed
- `npx vitest run --exclude src/hooks/audio/__tests__/useDoA.test.ts` — 81/81 passed
- `npx prettier --check <changed files>` — passed
- `npx eslint <changed files>` — zero errors (one pre-existing hook warning)
- `npm run build:web` — passed
- `git diff --check` — passed

The full 96-test suite on current `develop` has five pre-existing DoA endpoint failures; #297 fixes those without overlap with this PR.