### PR TITLE
fix(linux): serve external camera viewer over loopback HTTP

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,7 +27,10 @@ fn crash_marker_path() -> Option<std::path::PathBuf> {
 }
 use discovery::DiscoveryState;
 use local_proxy::LocalProxyState;
-use std::sync::Arc;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::sync::{Arc, Mutex};
+use std::thread;
 use tauri::{Manager, State};
 use tauri_plugin_log::{Target, TargetKind};
 use tauri_plugin_opener::OpenerExt;
@@ -143,6 +146,62 @@ fn get_logs(state: State<DaemonState>) -> Result<Vec<String>, String> {
     Ok(logs.iter().cloned().collect())
 }
 
+static CAMERA_VIEWER_HTML: Mutex<String> = Mutex::new(String::new());
+static CAMERA_VIEWER_PORT: Mutex<Option<u16>> = Mutex::new(None);
+
+/// Serve the camera viewer over loopback so Snap/Flatpak browsers can load it.
+fn ensure_camera_viewer_server() -> Result<u16, String> {
+    let mut port_guard = CAMERA_VIEWER_PORT
+        .lock()
+        .map_err(|e| format!("Camera viewer port mutex poisoned: {e}"))?;
+    if let Some(port) = *port_guard {
+        return Ok(port);
+    }
+
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .map_err(|e| format!("Failed to bind camera viewer: {e}"))?;
+    let port = listener
+        .local_addr()
+        .map_err(|e| format!("Failed to read camera viewer address: {e}"))?
+        .port();
+
+    thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else {
+                continue;
+            };
+            let mut req = Vec::new();
+            let mut tmp = [0u8; 512];
+            loop {
+                match stream.read(&mut tmp) {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => {
+                        req.extend_from_slice(&tmp[..n]);
+                        if req.windows(4).any(|w| w == b"\r\n\r\n") || req.len() > 8192 {
+                            break;
+                        }
+                    }
+                }
+            }
+            let html = CAMERA_VIEWER_HTML
+                .lock()
+                .ok()
+                .map(|guard| guard.clone())
+                .unwrap_or_default();
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                html.len(),
+                html
+            );
+            let _ = stream.write_all(response.as_bytes());
+        }
+    });
+
+    *port_guard = Some(port);
+    log::info!("[camera] Viewer listening on http://127.0.0.1:{port}/");
+    Ok(port)
+}
+
 #[tauri::command]
 fn open_external_camera_viewer(
     app_handle: tauri::AppHandle,
@@ -157,14 +216,13 @@ fn open_external_camera_viewer(
     let html = external_camera_viewer_html()
         .replace("__SIGNALING_URL__", &signaling_url_json)
         .replace("__GST_WEBRTC_API__", gstwebrtc_api_js());
-    let path = paths::external_camera_viewer_path()?;
 
-    std::fs::write(&path, html)
-        .map_err(|e| format!("Failed to write external camera viewer: {}", e))?;
+    *CAMERA_VIEWER_HTML
+        .lock()
+        .map_err(|e| format!("Camera viewer html mutex poisoned: {e}"))? = html;
 
-    let url = tauri::Url::from_file_path(&path)
-        .map_err(|_| format!("Failed to convert path to file URL: {}", path.display()))?
-        .to_string();
+    let port = ensure_camera_viewer_server()?;
+    let url = format!("http://127.0.0.1:{port}/");
 
     app_handle
         .opener()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -31,6 +31,7 @@ use std::io::{Read, Write};
 use std::net::TcpListener;
 use std::sync::{Arc, Mutex};
 use std::thread;
+use std::time::Duration;
 use tauri::{Manager, State};
 use tauri_plugin_log::{Target, TargetKind};
 use tauri_plugin_opener::OpenerExt;
@@ -170,6 +171,9 @@ fn ensure_camera_viewer_server() -> Result<u16, String> {
             let Ok(mut stream) = stream else {
                 continue;
             };
+            let timeout = Some(Duration::from_secs(2));
+            let _ = stream.set_read_timeout(timeout);
+            let _ = stream.set_write_timeout(timeout);
             let mut req = Vec::new();
             let mut tmp = [0u8; 512];
             loop {
@@ -189,7 +193,7 @@ fn ensure_camera_viewer_server() -> Result<u16, String> {
                 .map(|guard| guard.clone())
                 .unwrap_or_default();
             let response = format!(
-                "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nCache-Control: no-store\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
                 html.len(),
                 html
             );

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -157,7 +157,7 @@ fn open_external_camera_viewer(
     let html = external_camera_viewer_html()
         .replace("__SIGNALING_URL__", &signaling_url_json)
         .replace("__GST_WEBRTC_API__", gstwebrtc_api_js());
-    let path = std::env::temp_dir().join("reachy-mini-camera-viewer.html");
+    let path = paths::external_camera_viewer_path()?;
 
     std::fs::write(&path, html)
         .map_err(|e| format!("Failed to write external camera viewer: {}", e))?;

--- a/src-tauri/src/paths.rs
+++ b/src-tauri/src/paths.rs
@@ -36,22 +36,3 @@ pub fn get_data_dir() -> Result<PathBuf, String> {
             .map_err(|_| "HOME not set".to_string())
     }
 }
-
-/// Path for the external browser camera viewer HTML page.
-///
-/// On Linux, Snap/Flatpak browsers often cannot read `/tmp` or hidden app-data
-/// directories. Use a visible location under the user's home directory instead.
-pub fn external_camera_viewer_path() -> Result<PathBuf, String> {
-    #[cfg(target_os = "linux")]
-    {
-        if let Some(downloads) = dirs::download_dir() {
-            return Ok(downloads.join("reachy-mini-camera-viewer.html"));
-        }
-
-        if let Some(home) = dirs::home_dir() {
-            return Ok(home.join("reachy-mini-camera-viewer.html"));
-        }
-    }
-
-    Ok(std::env::temp_dir().join("reachy-mini-camera-viewer.html"))
-}

--- a/src-tauri/src/paths.rs
+++ b/src-tauri/src/paths.rs
@@ -36,3 +36,22 @@ pub fn get_data_dir() -> Result<PathBuf, String> {
             .map_err(|_| "HOME not set".to_string())
     }
 }
+
+/// Path for the external browser camera viewer HTML page.
+///
+/// On Linux, Snap/Flatpak browsers often cannot read `/tmp` or hidden app-data
+/// directories. Use a visible location under the user's home directory instead.
+pub fn external_camera_viewer_path() -> Result<PathBuf, String> {
+    #[cfg(target_os = "linux")]
+    {
+        if let Some(downloads) = dirs::download_dir() {
+            return Ok(downloads.join("reachy-mini-camera-viewer.html"));
+        }
+
+        if let Some(home) = dirs::home_dir() {
+            return Ok(home.join("reachy-mini-camera-viewer.html"));
+        }
+    }
+
+    Ok(std::env::temp_dir().join("reachy-mini-camera-viewer.html"))
+}


### PR DESCRIPTION
## Summary
- Serve the external camera viewer's HTML from a loopback HTTP server (`http://127.0.0.1:{port}/`) instead of writing a `file://` HTML file, on every platform

- Fixes `ERR_FILE_NOT_FOUND` when opening the camera in Snap/Flatpak-confined browsers, which can't read arbitrary paths (`/tmp` or `~/Downloads`)
- Reject requests with an unexpected `Host` header (403), since a loopback server is reachable from web content in a  way `file://` never was (DNS rebinding)
- Time out server reads/writes, disable HTML caching, and recover if the accept loop dies so a later "Open in browser" can rebind
- Add unit tests for the `Host` check and the accept loop


## Context
The desktop app can't play WebRTC inline on Linux (WebKitGTK limitation), so users rely on an "Open in browser" fallback. That fallback used to write a temp HTML file and open it via `file://`, which sandboxed browsers   (Snap/Flatpak) can't read regardless of which directory it's written to. Serving the same HTML over `127.0.0.1`   sidesteps the filesystem entirely, so the fix is no longer Linux-specific.

A loopback HTTP server is same-origin-reachable from any web page via DNS rebinding, unlike a `file://` URL. Requests are now rejected with 403 unless the `Host` header matches `127.0.0.1:{port}` exactly, closing that path.

## Test plan
  - [x] Unit tests for `Host` validation and the accept loop (`src-tauri/src/lib.rs`)
  - [x] Manual: Snap Firefox opens `http://127.0.0.1:{port}/` and the camera stream connects
  - [x] Manual: a stale/dead accept loop is detected and the server rebinds on the next "Open in browser"
  - [x] Manual: request with a mismatched `Host` gets a 403
