### PR TITLE
fix(update): make the beta channel work on robots running <= 1.9.0

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -675,6 +675,7 @@ pub fn run() {
             wifi::scan_local_wifi_networks,
             wifi::get_current_wifi_ssid,
             update::check_daemon_update,
+            update::check_remote_daemon_update,
             update::update_daemon,
             reset::reset_apps_venv,
             reset::reset_python_env,

--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -267,6 +267,34 @@ pub async fn check_daemon_update(
     })
 }
 
+/// Resolve the version available for a robot whose daemon runs remotely.
+///
+/// A Wireless normally answers this itself via `GET /update/available`, but
+/// daemons up to 1.9.0 sort the PyPI pre-release list as strings, so
+/// "1.9.0rc1" ranks above "1.10.0rc5" and the beta channel always answers
+/// "up to date" (fixed in reachy_mini 1.10.0). Resolving it here keeps the
+/// beta channel usable on robots that still run the broken check.
+#[tauri::command]
+pub async fn check_remote_daemon_update(
+    current_version: String,
+    pre_release: bool,
+) -> Result<DaemonUpdateInfo, String> {
+    let available_version = get_github_version(pre_release).await?;
+    let is_available = is_update_available(&current_version, &available_version)?;
+    log::info!(
+        "[update] Remote robot on {}: available {} (update: {})",
+        current_version,
+        available_version,
+        is_available
+    );
+
+    Ok(DaemonUpdateInfo {
+        current_version,
+        available_version,
+        is_available,
+    })
+}
+
 /// Run an upgrade via the uv-trampoline sidecar.
 /// This ensures macOS code signing happens automatically after pip install.
 /// Emits sidecar-stdout/stderr events so the UI can display progress.

--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -270,29 +270,43 @@ pub async fn check_daemon_update(
 /// Resolve the version available for a robot whose daemon runs remotely.
 ///
 /// A Wireless normally answers this itself via `GET /update/available`, but
-/// daemons up to 1.9.0 sort the PyPI pre-release list as strings, so
+/// daemons below 1.10.0 sort the PyPI pre-release list as strings, so
 /// "1.9.0rc1" ranks above "1.10.0rc5" and the beta channel always answers
 /// "up to date" (fixed in reachy_mini 1.10.0). Resolving it here keeps the
 /// beta channel usable on robots that still run the broken check.
+///
+/// Returns `None` for daemons at or above 1.10.0: their own answer is
+/// correct, so the workaround retires itself as the fleet updates.
 #[tauri::command]
 pub async fn check_remote_daemon_update(
     current_version: String,
     pre_release: bool,
-) -> Result<DaemonUpdateInfo, String> {
+) -> Result<Option<DaemonUpdateInfo>, String> {
+    if !daemon_prerelease_check_is_broken(&current_version)? {
+        return Ok(None);
+    }
+
     let available_version = get_github_version(pre_release).await?;
     let is_available = is_update_available(&current_version, &available_version)?;
     log::info!(
-        "[update] Remote robot on {}: available {} (update: {})",
+        "[update] Legacy daemon on {}: available {} (update: {})",
         current_version,
         available_version,
         is_available
     );
 
-    Ok(DaemonUpdateInfo {
+    Ok(Some(DaemonUpdateInfo {
         current_version,
         available_version,
         is_available,
-    })
+    }))
+}
+
+/// Daemons below 1.10.0 mis-sort PyPI pre-releases (string order), so their
+/// `/update/available` answer cannot be trusted on the beta channel.
+/// 1.10.0 pre-releases are still broken: the fix lands in 1.10.0 final.
+fn daemon_prerelease_check_is_broken(current: &str) -> Result<bool, String> {
+    Ok(parse_version(current)? < semver::Version::new(1, 10, 0))
 }
 
 /// Run an upgrade via the uv-trampoline sidecar.
@@ -529,6 +543,14 @@ mod tests {
     #[test]
     fn rc_is_less_than_release() {
         assert!(is_update_available("1.2.5rc1", "1.2.5").unwrap());
+    }
+
+    #[test]
+    fn legacy_daemon_gate_boundary() {
+        assert!(daemon_prerelease_check_is_broken("1.9.0").unwrap());
+        assert!(daemon_prerelease_check_is_broken("1.10.0rc5").unwrap());
+        assert!(!daemon_prerelease_check_is_broken("1.10.0").unwrap());
+        assert!(!daemon_prerelease_check_is_broken("1.11.0").unwrap());
     }
 
     #[test]

--- a/src/components/viewer3d/SettingsOverlay.tsx
+++ b/src/components/viewer3d/SettingsOverlay.tsx
@@ -153,7 +153,19 @@ export default function SettingsOverlay({
 
         if (response.ok) {
           const data = await response.json();
-          setUpdateInfo((data.update?.reachy_mini as UpdateInfo) || null);
+          const info = (data.update?.reachy_mini as UpdateInfo) || null;
+
+          // Daemons up to 1.9.0 mis-sort the PyPI pre-release list and always
+          // answer "up to date" on the beta channel, so resolve the available
+          // version here instead. Their current_version is reliable.
+          setUpdateInfo(
+            info && preRelease
+              ? ((await invoke('check_remote_daemon_update', {
+                  currentVersion: info.current_version,
+                  preRelease,
+                })) as UpdateInfo)
+              : info
+          );
         }
       } else {
         const data = (await invoke('check_daemon_update', { preRelease })) as UpdateInfo;
@@ -282,12 +294,27 @@ export default function SettingsOverlay({
       }
 
       if (isWifiMode) {
-        const response = await fetchWithTimeout(
+        let response = await fetchWithTimeout(
           buildApiUrl(`/update/start?pre_release=${preRelease}`),
           { method: 'POST' },
           DAEMON_CONFIG.TIMEOUTS.COMMAND,
           { label: 'Start update' }
         );
+
+        // Daemons up to 1.9.0 gate /update/start on the same broken
+        // pre-release lookup, so they refuse an RC that does exist. Install
+        // the release tag directly: /update/start-from-ref has no such gate.
+        if (!response.ok && preRelease && updateInfo?.available_version) {
+          console.warn('[Update] Daemon refused the RC, retrying from the release tag');
+          response = await fetchWithTimeout(
+            // Every release is tagged "v<version>" on GitHub; a mismatch
+            // surfaces as a failed install job in the log stream.
+            buildApiUrl(`/update/start-from-ref?git_ref=v${updateInfo.available_version}`),
+            { method: 'POST' },
+            DAEMON_CONFIG.TIMEOUTS.COMMAND,
+            { label: 'Start update from tag' }
+          );
+        }
 
         if (response.ok) {
           const data = await response.json();
@@ -334,7 +361,14 @@ export default function SettingsOverlay({
       setIsUpdating(false);
     }
     // safelyParkRobot is stable (defined in-scope), intentionally omitted from deps to preserve 1:1 behavior
-  }, [isWifiMode, preRelease, showToast, onClose, connectUpdateWebSocket]);
+  }, [
+    isWifiMode,
+    preRelease,
+    updateInfo?.available_version,
+    showToast,
+    onClose,
+    connectUpdateWebSocket,
+  ]);
 
   const fetchWifiStatus = useCallback(async (): Promise<void> => {
     if (!isWifiMode) return;

--- a/src/components/viewer3d/SettingsOverlay.tsx
+++ b/src/components/viewer3d/SettingsOverlay.tsx
@@ -153,19 +153,26 @@ export default function SettingsOverlay({
 
         if (response.ok) {
           const data = await response.json();
-          const info = (data.update?.reachy_mini as UpdateInfo) || null;
+          let info = (data.update?.reachy_mini as UpdateInfo) || null;
 
-          // Daemons up to 1.9.0 mis-sort the PyPI pre-release list and always
+          // Daemons below 1.10.0 mis-sort the PyPI pre-release list and always
           // answer "up to date" on the beta channel, so resolve the available
-          // version here instead. Their current_version is reliable.
-          setUpdateInfo(
-            info && preRelease
-              ? ((await invoke('check_remote_daemon_update', {
-                  currentVersion: info.current_version,
-                  preRelease,
-                })) as UpdateInfo)
-              : info
-          );
+          // version app-side instead (returns null for fixed daemons). Their
+          // current_version is reliable. On failure (GitHub down, rate limit)
+          // fall back to the robot's own answer rather than no answer.
+          if (info && preRelease) {
+            try {
+              const resolved = (await invoke('check_remote_daemon_update', {
+                currentVersion: info.current_version,
+                preRelease,
+              })) as UpdateInfo | null;
+              if (resolved) info = resolved;
+            } catch (err) {
+              console.warn('[Update] App-side version check failed, using the robot answer:', err);
+            }
+          }
+
+          setUpdateInfo(info);
         }
       } else {
         const data = (await invoke('check_daemon_update', { preRelease })) as UpdateInfo;
@@ -300,20 +307,35 @@ export default function SettingsOverlay({
           DAEMON_CONFIG.TIMEOUTS.COMMAND,
           { label: 'Start update' }
         );
+        let errorDetail: string | undefined;
 
-        // Daemons up to 1.9.0 gate /update/start on the same broken
-        // pre-release lookup, so they refuse an RC that does exist. Install
-        // the release tag directly: /update/start-from-ref has no such gate.
-        if (!response.ok && preRelease && updateInfo?.available_version) {
-          console.warn('[Update] Daemon refused the RC, retrying from the release tag');
-          response = await fetchWithTimeout(
-            // Every release is tagged "v<version>" on GitHub; a mismatch
-            // surfaces as a failed install job in the log stream.
-            buildApiUrl(`/update/start-from-ref?git_ref=v${updateInfo.available_version}`),
-            { method: 'POST' },
-            DAEMON_CONFIG.TIMEOUTS.COMMAND,
-            { label: 'Start update from tag' }
-          );
+        if (!response.ok) {
+          errorDetail = ((await response.json().catch(() => null)) as { detail?: string } | null)
+            ?.detail;
+
+          // Daemons below 1.10.0 gate /update/start on the same broken
+          // pre-release lookup, so they refuse an RC that does exist. Install
+          // the release tag directly: /update/start-from-ref has no such
+          // gate. Only on that exact refusal — any other failure (busy, 5xx)
+          // must not trigger a git install, whose pip-check fallback can
+          // silently reinstall stable.
+          const isLegacyRefusal = response.status === 400 && errorDetail === 'No update available';
+          if (isLegacyRefusal && preRelease && updateInfo?.available_version) {
+            console.warn('[Update] Legacy daemon refused the RC, retrying from the release tag');
+            response = await fetchWithTimeout(
+              // Every release is tagged "v<version>" on GitHub; a mismatch
+              // surfaces as a failed install job in the log stream.
+              buildApiUrl(`/update/start-from-ref?git_ref=v${updateInfo.available_version}`),
+              { method: 'POST' },
+              DAEMON_CONFIG.TIMEOUTS.COMMAND,
+              { label: 'Start update from tag' }
+            );
+            if (!response.ok) {
+              errorDetail = (
+                (await response.json().catch(() => null)) as { detail?: string } | null
+              )?.detail;
+            }
+          }
         }
 
         if (response.ok) {
@@ -325,8 +347,7 @@ export default function SettingsOverlay({
 
           connectUpdateWebSocket(data.job_id);
         } else {
-          const error = await response.json();
-          setWifiError(`Update failed: ${error.detail || 'Unknown error'}`);
+          setWifiError(`Update failed: ${errorDetail || 'Unknown error'}`);
           setIsUpdating(false);
         }
       } else {


### PR DESCRIPTION
## Problem

With the pre-release toggle on, the app never offers an available RC on a Wireless, and clicking update would fail even if it did. `1.10.0rc5` is invisible to every robot in the field.

Repro, robot on the `1.9.0` release, beta channel enabled: Settings → check for update → "up to date", while `1.10.0rc5` is live on PyPI and GitHub.

## Cause

In WiFi mode both the version check and the install gate run on the robot, and daemons up to 1.9.0 sort the PyPI pre-release list as strings, so `1.9.0rc1` outranks `1.10.0rc5` (fixed in pollen-robotics/reachy_mini#1351, ships in 1.10.0). Those robots answer `/update/available` with "up to date" and refuse `/update/start` with 400 — a closed loop: the daemon-side fix is in the exact version they can't reach.

## Solution

Only on the beta channel, in WiFi mode:

- resolve the available version in the app (new `check_remote_daemon_update` Tauri command reusing the existing GitHub lookup), keeping the robot's `current_version`;
- when the daemon refuses `/update/start`, retry via `/update/start-from-ref?git_ref=v<version>`, which has no version gate.

Stable channel untouched. Transitional: once robots run >= 1.10.0 their own check is correct and this can be removed.

Tested against a Wireless on the 1.9.0 PyPI release: check went from "up to date" to offering `1.10.0-rc.5`, and the tag install path was exercised end-to-end from the locally built app.

## AI assistance

`Assisted-by: Claude:claude-fable-5`