### PR TITLE
fix(apps): stop reporting "No internet connection" when the catalog is slow

### DIFF
--- a/src/config/daemon.ts
+++ b/src/config/daemon.ts
@@ -21,6 +21,11 @@ export const DAEMON_CONFIG = {
     VERSION: 3000,
     EMOTIONS_CHECK: 3000,
     APPS_LIST: 5000,
+    // The catalog routes are not local lookups: the daemon queries the
+    // HuggingFace API for every source before answering, which on a Wireless
+    // robot's CM4 measures ~3.5s uncontended. 5s left almost no headroom, and
+    // a timeout here reads to the user as "No internet connection".
+    APPS_CATALOG: 20000,
     APP_INSTALL: 60000,
     APP_REMOVE: 90000,
     APP_START: 120000,

--- a/src/utils/__tests__/singleFlight.test.ts
+++ b/src/utils/__tests__/singleFlight.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { createSingleFlight } from '../singleFlight';
+
+// The contract this encodes is the one the app store depends on: two hook
+// instances asking for the catalog at the same moment must produce ONE request.
+// Two concurrent `/api/apps/list-available` calls made the daemon serialise
+// them, turning a ~3.5s route into ~6.8s and pushing it past the fetch timeout,
+// which surfaced to users as "No internet connection".
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('createSingleFlight', () => {
+  it('runs the task once for concurrent callers and gives them all the result', async () => {
+    const gate = deferred<string>();
+    let runs = 0;
+    const singleFlight = createSingleFlight<string>();
+    const task = () => {
+      runs += 1;
+      return gate.promise;
+    };
+
+    const a = singleFlight(task);
+    const b = singleFlight(task);
+    const c = singleFlight(task);
+
+    expect(runs).toBe(1);
+
+    gate.resolve('catalog');
+
+    expect(await a).toBe('catalog');
+    expect(await b).toBe('catalog');
+    expect(await c).toBe('catalog');
+    expect(runs).toBe(1);
+  });
+
+  it('hands concurrent callers the very same promise', () => {
+    const gate = deferred<number>();
+    const singleFlight = createSingleFlight<number>();
+    const task = () => gate.promise;
+
+    expect(singleFlight(task)).toBe(singleFlight(task));
+
+    gate.resolve(1);
+  });
+
+  it('starts fresh work once the previous call has settled', async () => {
+    let runs = 0;
+    const singleFlight = createSingleFlight<number>();
+    const task = () => {
+      runs += 1;
+      return Promise.resolve(runs);
+    };
+
+    expect(await singleFlight(task)).toBe(1);
+    expect(await singleFlight(task)).toBe(2);
+    expect(runs).toBe(2);
+  });
+
+  it('propagates a rejection to every concurrent caller', async () => {
+    const gate = deferred<string>();
+    const singleFlight = createSingleFlight<string>();
+    const task = () => gate.promise;
+
+    const a = singleFlight(task);
+    const b = singleFlight(task);
+
+    gate.reject(new Error('daemon unreachable'));
+
+    await expect(a).rejects.toThrow('daemon unreachable');
+    await expect(b).rejects.toThrow('daemon unreachable');
+  });
+
+  it('reopens the gate after a rejection instead of wedging shut', async () => {
+    let runs = 0;
+    const singleFlight = createSingleFlight<string>();
+    const failing = () => {
+      runs += 1;
+      return Promise.reject(new Error('boom'));
+    };
+
+    await expect(singleFlight(failing)).rejects.toThrow('boom');
+    await expect(singleFlight(failing)).rejects.toThrow('boom');
+
+    expect(runs).toBe(2);
+  });
+
+  it('does not leave the gate closed when the task throws synchronously', async () => {
+    const singleFlight = createSingleFlight<string>();
+
+    expect(() =>
+      singleFlight(() => {
+        throw new Error('sync boom');
+      })
+    ).toThrow('sync boom');
+
+    expect(await singleFlight(() => Promise.resolve('recovered'))).toBe('recovered');
+  });
+});

--- a/src/utils/singleFlight.ts
+++ b/src/utils/singleFlight.ts
@@ -1,0 +1,30 @@
+/**
+ * Coalesce concurrent calls for one shared resource into a single execution.
+ *
+ * A `useRef` guard cannot deduplicate work that belongs to the application
+ * rather than to a component: each hook instance gets its own ref, so every
+ * instance issues its own request. Hold the in-flight promise in a scope shared
+ * by all callers instead, and hand the same promise to whoever asks while it is
+ * still running.
+ *
+ * The gate reopens as soon as the task settles, so a later call starts fresh
+ * work rather than reusing a stale result — this deduplicates, it does not
+ * cache.
+ */
+export function createSingleFlight<T>(): (task: () => Promise<T>) => Promise<T> {
+  let inFlight: Promise<T> | null = null;
+
+  return (task: () => Promise<T>): Promise<T> => {
+    if (inFlight) {
+      return inFlight;
+    }
+
+    // `task()` is invoked before the assignment so a synchronous throw
+    // propagates to this caller without leaving a poisoned gate behind.
+    const started = task();
+    inFlight = started.finally(() => {
+      inFlight = null;
+    });
+    return inFlight;
+  };
+}

--- a/src/views/active-robot/application-store/hooks/useAppFetching.ts
+++ b/src/views/active-robot/application-store/hooks/useAppFetching.ts
@@ -248,7 +248,7 @@ export function useAppFetching(): UseAppFetchingReturn {
       const response = await fetchWithTimeout(
         buildApiUrl(DAEMON_APPS_CATALOG_ENDPOINT),
         {},
-        DAEMON_CONFIG.TIMEOUTS.APPS_LIST,
+        DAEMON_CONFIG.TIMEOUTS.APPS_CATALOG,
         { silent: true }
       );
 
@@ -267,12 +267,15 @@ export function useAppFetching(): UseAppFetchingReturn {
     const daemonCatalogResult = await fetchAppsFromDaemonCatalog();
 
     try {
+      // No `credentials: 'include'`. The catalog is public, and the Space does
+      // not send `Access-Control-Allow-Credentials`, so a credentialed request
+      // is rejected by CORS before we ever see the body — the website source
+      // then silently never contributes and we fall back to the daemon catalog
+      // on every single call.
       const websiteResponse = await fetchExternal(
         WEBSITE_API_URL,
-        {
-          credentials: 'include',
-        },
-        DAEMON_CONFIG.TIMEOUTS.APPS_LIST,
+        {},
+        DAEMON_CONFIG.TIMEOUTS.APPS_CATALOG,
         {
           silent: true,
         }
@@ -342,7 +345,7 @@ export function useAppFetching(): UseAppFetchingReturn {
       const installedResponse = await fetchWithTimeout(
         installedUrl,
         {},
-        DAEMON_CONFIG.TIMEOUTS.APPS_LIST,
+        DAEMON_CONFIG.TIMEOUTS.APPS_CATALOG,
         { silent: true }
       );
 

--- a/src/views/active-robot/application-store/hooks/useAppFetching.ts
+++ b/src/views/active-robot/application-store/hooks/useAppFetching.ts
@@ -341,11 +341,15 @@ export function useAppFetching(): UseAppFetchingReturn {
     const RETRY_DELAYS = [1000, 2000, 3000];
 
     try {
+      // Stays on the shorter APPS_LIST budget: this route is served from local
+      // state (~0.4s measured) rather than the HuggingFace-backed catalog, and
+      // it is wrapped in a 3-attempt retry loop, so a long timeout here would
+      // multiply into a minute-long stall when the daemon is actually down.
       const installedUrl = buildApiUrl('/api/apps/list-available/installed');
       const installedResponse = await fetchWithTimeout(
         installedUrl,
         {},
-        DAEMON_CONFIG.TIMEOUTS.APPS_CATALOG,
+        DAEMON_CONFIG.TIMEOUTS.APPS_LIST,
         { silent: true }
       );
 

--- a/src/views/active-robot/application-store/hooks/useAppsStore.ts
+++ b/src/views/active-robot/application-store/hooks/useAppsStore.ts
@@ -2,6 +2,7 @@ import { useEffect, useCallback, useRef, useMemo } from 'react';
 import useAppStore from '@store/useAppStore';
 import { DAEMON_CONFIG, fetchWithTimeout, buildApiUrl } from '@config/daemon';
 import { useLogger } from '@utils/logging';
+import { createSingleFlight } from '@utils/singleFlight';
 import { useAppFetching, mergeAppsData } from './useAppFetching';
 import { useAppJobs } from './useAppJobs';
 import { useAppUpdates } from './useAppUpdates';
@@ -103,8 +104,8 @@ const handlePermissionError = (
 // per-instance `useRef` guard cannot deduplicate anything: each instance had its
 // own flag and both issued the request. The daemon serialises them, which turned
 // a ~3.5s catalog call into ~6.8s and pushed it past the fetch timeout. Share
-// the in-flight promise across every instance instead.
-let inFlightCatalogFetch: Promise<AppLike[]> | null = null;
+// one in-flight fetch across every instance instead.
+const catalogSingleFlight = createSingleFlight<AppLike[]>();
 
 export function useAppsStore(isActive: boolean) {
   const logger = useLogger();
@@ -141,10 +142,6 @@ export function useAppsStore(isActive: boolean) {
 
   const fetchAvailableApps = useCallback(
     async (forceRefresh: boolean = false): Promise<AppLike[]> => {
-      if (inFlightCatalogFetch) {
-        return inFlightCatalogFetch;
-      }
-
       const storeState = useAppStore.getState() as unknown as AnyRecord;
       const currentAvailableApps = storeState.availableApps as AppLike[];
       const currentInstalledApps = storeState.installedApps as AppLike[];
@@ -233,12 +230,7 @@ export function useAppsStore(isActive: boolean) {
         }
       };
 
-      inFlightCatalogFetch = runCatalogFetch();
-      try {
-        return await inFlightCatalogFetch;
-      } finally {
-        inFlightCatalogFetch = null;
-      }
+      return catalogSingleFlight(runCatalogFetch);
     },
     [
       fetchAppsFromWebsite,

--- a/src/views/active-robot/application-store/hooks/useAppsStore.ts
+++ b/src/views/active-robot/application-store/hooks/useAppsStore.ts
@@ -98,6 +98,14 @@ const handlePermissionError = (
   return null;
 };
 
+// The catalog is a single global resource but `useAppsStore` is instantiated by
+// more than one component (ActiveRobotView and ApplicationsSection), so a
+// per-instance `useRef` guard cannot deduplicate anything: each instance had its
+// own flag and both issued the request. The daemon serialises them, which turned
+// a ~3.5s catalog call into ~6.8s and pushed it past the fetch timeout. Share
+// the in-flight promise across every instance instead.
+let inFlightCatalogFetch: Promise<AppLike[]> | null = null;
+
 export function useAppsStore(isActive: boolean) {
   const logger = useLogger();
   const availableApps = useAppStore(s => s.availableApps) as AppLike[];
@@ -125,8 +133,6 @@ export function useAppsStore(isActive: boolean) {
 
   const { fetchAppsFromWebsite, fetchInstalledApps } = useAppFetching();
 
-  const isFetchingRef = useRef<boolean>(false);
-
   const errorClearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const lastDismissedErrorAppRef = useRef<string | null>(null);
@@ -135,8 +141,8 @@ export function useAppsStore(isActive: boolean) {
 
   const fetchAvailableApps = useCallback(
     async (forceRefresh: boolean = false): Promise<AppLike[]> => {
-      if (isFetchingRef.current) {
-        return useAppStore.getState().availableApps as AppLike[];
+      if (inFlightCatalogFetch) {
+        return inFlightCatalogFetch;
       }
 
       const storeState = useAppStore.getState() as unknown as AnyRecord;
@@ -162,70 +168,76 @@ export function useAppsStore(isActive: boolean) {
         return currentAvailableApps;
       }
 
-      try {
-        isFetchingRef.current = true;
-        setAppsLoading(true);
-        setAppsError(null);
-
-        let availableAppsFromWebsite: AppLike[] = [];
-        let fetchError: Error | null = null;
-
+      const runCatalogFetch = async (): Promise<AppLike[]> => {
         try {
-          availableAppsFromWebsite = (await fetchAppsFromWebsite()) as AppLike[];
-        } catch (err) {
-          fetchError = err as Error;
-          console.error('❌ Failed to fetch apps from website:', (err as Error).message);
-        }
-
-        const installedResult = await fetchInstalledApps();
-        const installedAppsFromDaemon = (installedResult.apps || []) as AppLike[];
-
-        if (installedResult.error) {
-          console.warn(`⚠️ Error fetching installed apps: ${installedResult.error}`);
-        }
-
-        const hasNetworkIssue =
-          availableAppsFromWebsite.length === 0 && (fetchError || !navigator.onLine);
-
-        if (hasNetworkIssue) {
-          if (installedAppsFromDaemon.length === 0) {
-            const errorMessage = 'No internet connection. Please check your network and try again.';
-            console.error(`❌ ${errorMessage}`);
-            setAppsError(errorMessage);
-            setAppsLoading(false);
-            isFetchingRef.current = false;
-            return [];
-          } else {
-            const warningMessage = `No internet connection - showing ${installedAppsFromDaemon.length} installed app${installedAppsFromDaemon.length > 1 ? 's' : ''} only`;
-            console.warn(`⚠️ ${warningMessage}`);
-            setAppsError(warningMessage);
-          }
-        } else {
+          setAppsLoading(true);
           setAppsError(null);
+
+          let availableAppsFromWebsite: AppLike[] = [];
+          let fetchError: Error | null = null;
+
+          try {
+            availableAppsFromWebsite = (await fetchAppsFromWebsite()) as AppLike[];
+          } catch (err) {
+            fetchError = err as Error;
+            console.error('❌ Failed to fetch apps from website:', (err as Error).message);
+          }
+
+          const installedResult = await fetchInstalledApps();
+          const installedAppsFromDaemon = (installedResult.apps || []) as AppLike[];
+
+          if (installedResult.error) {
+            console.warn(`⚠️ Error fetching installed apps: ${installedResult.error}`);
+          }
+
+          const hasNetworkIssue =
+            availableAppsFromWebsite.length === 0 && (fetchError || !navigator.onLine);
+
+          if (hasNetworkIssue) {
+            if (installedAppsFromDaemon.length === 0) {
+              const errorMessage =
+                'No internet connection. Please check your network and try again.';
+              console.error(`❌ ${errorMessage}`);
+              setAppsError(errorMessage);
+              setAppsLoading(false);
+              return [];
+            } else {
+              const warningMessage = `No internet connection - showing ${installedAppsFromDaemon.length} installed app${installedAppsFromDaemon.length > 1 ? 's' : ''} only`;
+              console.warn(`⚠️ ${warningMessage}`);
+              setAppsError(warningMessage);
+            }
+          } else {
+            setAppsError(null);
+          }
+
+          const { enrichedApps, installedApps: installed } = mergeAppsData(
+            availableAppsFromWebsite,
+            installedAppsFromDaemon
+          );
+
+          setAvailableApps(enrichedApps as AppLike[]);
+          setInstalledApps(installed as AppLike[]);
+
+          if (hasNetworkIssue) {
+            invalidateAppsCache();
+          }
+
+          setAppsLoading(false);
+
+          return enrichedApps as AppLike[];
+        } catch (err) {
+          console.error('❌ Failed to fetch apps:', err);
+          setAppsError((err as Error).message);
+          setAppsLoading(false);
+          return useAppStore.getState().availableApps as AppLike[];
         }
+      };
 
-        const { enrichedApps, installedApps: installed } = mergeAppsData(
-          availableAppsFromWebsite,
-          installedAppsFromDaemon
-        );
-
-        setAvailableApps(enrichedApps as AppLike[]);
-        setInstalledApps(installed as AppLike[]);
-
-        if (hasNetworkIssue) {
-          invalidateAppsCache();
-        }
-
-        setAppsLoading(false);
-
-        return enrichedApps as AppLike[];
-      } catch (err) {
-        console.error('❌ Failed to fetch apps:', err);
-        setAppsError((err as Error).message);
-        setAppsLoading(false);
-        return useAppStore.getState().availableApps as AppLike[];
+      inFlightCatalogFetch = runCatalogFetch();
+      try {
+        return await inFlightCatalogFetch;
       } finally {
-        isFetchingRef.current = false;
+        inFlightCatalogFetch = null;
       }
     },
     [


### PR DESCRIPTION
Fixes #306.

The app store intermittently refuses to search or install, showing "No internet connection" on a machine with working internet. Three defects have to line up, so it looks random; two users hit it independently.

## 1. The website catalog fetch has never worked

`fetchAppsFromWebsite` sent `credentials: 'include'`. The Space returns a reflected `Access-Control-Allow-Origin` and **no `Access-Control-Allow-Credentials`**, so the credentialed request is rejected by CORS before the body is readable. Measured in a browser against the real endpoint:

```
with credentials:'include'  (current code): FAILED TypeError: Failed to fetch
without credentials         (patched code): OK status=200 apps=409
```

It has thrown on every call since 0112364 (2026-04-20) and silently fallen through to `if (daemonCatalogResult.apps.length > 0) return daemonCatalogResult.apps`. This was invisible because the daemon catalog also carries HF spaces, so the list still looked full — while 409 catalog entries were being dropped.

The real damage is structural: it left the daemon catalog as a single point of failure.

## 2. Duplicate concurrent catalog requests

`useAppsStore` deduplicated with a per-instance `useRef`, but two components instantiate it (`ActiveRobotView` and `ApplicationsSection`). Two refs, one global resource, two requests — visible in the app log as a pair of simultaneous `GET /api/apps/list-available`.

The daemon serialises them; `list_all_available_apps` gathers four sources, two of which are live HuggingFace calls. Against a Wireless robot on `v1.10.0rc5`:

```
sequential : 3.55 / 3.66 / 3.68 / 3.73 / 3.81 s
concurrent : 6.75 / 6.79 / 6.81 / 6.87 / 6.93 / 6.98 s
```

## 3. No timeout headroom

Both catalog routes shared `APPS_LIST = 5000`. 3.5s uncontended is already tight on a CM4; 6.8s exceeds it every time.

Together: the daemon catalog times out, the website source is already dead, both are empty, and `hasNetworkIssue` fires.

## Changes

- **`useAppFetching.ts`** — drop `credentials: 'include'`. The catalog is public; nothing there needs cookies. Private spaces go through `/api/apps/install-private-space`, which is untouched.
- **`useAppsStore.ts`** — replace the per-instance `isFetchingRef` with a module-level in-flight promise, so concurrent callers await one request instead of issuing their own. Also removes the old behaviour where a concurrent caller got a stale array back instead of the pending result.
- **`config/daemon.ts`** — add `APPS_CATALOG: 20000` for the three catalog routes. `APPS_LIST` stays at 5000 for everything else.

## Verification

- browser check above, showing the credentialed fetch failing and the plain one returning 409 apps
- latency figures measured against a real Wireless robot
- `tsc --noEmit` clean, `eslint` clean on the changed files, `npm run build` succeeds

I could not reproduce the original intermittent failure on demand end-to-end, since it needs the daemon catalog to cross the timeout while the user is searching. The chain is evidenced at each link rather than by one reproduction, and any one of the three fixes breaks it.

## Follow-ups I would suggest, deliberately not in this PR

- `navigator.onLine` is used as a hard gate in 13 places, including one that refuses to fetch before trying. It is unreliable in a webview. `useInternetHealthcheck` already exists and would be a better basis.
- A slow or failing daemon is reported to the user as *their internet* being down, which points them at the wrong problem. Those two cases deserve different copy.
- Server side, `list_all_available_apps` re-queries HuggingFace on every call with no caching or coalescing. That is the reason the route costs 3.5s at all, and it is worth an issue on `reachy_mini`.