### PR TITLE
fix: unbounded renderer memory growth from the log sync pipeline

### DIFF
--- a/src/hooks/useDaemonLogStream.ts
+++ b/src/hooks/useDaemonLogStream.ts
@@ -25,6 +25,11 @@ import type { LogEntry } from '../types/store';
 
 export type DaemonLogSource = 'api' | 'app' | 'daemon';
 
+// A busy robot emits tens of lines per second. Appending per line rebuilds the
+// capped `state.logs` array and re-runs every store subscriber for each line,
+// so lines are buffered and flushed in one `appendLogs` per interval.
+const APPEND_FLUSH_INTERVAL_MS = 250;
+
 export default function useDaemonLogStream(enabledCategories: DaemonLogSource[]): void {
   const connectionMode = useAppStore(s => s.connectionMode);
   const remoteHost = useAppStore(s => s.remoteHost);
@@ -42,24 +47,42 @@ export default function useDaemonLogStream(enabledCategories: DaemonLogSource[])
       return undefined;
     }
 
+    let buffer: LogEntry[] = [];
+    let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const flush = (): void => {
+      flushTimer = null;
+      if (buffer.length > 0) {
+        const entries = buffer;
+        buffer = [];
+        appendLogs(entries);
+      }
+    };
+
     const handle = connectDaemonLogWebSocket({
       host: remoteHost as string,
       onMessage: line => {
         const now = Date.now();
-        const entry: LogEntry = {
+        buffer.push({
           message: line,
           source: 'daemon',
           category: categorizeDaemonLine(line) === 'app' ? 'app' : 'daemon',
           level: parseDaemonLogLevel(line),
           timestamp: formatClockTime(now),
           timestampNumeric: now,
-        };
-        appendLogs([entry]);
+        });
+        if (!flushTimer) {
+          flushTimer = setTimeout(flush, APPEND_FLUSH_INTERVAL_MS);
+        }
       },
     });
     socketRef.current = handle;
 
     return () => {
+      if (flushTimer) {
+        clearTimeout(flushTimer);
+      }
+      flush();
       handle.dispose();
       socketRef.current = null;
     };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -22,6 +22,16 @@ const isJournalWindow = window.location.hash === '#journal';
 const isLogViewer = window.location.hash === '#log-viewer';
 const DEV_MODE = isDevPath && !isWebMode;
 
+// React 19 dev builds emit a performance.measure() per component per commit,
+// and the measure timeline is unbounded native memory. This app commits at
+// 20Hz, so clear it periodically. Production builds emit no such measures.
+if (import.meta.env.DEV) {
+  setInterval(() => {
+    performance.clearMeasures();
+    performance.clearMarks();
+  }, 10_000);
+}
+
 // Mock Tauri APIs if not in Tauri (browser/web mode)
 if (typeof window !== 'undefined' && !window.__TAURI__) {
   window.__TAURI__ = {

--- a/src/store/middleware/windowSync.ts
+++ b/src/store/middleware/windowSync.ts
@@ -2,6 +2,10 @@ import type { StateCreator, StoreApi } from 'zustand';
 import { extractChangedUpdates } from '../../utils/stateComparison';
 
 const ROBOT_STATE_THROTTLE_MS = 250; // 4Hz max for robot state IPC sync
+// The log arrays are capped at 10k entries and serialize to megabytes;
+// per-change emits flood the IPC channel faster than a busy renderer drains it.
+const LOGS_THROTTLE_MS = 1000;
+const THROTTLED_LOG_KEYS = ['logs', 'frontendLogs', 'appLogs'] as const;
 
 type Updates = Record<string, unknown>;
 type EmitStoreUpdate = (updates: Updates) => Promise<void>;
@@ -26,6 +30,10 @@ export const windowSyncMiddleware =
     // Throttle state for robotStateFull
     let pendingRobotState: unknown = null;
     let robotStateThrottleTimer: ReturnType<typeof setTimeout> | null = null;
+
+    // Throttle state for the log arrays (latest-wins, one timer for all three)
+    let pendingLogUpdates: Updates | null = null;
+    let logsThrottleTimer: ReturnType<typeof setTimeout> | null = null;
 
     const relevantKeys = [
       'darkMode',
@@ -102,6 +110,17 @@ export const windowSyncMiddleware =
     };
 
     /**
+     * Flush any pending throttled log arrays to secondary windows.
+     */
+    const flushLogUpdates = (): void => {
+      logsThrottleTimer = null;
+      if (pendingLogUpdates && emitStoreUpdate) {
+        emitStoreUpdate(pendingLogUpdates);
+        pendingLogUpdates = null;
+      }
+    };
+
+    /**
      * Process a Zustand state change and emit relevant diffs to secondary windows.
      * robotStateFull is throttled to avoid serializing a large object 20x/s.
      */
@@ -122,6 +141,18 @@ export const windowSyncMiddleware =
 
         if (!robotStateThrottleTimer) {
           robotStateThrottleTimer = setTimeout(flushRobotState, ROBOT_STATE_THROTTLE_MS);
+        }
+      }
+
+      // Same for the log arrays - latest reference wins within the window
+      for (const key of THROTTLED_LOG_KEYS) {
+        if (key in changedUpdates) {
+          pendingLogUpdates = { ...pendingLogUpdates, [key]: changedUpdates[key] };
+          delete changedUpdates[key];
+
+          if (!logsThrottleTimer) {
+            logsThrottleTimer = setTimeout(flushLogUpdates, LOGS_THROTTLE_MS);
+          }
         }
       }
 


### PR DESCRIPTION
The app's webview renderer grows without bound while connected to a robot that emits log lines, and eventually crashes with `Error code: Out of Memory`. 

Observed on Windows 11 / WebView2: ~1 GB per 20 s once established, renderer crashed within ~10 minutes of an idle connected session.

More details on what appears to be happening behind the scenes:

1. `useDaemonLogStream` appends one store entry per websocket line. A busy robot emits tens of lines per second, and each append rebuilds the 10,000-entry capped `state.logs` array and re-runs every store subscriber.
2. The windowSync middleware then re-emits the entire logs array (2–4 MB serialized) over Tauri IPC on every change. The emit rate outruns what a loaded renderer can drain, and the queued messages grow the WebView2 browser process and renderer without bound. Disabling this emit alone dropped the browser process from unbounded growth to a flat ~142 MB.
3. On dev builds only: React 19 emits a `performance.measure()` per component per commit for the DevTools performance tracks. At 20 Hz robot-state commits that is ~10k measures/s into the unbounded native measure timeline — a heap snapshot showed 6.5M retained `PerformanceMeasure` entries.

Changes in this PR to resolve this:

- Buffer incoming daemon log lines and flush one `appendLogs` per 250 ms
- Throttle `logs` / `frontendLogs` / `appLogs` windowSync emissions to one per second
- In dev, clear the performance measure timeline every 10 s.

Verified on Windows 11 (WebView2 151) against a Wireless reachy mini robot connected over WiFi: 
- before, renderer reached 8–10 GB and always crashed inside ten minutes
- after, browser process flat at ~142 MB and renderer bounded (0.7–1.3 GB, non-monotonic) over the same window with everything running

Possibly related: #190 works around the macOS webview being killed under memory pressure — this leak would produce exactly that pressure, so the auto-reload there may have been masking it on macOS.