### PR TITLE
Fix Windows E2E broken by WebView2 151 runner update

### DIFF
--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -1005,6 +1005,25 @@ jobs:
 
           Write-Host "✅ Application installed at: $APP_PATH"
 
+          # WebView2 150+ ignores WEBVIEW2_* env vars from elevated processes
+          # (security hardening, MicrosoftEdge/WebView2Feedback#5645). CI
+          # runners are elevated, so msedgedriver's env-var injection of
+          # --remote-debugging-port is dropped and session creation fails
+          # with "DevToolsActivePort file doesn't exist". The supported
+          # channel that survives elevation is the HKLM WebView2 loader
+          # policy: force the debug port and the user data folder on the app
+          # there. The UDF must match what msedgedriver watches, so the same
+          # path is handed to wdio.conf.js via E2E_WV2_UDF.
+          $UDF = "C:\wv2-e2e-udf"
+          New-Item -ItemType Directory -Path $UDF -Force | Out-Null
+          $POL = "HKLM:\SOFTWARE\Policies\Microsoft\Edge\WebView2"
+          New-Item -Path "$POL\AdditionalBrowserArguments" -Force | Out-Null
+          New-ItemProperty -Path "$POL\AdditionalBrowserArguments" -Name "reachy-mini-control.exe" -Value "--remote-debugging-port=0" -PropertyType String -Force | Out-Null
+          New-Item -Path "$POL\UserDataFolder" -Force | Out-Null
+          New-ItemProperty -Path "$POL\UserDataFolder" -Name "reachy-mini-control.exe" -Value $UDF -PropertyType String -Force | Out-Null
+          $env:E2E_WV2_UDF = $UDF
+          Write-Host "🔓 WebView2 HKLM automation policy set (UDF: $UDF)"
+
           # Update wdio.conf.js to use Windows path
           # We need to set the APP_BINARY environment variable
           $env:E2E_APP_BINARY = $APP_PATH

--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -1020,6 +1020,9 @@ jobs:
           # Run E2E tests (no xvfb needed on Windows)
           Write-Host "🧪 Running E2E tests..."
           yarn test:e2e
+          # pwsh does not stop on native command failure; bail out before the
+          # success banner
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
           Write-Host "🧪 ════════════════════════════════════════════════════════════════"
           Write-Host "🧪 ✅ E2E TESTS PASSED (Windows)"

--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -15,32 +15,58 @@ on:
         required: false
         type: boolean
         default: false
+      platforms:
+        description: 'Platforms to build (use with dry_run to iterate on one platform)'
+        required: false
+        type: choice
+        options:
+          - all
+          - windows
+          - macos
+          - linux
+        default: all
 
 jobs:
+  # Computes the build matrix so workflow_dispatch can restrict it to one
+  # platform. Tag pushes have no inputs and always build everything.
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - name: Compute build matrix
+        id: matrix
+        shell: bash
+        run: |
+          # macos-15-intel gives a native Intel build (macos-latest is ARM64
+          # only, cross-compilation to x86_64 is unreliable; image available
+          # until August 2027). Linux/macOS/Windows all use the runtime
+          # bootstrap (uv-trampoline downloads Python + creates venvs on
+          # first launch).
+          ALL='[
+            {"os": "macos-latest",   "target": "aarch64-apple-darwin",      "platform": "darwin-aarch64"},
+            {"os": "macos-15-intel", "target": "x86_64-apple-darwin",       "platform": "darwin-x86_64"},
+            {"os": "windows-latest", "target": "x86_64-pc-windows-msvc",    "platform": "windows-x86_64"},
+            {"os": "ubuntu-24.04",   "target": "x86_64-unknown-linux-gnu",  "platform": "linux-x86_64"}
+          ]'
+          case "${{ github.event.inputs.platforms }}" in
+            windows) FILTER='windows' ;;
+            macos)   FILTER='darwin' ;;
+            linux)   FILTER='linux' ;;
+            *)       FILTER='' ;;
+          esac
+          MATRIX=$(echo "$ALL" | jq -c --arg f "$FILTER" '[.[] | select(.platform | startswith($f))]')
+          echo "Building: $(echo "$MATRIX" | jq -r '[.[].platform] | join(", ")')"
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+
   build-and-release:
+    needs: plan
     permissions:
       contents: write
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            platform: darwin-aarch64
-          # Use macos-15-intel for native Intel build (no cross-compilation needed)
-          # macos-latest is now ARM64 only, cross-compilation to x86_64 is unreliable
-          # macos-15-intel available until August 2027
-          - os: macos-15-intel
-            target: x86_64-apple-darwin
-            platform: darwin-x86_64
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-            platform: windows-x86_64
-          # Linux uses runtime bootstrap (same as macOS/Windows)
-          # uv-trampoline downloads Python + creates venvs on first launch
-          - os: ubuntu-24.04
-            target: x86_64-unknown-linux-gnu
-            platform: linux-x86_64
+        include: ${{ fromJSON(needs.plan.outputs.matrix) }}
 
     runs-on: ${{ matrix.os }}
 
@@ -1533,8 +1559,10 @@ jobs:
   create-update-manifest:
     needs: build-and-release
     runs-on: ubuntu-latest
-    # Skip this job in dry_run mode - don't update latest.json or create release
-    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.event.inputs.dry_run != 'true'
+    # Skip this job in dry_run mode - don't update latest.json or create release.
+    # Also skip on partial-platform builds: the manifest needs artifacts from
+    # all platforms.
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.event.inputs.dry_run != 'true' && (github.event.inputs.platforms == null || github.event.inputs.platforms == 'all')
     permissions:
       contents: write
       actions: read

--- a/e2e/specs/app-launch.spec.js
+++ b/e2e/specs/app-launch.spec.js
@@ -34,9 +34,10 @@ async function handleUpdateViewIfPresent() {
     
     // Try to find and click "Skip for now" button using execute
     const clicked = await browser.execute(() => {
-      // Find all elements containing "Skip" text
-      const allElements = document.querySelectorAll('button, [role="button"], span, div');
-      for (const el of allElements) {
+      // Only real interactive elements: generic containers (div/span) also
+      // match by descendant text, and clicking a wrapper does nothing.
+      const candidates = document.querySelectorAll('button, [role="button"], a');
+      for (const el of candidates) {
         if (el.textContent && el.textContent.includes('Skip')) {
           el.click();
           return true;
@@ -128,40 +129,45 @@ describe('Reachy Mini Control - Application Launch', () => {
    * Test: Connection selection screen is visible (or handle intermediate views)
    */
   it('should show the connection selection screen', async () => {
-    // Wait for the UI to render
-    await browser.pause(2000);
-    
-    // Handle UpdateView if it appears
-    const wasUpdateView = await handleUpdateViewIfPresent();
-    if (wasUpdateView) {
-      await browser.pause(2000); // Wait for transition
-    }
+    // The updater check completes asynchronously and can replace the UI at
+    // any moment during the first seconds (race seen on Windows CI once a
+    // newer release existed), so poll: dismiss the update view whenever it
+    // shows up and wait for the connection UI instead of sampling once.
+    let pageContent = '';
+    let isPermissionsView = false;
 
-    // Look for the "Connect to Reachy" title or the connection cards
-    // The page should have text indicating connection options
-    const pageContent = await browser.execute(() => {
-      return document.body.innerText;
-    });
+    await browser.waitUntil(
+      async () => {
+        await handleUpdateViewIfPresent();
 
-    console.log(`📄 Page content preview: "${pageContent.substring(0, 200)}..."`);
-    
-    // Check for permissions view (macOS)
-    const isPermissionsView = await checkPermissionsView();
+        // Check for permissions view (macOS) - blocks automation, counts as done
+        isPermissionsView = await checkPermissionsView();
+        if (isPermissionsView) return true;
+
+        // Look for the "Connect to Reachy" title or the connection cards
+        pageContent = await browser.execute(() => {
+          return document.body.innerText;
+        });
+        return (
+          pageContent.includes('Connect') ||
+          pageContent.includes('Simulation') ||
+          pageContent.includes('USB') ||
+          pageContent.includes('WiFi')
+        );
+      },
+      {
+        timeout: 30000,
+        interval: 1000,
+        timeoutMsg: 'Connection selection screen did not appear within 30s',
+      }
+    );
+
     if (isPermissionsView) {
       console.log('⚠️ Permissions view is blocking - test will continue but may need manual setup');
-      // The test still passes - this is expected on fresh macOS installs
-      expect(true).toBe(true);
       return;
     }
 
-    // Should contain connection-related text
-    const hasConnectionUI =
-      pageContent.includes('Connect') ||
-      pageContent.includes('Simulation') ||
-      pageContent.includes('USB') ||
-      pageContent.includes('WiFi');
-
-    expect(hasConnectionUI).toBe(true);
+    console.log(`📄 Page content preview: "${pageContent.substring(0, 200)}..."`);
   });
 
   /**

--- a/e2e/wdio.conf.js
+++ b/e2e/wdio.conf.js
@@ -15,6 +15,7 @@
 
 import os from 'os';
 import path from 'path';
+import fs from 'fs';
 import { spawn } from 'child_process';
 import { fileURLToPath } from 'url';
 
@@ -70,6 +71,20 @@ function getTauriDriverPath() {
 
 const APP_BINARY = getAppBinary();
 
+/**
+ * Windows: give msedgedriver an explicit, writable WebView2 user data folder.
+ * WebView2 150+ ignores WEBVIEW2_* env vars from elevated processes (see
+ * MicrosoftEdge/WebView2Feedback#5645), so in elevated CI the folder must
+ * ALSO be forced on the app via the HKLM WebView2 loader policy, using the
+ * same path. E2E_WV2_UDF carries that shared path; the CI step sets both.
+ */
+function getWindowsWebviewOptions() {
+  const userDataFolder = process.env.E2E_WV2_UDF || path.join(os.tmpdir(), 'reachy-e2e-webview2');
+  fs.mkdirSync(userDataFolder, { recursive: true });
+  console.log(`📁 WebView2 user data folder: ${userDataFolder}`);
+  return { userDataFolder };
+}
+
 // Keep track of child processes
 let tauriDriver;
 let testRunnerBackend;
@@ -101,6 +116,7 @@ export const config = {
       maxInstances: 1,
       'tauri:options': {
         application: APP_BINARY,
+        ...(isWindows && { webviewOptions: getWindowsWebviewOptions() }),
       },
     },
   ],


### PR DESCRIPTION
## Problem

The Release Cross-Platform workflow fails on Windows since the runner image updated WebView2 from 149 to 151 (nothing changed in the repo; same tauri-driver v2.0.6 as the last green run). WebDriver session creation times out with `session not created: DevToolsActivePort file doesn't exist`. Failing run: https://github.com/pollen-robotics/reachy-mini-desktop-app/actions/runs/32729888173.

## Root cause

WebView2 150+ ignores `WEBVIEW2_*` environment variables from **elevated** processes (security hardening, see [MicrosoftEdge/WebView2Feedback#5645](https://github.com/MicrosoftEdge/WebView2Feedback/issues/5645)). CI runners are elevated, and msedgedriver passes `--remote-debugging-port` through exactly that env var, so the port never opens. Two latent E2E bugs were also exposed once a release newer than the app under test existed (updater dialog now appears): the connection-screen test sampled the page once instead of polling, and the Skip helper clicked a wrapper div instead of the real button.

## Reproduce

Dispatch **Release Cross-Platform** with `dry_run=true` on `develop`: the Windows job fails in "Install .msi and run E2E tests".

## Solution

- Set the debug port and user data folder via the **HKLM WebView2 loader policy** (survives elevation), sharing the folder with msedgedriver through `tauri:options.webviewOptions`.
- Fix the updater-dialog handling in the spec (poll + click the actual button).
- Add a `platforms` dispatch input to iterate on one platform (tag pushes still build all four).
- Fail the Windows E2E step before its success banner (it printed ✅ on failures).

Green Windows-only dry run: https://github.com/pollen-robotics/reachy-mini-desktop-app/actions/runs/32760320436

🤖 Generated with [Claude Code](https://claude.com/claude-code)