### PR TITLE
fix(webrtc): recover when the camera stream never arrives

### DIFF
--- a/src/contexts/WebRTCStreamContext.tsx
+++ b/src/contexts/WebRTCStreamContext.tsx
@@ -18,6 +18,7 @@ import useAppStore from '../store/useAppStore';
 import { fetchWithTimeout, buildApiUrl } from '../config/daemon';
 import { ROBOT_STATUS } from '../constants/robotStatus';
 import { invoke } from '../utils/tauriCompat';
+import { closeStalledSession, scheduleReconnect } from './webrtcRecovery';
 
 // Import the GStreamer WebRTC API for its side effect (registers `window.GstWebRTCAPI`).
 import '../lib/gstwebrtc-api';
@@ -32,8 +33,6 @@ import type {
 } from '../types/gstwebrtc';
 
 const SIGNALING_PORT = 8443;
-const RECONNECT_DELAY = 2000;
-const INITIAL_RECONNECT_DELAY = 500;
 const STREAM_CONNECT_TIMEOUT = 10000;
 export const WEBRTC_UNSUPPORTED_MESSAGE = 'WebRTC is not supported by this desktop WebView';
 
@@ -231,10 +230,27 @@ export function WebRTCStreamProvider({ children }: WebRTCStreamProviderProps): R
       connectTimeoutRef.current = setTimeout(() => {
         if (!mountedRef.current) return;
 
+        connectTimeoutRef.current = null;
+
         const message = `Timed out waiting for WebRTC stream from ${signalingUrl}`;
         console.error('[WebRTC]', message);
         setError(message);
-        setState(StreamState.ERROR);
+
+        // The daemon keeps a half-negotiated consumer alive until its own ICE
+        // watchdog fires; drop ours so the next `producerAdded` is not
+        // short-circuited by the stale ref.
+        closeStalledSession(sessionRef);
+
+        // Retry, like the signaling-drop and session-error paths do. A stream
+        // that never arrives is usually transient (the robot was still
+        // bringing its pipeline up), so giving up permanently here left the
+        // camera dead until the user restarted the app.
+        const retrying = scheduleReconnect(reconnectTimeoutRef, {
+          hasConnectedBefore: hasConnectedRef.current,
+          isMounted: () => mountedRef.current,
+          reconnect: connect,
+        });
+        setState(retrying ? StreamState.CONNECTING : StreamState.ERROR);
       }, STREAM_CONNECT_TIMEOUT);
 
       const api = new GstWebRTCAPI({
@@ -264,20 +280,12 @@ export function WebRTCStreamProvider({ children }: WebRTCStreamProviderProps): R
           setStream(null);
           setAudioTrack(null);
 
-          if (mountedRef.current && !reconnectTimeoutRef.current) {
-            reconnectTimeoutRef.current = setTimeout(
-              () => {
-                reconnectTimeoutRef.current = null;
-                if (mountedRef.current) {
-                  connect();
-                }
-              },
-              hasConnectedRef.current ? RECONNECT_DELAY : INITIAL_RECONNECT_DELAY
-            );
-            setState(StreamState.CONNECTING);
-          } else {
-            setState(StreamState.DISCONNECTED);
-          }
+          const retrying = scheduleReconnect(reconnectTimeoutRef, {
+            hasConnectedBefore: hasConnectedRef.current,
+            isMounted: () => mountedRef.current,
+            reconnect: connect,
+          });
+          setState(retrying ? StreamState.CONNECTING : StreamState.DISCONNECTED);
         },
       };
 
@@ -317,20 +325,12 @@ export function WebRTCStreamProvider({ children }: WebRTCStreamProviderProps): R
             console.error('[WebRTC] Session error:', message, errorEvent.error);
             setError(message);
 
-            if (mountedRef.current && !reconnectTimeoutRef.current) {
-              reconnectTimeoutRef.current = setTimeout(
-                () => {
-                  reconnectTimeoutRef.current = null;
-                  if (mountedRef.current) {
-                    connect();
-                  }
-                },
-                hasConnectedRef.current ? RECONNECT_DELAY : INITIAL_RECONNECT_DELAY
-              );
-              setState(StreamState.CONNECTING);
-            } else {
-              setState(StreamState.ERROR);
-            }
+            const retrying = scheduleReconnect(reconnectTimeoutRef, {
+              hasConnectedBefore: hasConnectedRef.current,
+              isMounted: () => mountedRef.current,
+              reconnect: connect,
+            });
+            setState(retrying ? StreamState.CONNECTING : StreamState.ERROR);
           });
 
           session.addEventListener('closed', () => {

--- a/src/contexts/__tests__/webrtcRecovery.test.ts
+++ b/src/contexts/__tests__/webrtcRecovery.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  closeStalledSession,
+  scheduleReconnect,
+  RECONNECT_DELAY,
+  INITIAL_RECONNECT_DELAY,
+  type ClosableSession,
+  type MutableRef,
+} from '../webrtcRecovery';
+
+// These helpers back every failure path in `WebRTCStreamContext`: the signaling
+// socket dropping, the consumer session erroring, and the stream never arriving
+// before the connect deadline.
+//
+// The deadline path is the one that regressed: it used to only set `ERROR`,
+// leaving the stalled session on `sessionRef` (which makes `producerAdded`
+// bail out early forever) and scheduling no retry. The camera then stayed dead
+// until the app was restarted, even though the robot was healthy — the daemon
+// logs this side of it as `ice_negotiation_timeout` from its own watchdog.
+
+function makeSessionRef(session: ClosableSession | null): MutableRef<ClosableSession | null> {
+  return { current: session };
+}
+
+function makeTimerRef(): MutableRef<ReturnType<typeof setTimeout> | null> {
+  return { current: null };
+}
+
+describe('closeStalledSession', () => {
+  it('closes the session and clears the ref', () => {
+    const close = vi.fn();
+    const ref = makeSessionRef({ close });
+
+    closeStalledSession(ref);
+
+    expect(close).toHaveBeenCalledTimes(1);
+    // `producerAdded` short-circuits while this is non-null, so clearing it is
+    // what lets a later producer event open a fresh session.
+    expect(ref.current).toBeNull();
+  });
+
+  it('still clears the ref when close() throws', () => {
+    const ref = makeSessionRef({
+      close: () => {
+        throw new Error('already torn down');
+      },
+    });
+
+    expect(() => closeStalledSession(ref)).not.toThrow();
+    expect(ref.current).toBeNull();
+  });
+
+  it('is a no-op when there is no session', () => {
+    const ref = makeSessionRef(null);
+
+    expect(() => closeStalledSession(ref)).not.toThrow();
+    expect(ref.current).toBeNull();
+  });
+});
+
+describe('scheduleReconnect', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('schedules a retry and reports that it did', () => {
+    const timerRef = makeTimerRef();
+    const reconnect = vi.fn();
+
+    const scheduled = scheduleReconnect(timerRef, {
+      hasConnectedBefore: false,
+      isMounted: () => true,
+      reconnect,
+    });
+
+    expect(scheduled).toBe(true);
+    expect(timerRef.current).not.toBeNull();
+
+    vi.advanceTimersByTime(INITIAL_RECONNECT_DELAY);
+
+    expect(reconnect).toHaveBeenCalledTimes(1);
+    // Cleared before firing so the next failure can arm a fresh timer.
+    expect(timerRef.current).toBeNull();
+  });
+
+  it('waits longer once a stream has been seen before', () => {
+    const timerRef = makeTimerRef();
+    const reconnect = vi.fn();
+
+    scheduleReconnect(timerRef, {
+      hasConnectedBefore: true,
+      isMounted: () => true,
+      reconnect,
+    });
+
+    vi.advanceTimersByTime(INITIAL_RECONNECT_DELAY);
+    expect(reconnect).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(RECONNECT_DELAY - INITIAL_RECONNECT_DELAY);
+    expect(reconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not stack a second timer when one is pending', () => {
+    const timerRef = makeTimerRef();
+    const reconnect = vi.fn();
+
+    expect(
+      scheduleReconnect(timerRef, {
+        hasConnectedBefore: false,
+        isMounted: () => true,
+        reconnect,
+      })
+    ).toBe(true);
+
+    const pending = timerRef.current;
+
+    expect(
+      scheduleReconnect(timerRef, {
+        hasConnectedBefore: false,
+        isMounted: () => true,
+        reconnect,
+      })
+    ).toBe(false);
+
+    expect(timerRef.current).toBe(pending);
+
+    vi.advanceTimersByTime(RECONNECT_DELAY * 2);
+    expect(reconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not schedule anything once unmounted', () => {
+    const timerRef = makeTimerRef();
+    const reconnect = vi.fn();
+
+    const scheduled = scheduleReconnect(timerRef, {
+      hasConnectedBefore: false,
+      isMounted: () => false,
+      reconnect,
+    });
+
+    expect(scheduled).toBe(false);
+    expect(timerRef.current).toBeNull();
+
+    vi.advanceTimersByTime(RECONNECT_DELAY * 2);
+    expect(reconnect).not.toHaveBeenCalled();
+  });
+
+  it('skips the reconnect if the provider unmounts before the timer fires', () => {
+    const timerRef = makeTimerRef();
+    const reconnect = vi.fn();
+    let mounted = true;
+
+    scheduleReconnect(timerRef, {
+      hasConnectedBefore: false,
+      isMounted: () => mounted,
+      reconnect,
+    });
+
+    mounted = false;
+    vi.advanceTimersByTime(RECONNECT_DELAY * 2);
+
+    expect(reconnect).not.toHaveBeenCalled();
+  });
+});

--- a/src/contexts/webrtcRecovery.ts
+++ b/src/contexts/webrtcRecovery.ts
@@ -1,0 +1,84 @@
+/**
+ * Shared recovery helpers for the WebRTC stream provider.
+ *
+ * Every way the camera stream can fail — the signaling socket dropping, the
+ * consumer session raising an error, or the stream never arriving before the
+ * connect deadline — needs the same two things: drop the dead consumer session
+ * so the next `producerAdded` is not short-circuited by a stale ref, and get a
+ * retry on the books. Keeping that in one place is what stops a new failure
+ * path from silently becoming a dead end.
+ */
+
+export interface ClosableSession {
+  close: () => void;
+}
+
+/** Minimal shape of a React ref, so these helpers stay testable without React. */
+export interface MutableRef<T> {
+  current: T;
+}
+
+/** Delay before retrying once a stream has been running at least once. */
+export const RECONNECT_DELAY = 2000;
+
+/** Shorter delay for the first attempts, before any stream has arrived. */
+export const INITIAL_RECONNECT_DELAY = 500;
+
+/**
+ * Close and forget a consumer session.
+ *
+ * The provider's `producerAdded` handler bails out early while `sessionRef` is
+ * non-null, so a session that is left behind after a failure blocks every later
+ * attempt on that producer. `close()` is best-effort: the session may already
+ * be torn down on the daemon side.
+ */
+export function closeStalledSession(sessionRef: MutableRef<ClosableSession | null>): void {
+  if (!sessionRef.current) {
+    return;
+  }
+
+  try {
+    sessionRef.current.close();
+  } catch {
+    // Ignore close errors - the session may already be gone.
+  }
+
+  sessionRef.current = null;
+}
+
+export interface ScheduleReconnectOptions {
+  /** `true` once a stream has arrived at least once, which relaxes the delay. */
+  hasConnectedBefore: boolean;
+  /** Checked both now and again when the timer fires. */
+  isMounted: () => boolean;
+  /** Called when the delay elapses. */
+  reconnect: () => void;
+}
+
+/**
+ * Arm a reconnect timer unless one is already pending.
+ *
+ * @returns `true` when a retry was scheduled (the caller should show
+ *   "connecting"), `false` when one was already pending or the provider is
+ *   unmounted (the caller keeps its own terminal state).
+ */
+export function scheduleReconnect(
+  reconnectTimerRef: MutableRef<ReturnType<typeof setTimeout> | null>,
+  { hasConnectedBefore, isMounted, reconnect }: ScheduleReconnectOptions
+): boolean {
+  if (!isMounted() || reconnectTimerRef.current) {
+    return false;
+  }
+
+  reconnectTimerRef.current = setTimeout(
+    () => {
+      reconnectTimerRef.current = null;
+      if (isMounted()) {
+        reconnect();
+      }
+    },
+    hasConnectedBefore ? RECONNECT_DELAY : INITIAL_RECONNECT_DELAY
+  );
+
+  return true;
+}


### PR DESCRIPTION
### Problem

The stream-connect deadline in `WebRTCStreamProvider` is the only failure path that gives up permanently. When signaling comes up and a producer is found but no media stream arrives within `STREAM_CONNECT_TIMEOUT`, the handler sets `ERROR` and stops there. Two things are left behind:

1. The stalled consumer session stays on `sessionRef`. `producerAdded` bails out early while that ref is non-null, so no later producer event can open a new session — the failure is permanent for that producer.
2. No retry is scheduled, unlike the signaling-drop and session-error paths, which both reconnect. The camera stays dead until the app is restarted, even when the robot is healthy and a retry would succeed.

### How it showed up

On a Reachy Mini Wireless (daemon 1.10.0, desktop app 0.9.34, WiFi mode) the camera preview never came up. The daemon side reported its own ICE watchdog firing while the app sat in `ERROR`:

```
media_server - ERROR - [watchdog] peer=… stuck mid-negotiation after 12s,
snapshot={'ice_state': 'new', 'conn_state': 'new',
          'signaling_state': 'have-local-offer', 'elapsed_s': 12.62}
central_signaling_relay - WARNING - notify_peer_session_failed: …
          (reason=ice_negotiation_timeout, …)
```

The robot had sent a full SDP offer plus 9 ICE candidates (host + srflx via STUN); the app never answered, so negotiation stalled at `have-local-offer`.

The stall looks transient rather than fatal: connecting to the same robot's signaling server with the same vendored `gstwebrtc-api` and the same `GstWebRTCAPI` config from a plain browser page negotiated and rendered video in under 3 seconds, repeatedly. So a retry is worth attempting.

### Change

Make the deadline path behave like the other two failure paths: close the stalled session, then schedule a reconnect.

The close-and-retry logic all three paths shared is extracted into `src/contexts/webrtcRecovery.ts` (`closeStalledSession`, `scheduleReconnect`) so a new failure path cannot silently become a dead end again. Behaviour of the signaling-drop and session-error paths is unchanged — same guards, same delays.

### Scope / what this does not do

This is a recovery fix. It does **not** explain why the negotiation stalls in the first place inside WKWebView — I could not reproduce that stall outside the app (same library, same config, Chromium: works immediately). If the underlying stall has a separate cause, that is still worth a look; this change stops it from being unrecoverable without an app restart.

### Testing

- `yarn typecheck` — clean
- `yarn test` — 110 passing (8 files), including 8 new tests for the extracted helpers
- `yarn lint` — 0 errors (pre-existing warnings elsewhere untouched)
- `prettier --check` — clean
- Regression check: reverting either half of the fix (not clearing `sessionRef`, or not scheduling the retry) turns 4 of the 8 new tests red, so they guard the real code rather than restating it.
